### PR TITLE
Show description in snippets loaded from vscode

### DIFF
--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -80,6 +80,7 @@ local function load_snippet_file(langs, snippet_set_path)
 								ls.parser.parse_snippet({
 									trig = prefix,
 									name = name,
+									dscr = parts.description or name,
 									wordTrig = true,
 								}, body)
 							)


### PR DESCRIPTION
The description of the vscode snippets is not set, even when it is available. This adds the description to those snippets. It uses the name when the description is missing.