### PR TITLE
feat: Error for users when they don't have i(0)

### DIFF
--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -45,6 +45,19 @@ local function S(context, nodes, condition, ...)
 	if type(context) == 'string' then
 		error("Pass table containing a 'trig'-key and optionally 'dscr' and 'name' as first arg.")
 	end
+
+    local insert_nodes = vim.tbl_filter(function(n)
+      -- todo: type should be an enum
+      return n.type == 1 and n.pos == 0
+    end, nodes)
+
+    if #insert_nodes == 0 then
+      error(string.format(
+        "It is required to have an `i(0)` insert node in your snippet\nctx: %s\nnodes: %s",
+        util.short_inspect(context), util.short_inspect(nodes)
+      ))
+    end
+
 	local snip = Snippet:new{
 		trigger = context.trig,
 		dscr = context.dscr or context.trig,
@@ -172,6 +185,10 @@ local function insert_into_jumplist(snippet, start_node, current_node)
 
 	snippet.next = snippet.insert_nodes[0]
 	snippet.prev = start_node
+
+    if not snippet.insert_nodes[0] then
+      error("[LuaSnip] Missing `i(0)` which is a required node")
+    end
 
 	snippet.insert_nodes[0].prev = snippet
 	start_node.next = snippet

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -114,6 +114,14 @@ local function put(text, pos)
 	pos[2] = (#text > 1 and 0 or pos[2]) + #text[#text]
 end
 
+local remove_all_metatables = function(item, path)
+  if path[#path] ~= vim.inspect.METATABLE then return item end
+end
+
+local function short_inspect(obj)
+  return vim.inspect(obj, { process = remove_all_metatables })
+end
+
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -127,5 +135,6 @@ return {
 	mark_pos_equal = mark_pos_equal,
 	multiline_equal = multiline_equal,
 	word_under_cursor = word_under_cursor,
-	put = put
+	put = put,
+    short_inspect = short_inspect,
 }


### PR DESCRIPTION
Now when users don't put an `i(0)` in their snippet, they get an error on creation (as well as an error that explains what's happening on expansion, but that should not happen anymore)

```
|| E5113: Error while calling lua chunk: .../pack/packer/start/LuaSnip/lua/luasnip/nodes/snippet.lua:63: It is required to have an `i(0)` insert node in your snippet
|| ctx: {
||   trig = "test"
|| }
|| nodes: { {
||     markers = {},
||     static_text = { "mirrored: " },
||     type = 0
||   }, {
||     dependents = {},
||     inner_active = false,
||     markers = {},
||     pos = 1,
||     type = 1
||   }, {
||     markers = {},
||     static_text = { " // " },
||     type = 0
||   }, {
||     args = { 1 },
||     fn = <function 1>,
||     markers = {},
||     type = 2,
||     user_args = {}
||   }, {
||     markers = {},
||     static_text = { " | " },
||     type = 0
||   } }
```