### PR TITLE
[WIP] Snippet-docstrings

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -43,13 +43,15 @@ entries:
 
 - `trig`: string, plain text by default. The only entry that must be given.
 - `name`: string, can be used by eg. `nvim-compe` to identify the snippet.
-- `dscr`: string, textual description of the snippet, \n-separated or table
+- `dscr`: string, description of the snippet, \n-separated or table
           for multiple lines.
 - `wordTrig`: boolean, if true, the snippet is only expanded if the word
               (`[%w_]+`) before the cursor matches the trigger entirely.
 			  True by default.
 - `regTrig`: boolean, whether the trigger should be interpreted as a
              lua pattern. False by default.
+- `docstring`: string, textual representation of the snippet, specified like
+               `dscr`. Overrides docstrings loaded from json.
 
 `s` can also be a single string, in which case it is used instead of `trig`, all
 other values being defaulted:

--- a/DOC.md
+++ b/DOC.md
@@ -465,9 +465,25 @@ Other issues will have to be handled manually by checking the contents of eg.
 `snip.env` or predefining the docstring for the snippet:
 
 ```lua
-s({trig = "(%d)", regTrig = true, docstring = "repeatmerepeatmerepatme"}, {
+s({trig = "(%d)", regTrig = true, docstring = "repeatmerepeatmerepeatme"}, {
 	f(function(args)
 		return string.rep("repeatme ", tonumber(args[1].captures[1]))
 	end, {})
 }),
 ```
+
+# DOCSTRING-CACHE
+
+Although generation of docstrings is pretty fast, it's preferable to not
+redo it as long as the snippets haven't changed. Using
+`ls.store_snippet_docstrings(ls.snippets)` and its counterpart
+`ls.load_snippet_docstrings(ls.snippets)`, they may be serialized from or
+deserialized into the snippets.
+Both functions accept a table structured like `ls.snippets`, ie.
+`{ft1={snippets}, ft2={snippets}}`.
+`load` should be called before any of the `loader`-functions as snippets loaded
+from vscode-style packages already have their `docstring` set (`docstrings`
+wouldn't be overwritten, but there'd be unnecessary calls).
+
+The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
+`~/.cache/nvim/luasnip/docstrings.json`).

--- a/Examples/snippets.lua
+++ b/Examples/snippets.lua
@@ -265,7 +265,7 @@ ls.snippets = {
 		s("link_url", {
 			t('<a href="'),
 			f(function(args)
-				return args[1].env.TM_SELECTED_TEXT[1]
+				return args[1].env.TM_SELECTED_TEXT[1] or {}
 			end, {}),
 			t('">'),
 			i(1),

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -16,6 +16,7 @@ CONTENTS                                                        *luasnip-content
 10. VSCODE SNIPPETS LOADER........................|luasnip-vscode_snippets_loader|
 11. EXT_OPTS....................................................|luasnip-ext_opts|
 12. DOCSTRING..................................................|luasnip-docstring|
+13. DOCSTRING-CACHE......................................|luasnip-docstring-cache|
 >
                 __                       ____                          
                /\ \                     /\  _`\           __           
@@ -479,10 +480,27 @@ triggered with `3`.
 Other issues will have to be handled manually by checking the contents of eg.
 `snip.env` or predefining the docstring for the snippet:
 >
-    s({trig = "(%d)", regTrig = true, docstring = "repeatmerepeatmerepatme"}, {
+    s({trig = "(%d)", regTrig = true, docstring = "repeatmerepeatmerepeatme"}, {
     	f(function(args)
     		return string.rep("repeatme ", tonumber(args[1].captures[1]))
     	end, {})
     }),
 <
+
+================================================================================
+DOCSTRING-CACHE                                          *luasnip-docstring-cache*
+
+Although generation of docstrings is pretty fast, it's preferable to not
+redo it as long as the snippets haven't changed. Using
+`ls.store_snippet_docstrings(ls.snippets)` and its counterpart
+`ls.load_snippet_docstrings(ls.snippets)`, they may be serialized from or
+deserialized into the snippets.
+Both functions accept a table structured like `ls.snippets`, ie.
+`{ft1={snippets}, ft2={snippets}}`.
+`load` should be called before any of the `loader`-functions as snippets loaded
+from vscode-style packages already have their `docstring` set (`docstrings`
+wouldn't be overwritten, but there'd be unnecessary calls).
+
+The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
+`~/.cache/nvim/luasnip/docstrings.json`).
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -15,6 +15,7 @@ CONTENTS                                                        *luasnip-content
 9. VARIABLES...................................................|luasnip-variables|
 10. VSCODE SNIPPETS LOADER........................|luasnip-vscode_snippets_loader|
 11. EXT_OPTS....................................................|luasnip-ext_opts|
+12. DOCSTRING..................................................|luasnip-docstring|
 >
                 __                       ____                          
                /\ \                     /\  _`\           __           
@@ -60,13 +61,17 @@ entries:
 
 *   `trig`: string, plain text by default. The only entry that must be given.
 *   `name`: string, can be used by eg. `nvim-compe` to identify the snippet.
-*   `dscr`: string, textual description of the snippet, \n-separated or table
+*   `dscr`: string, description of the snippet, \n-separated or table
           for multiple lines.
 *   `wordTrig`: boolean, if true, the snippet is only expanded if the word
               (`[%w_]+`) before the cursor matches the trigger entirely.
               True by default.
 *   `regTrig`: boolean, whether the trigger should be interpreted as a
              lua pattern. False by default.
+*   `docstring`: string, textual representation of the snippet, specified like
+               `dscr`. Overrides docstrings loaded from json.
+*   `docTrig`: string, for snippets triggered using a lua pattern: define the
+             trigger that is used during docstring-generation.
 
 `s` can also be a single string, in which case it is used instead of `trig`, all
 other values being defaulted:
@@ -431,7 +436,53 @@ snippet(Node), `ext_base_prio` is increased by `ext_prio_increase`)).
 
 As a shortcut for setting `hl_group`, the highlight-groups
 `Luasnip*Node{Active,Passive}` may be defined (to be actually used by LuaSnip,
-`ls.config.setup` has to be called after defining). They are overridden by the values
-defined in `ext_opts` directly, but otherwise behave the same (active is
+`ls.config.setup` has to be called after defining). They are overridden by the
+values defined in `ext_opts` directly, but otherwise behave the same (active is
 extended by passive).
+
+================================================================================
+DOCSTRING                                                      *luasnip-docstring*
+
+Snippet-docstrings can be queried using `snippet:get_docstring()`. The function
+evaluates the snippet as if it was expanded regularly, which can be problematic
+if eg. a dynamicNode in the snippet relies on inputs other than
+the argument-nodes.
+`snip.env` and `snip.captures` are populated with the names of the queried
+variable and the index of the capture respectively
+(`snip.env.TM_SELECTED_TEXT` -> `'$TM_SELECTED_TEXT'`, `snip.captures[1]` ->
+ `'$CAPTURES1'`). Although this leads to more expressive docstrings, it can
+ cause errors in functions that eg. rely on a capture being a number:
+>
+    s({trig = "(%d)", regTrig = true}, {
+    	f(function(args)
+    		return string.rep("repeatme ", tonumber(args[1].captures[1]))
+    	end, {})
+    }),
+<
+
+This snippet works fine because `snippet.captures[1]` is always a number.
+During docstring-generation, however, `snippet.captures[1]` is `'$CAPTURES1'`,
+which will cause an error in the functionNode.
+Issues with `snippet.captures` can be prevented by specifying `docTrig` during
+snippet-definition:
+>
+    s({trig = "(%d)", regTrig = true, docTrig = "3"}, {
+    	f(function(args)
+    		return string.rep("repeatme ", tonumber(args[1].captures[1]))
+    	end, {})
+    }),
+<
+
+`snippet.captures` and `snippet.trigger` will be populated as if actually
+triggered with `3`.
+
+Other issues will have to be handled manually by checking the contents of eg.
+`snip.env` or predefining the docstring for the snippet:
+>
+    s({trig = "(%d)", regTrig = true, docstring = "repeatmerepeatmerepatme"}, {
+    	f(function(args)
+    		return string.rep("repeatme ", tonumber(args[1].captures[1]))
+    	end, {})
+    }),
+<
 

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -197,11 +197,16 @@ end
 local function generate_snippet_docstring(snippet_table)
 	local strings = {}
 	for ft, snippets in pairs(snippet_table) do
+		local ft_snippets = {}
+		strings[ft] = ft_snippets
+
 		for _, snippet in ipairs(snippets) do
 			local snipcop = snippet:copy()
 			snipcop:fake_expand()
-			strings[#strings + 1] = snipcop:get_docstring()
-			snippet.docstring = strings[#strings]
+			local docstring = snipcop:get_docstring()
+
+			ft_snippets[snippet.trigger] = docstring
+			snippet.docstring = docstring
 		end
 	end
 	return strings

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -200,7 +200,7 @@ local function generate_snippet_doctext(snippet_table)
 		for _, snippet in ipairs(snippets) do
 			snippet = snippet:copy()
 			snippet:fake_expand()
-			strings[#strings+1] = snippet:get_docstring()
+			strings[#strings + 1] = snippet:get_docstring()
 		end
 	end
 	return strings

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -253,13 +253,13 @@ local function load_snippet_docstrings(snippet_table)
 	for ft, snippets in pairs(snippet_table) do
 		-- skip if fieltype not in cache.
 		if docstrings[ft] then
-            for _, snippet in ipairs(snippets) do
-                -- only set if it hasn't been set already.
-                if not snippet.docstring then
-                    snippet.docstring = docstrings[ft][snippet.trigger]
-                end
-            end
-        end
+			for _, snippet in ipairs(snippets) do
+				-- only set if it hasn't been set already.
+				if not snippet.docstring then
+					snippet.docstring = docstrings[ft][snippet.trigger]
+				end
+			end
+		end
 	end
 end
 

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -195,13 +195,15 @@ end
 
 -- snippet_table structured like ls.snippets.
 local function generate_snippet_doctext(snippet_table)
+	local strings = {}
 	for ft, snippets in pairs(snippet_table) do
 		for _, snippet in ipairs(snippets) do
 			snippet = snippet:copy()
 			snippet:fake_expand()
-			Insp(snippet:get_static_text())
+			strings[#strings+1] = snippet:get_docstring()
 		end
 	end
+	return strings
 end
 
 ls = {

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -194,7 +194,7 @@ local function active_update_dependents()
 end
 
 -- snippet_table structured like ls.snippets.
-local function generate_snippet_docstring(snippet_table)
+local function generate_snippet_docstrings(snippet_table)
 	local strings = {}
 	for ft, snippets in pairs(snippet_table) do
 		local ft_snippets = {}
@@ -227,7 +227,7 @@ ls = {
 	lsp_expand = lsp_expand,
 	active_update_dependents = active_update_dependents,
 	available = available,
-	generate_snippet_docstring = generate_snippet_docstring,
+	generate_snippet_docstrings = generate_snippet_docstrings,
 	s = snip_mod.S,
 	sn = snip_mod.SN,
 	t = require("luasnip.nodes.textNode").T,

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -194,7 +194,7 @@ local function active_update_dependents()
 end
 
 -- snippet_table structured like ls.snippets.
-local function generate_snippet_doctext(snippet_table)
+local function generate_snippet_docstring(snippet_table)
 	local strings = {}
 	for ft, snippets in pairs(snippet_table) do
 		for _, snippet in ipairs(snippets) do
@@ -221,7 +221,7 @@ ls = {
 	lsp_expand = lsp_expand,
 	active_update_dependents = active_update_dependents,
 	available = available,
-	generate_snippet_doctext = generate_snippet_doctext,
+	generate_snippet_docstring = generate_snippet_docstring,
 	s = snip_mod.S,
 	sn = snip_mod.SN,
 	t = require("luasnip.nodes.textNode").T,

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -252,16 +252,14 @@ local function load_snippet_docstrings(snippet_table)
 
 	for ft, snippets in pairs(snippet_table) do
 		-- skip if fieltype not in cache.
-		if not docstrings[ft] then
-			goto continue
-		end
-		for _, snippet in ipairs(snippets) do
-			-- only set if it hasn't been set already.
-			if not snippet.docstring then
-				snippet.docstring = docstrings[ft][snippet.trigger]
-			end
-		end
-		::continue::
+		if docstrings[ft] then
+            for _, snippet in ipairs(snippets) do
+                -- only set if it hasn't been set already.
+                if not snippet.docstring then
+                    snippet.docstring = docstrings[ft][snippet.trigger]
+                end
+            end
+        end
 	end
 end
 

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -194,18 +194,6 @@ local function active_update_dependents()
 	end
 end
 
--- snippet_table structured like ls.snippets.
-local function generate_snippet_docstrings(snippet_table)
-	for _, snippets in pairs(snippet_table) do
-		for _, snippet in ipairs(snippets) do
-			local snipcop = snippet:copy()
-			snipcop:fake_expand()
-			local docstring = snipcop:get_docstring()
-			snippet.docstring = docstring
-		end
-	end
-end
-
 local function store_snippet_docstrings(snippet_table)
 	-- ensure the directory exists.
 	-- 493 = 0755
@@ -230,7 +218,7 @@ local function store_snippet_docstrings(snippet_table)
 			docstrings[ft] = {}
 		end
 		for _, snippet in ipairs(snippets) do
-			docstrings[ft][snippet.trigger] = snippet.docstring
+			docstrings[ft][snippet.trigger] = snippet:get_docstring()
 		end
 	end
 

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -198,9 +198,10 @@ local function generate_snippet_docstring(snippet_table)
 	local strings = {}
 	for ft, snippets in pairs(snippet_table) do
 		for _, snippet in ipairs(snippets) do
-			snippet = snippet:copy()
-			snippet:fake_expand()
-			strings[#strings + 1] = snippet:get_docstring()
+			local snipcop = snippet:copy()
+			snipcop:fake_expand()
+			strings[#strings + 1] = snipcop:get_docstring()
+			snippet.docstring = strings[#strings]
 		end
 	end
 	return strings

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -230,16 +230,15 @@ local function load_snippet_docstrings(snippet_table)
 	-- 493 = 0755
 	vim.loop.fs_mkdir(luasnip_data_dir, 493)
 
-	-- open synchronously,
-	-- fs_open() with w+ creates the file if nonexistent.
-	local exists, docstring_cache_fd = pcall(vim.loop.fs_open,
+	-- fs_open() with "r" returns nil if the file doesn't exist.
+	local docstring_cache_fd = vim.loop.fs_open(
 		luasnip_data_dir.."/docstrings.json",
 		"r",
 		-- 420 = 0644
 		420)
 
-	if not exists then
-		print("Cached docstrings could not be read!")
+	if not docstring_cache_fd then
+		error("Cached docstrings could not be read!")
 		return
 	end
 	-- get size for fs_read()

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -3,7 +3,7 @@ local util = require("luasnip.util.util")
 
 local next_expand = nil
 local ls
-local luasnip_data_dir = vim.fn.stdpath("cache").."/luasnip"
+local luasnip_data_dir = vim.fn.stdpath("cache") .. "/luasnip"
 
 Luasnip_current_nodes = {}
 
@@ -201,16 +201,18 @@ local function store_snippet_docstrings(snippet_table)
 
 	-- fs_open() with w+ creates the file if nonexistent.
 	local docstring_cache_fd = vim.loop.fs_open(
-		luasnip_data_dir.."/docstrings.json",
+		luasnip_data_dir .. "/docstrings.json",
 		"w+",
 		-- 420 = 0644
-		420)
+		420
+	)
 
 	-- get size for fs_read()
 	local cache_size = vim.loop.fs_fstat(docstring_cache_fd).size
 	local file_could_be_read, docstrings = pcall(
 		vim.fn.json_decode,
-		vim.loop.fs_read(docstring_cache_fd, cache_size))
+		vim.loop.fs_read(docstring_cache_fd, cache_size)
+	)
 	docstrings = file_could_be_read and docstrings or {}
 
 	for ft, snippets in pairs(snippet_table) do
@@ -232,10 +234,11 @@ local function load_snippet_docstrings(snippet_table)
 
 	-- fs_open() with "r" returns nil if the file doesn't exist.
 	local docstring_cache_fd = vim.loop.fs_open(
-		luasnip_data_dir.."/docstrings.json",
+		luasnip_data_dir .. "/docstrings.json",
 		"r",
 		-- 420 = 0644
-		420)
+		420
+	)
 
 	if not docstring_cache_fd then
 		error("Cached docstrings could not be read!")
@@ -243,7 +246,9 @@ local function load_snippet_docstrings(snippet_table)
 	end
 	-- get size for fs_read()
 	local cache_size = vim.loop.fs_fstat(docstring_cache_fd).size
-	local docstrings = vim.fn.json_decode(vim.loop.fs_read(docstring_cache_fd, cache_size))
+	local docstrings = vim.fn.json_decode(
+		vim.loop.fs_read(docstring_cache_fd, cache_size)
+	)
 
 	for ft, snippets in pairs(snippet_table) do
 		-- skip if fieltype not in cache.

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -193,6 +193,17 @@ local function active_update_dependents()
 	end
 end
 
+-- snippet_table structured like ls.snippets.
+local function generate_snippet_doctext(snippet_table)
+	for ft, snippets in pairs(snippet_table) do
+		for _, snippet in ipairs(snippets) do
+			snippet = snippet:copy()
+			snippet:fake_expand()
+			Insp(snippet:get_static_text())
+		end
+	end
+end
+
 ls = {
 	expand_or_jumpable = expand_or_jumpable,
 	jumpable = jumpable,
@@ -208,6 +219,7 @@ ls = {
 	lsp_expand = lsp_expand,
 	active_update_dependents = active_update_dependents,
 	available = available,
+	generate_snippet_doctext = generate_snippet_doctext,
 	s = snip_mod.S,
 	sn = snip_mod.SN,
 	t = require("luasnip.nodes.textNode").T,

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -27,16 +27,11 @@ local function C(pos, choices)
 		current_choice = 1,
 		dependents = {},
 	})
-	c:init_nodes()
 	return c
 end
 
-function ChoiceNode:put_initial(pos)
+function ChoiceNode:subsnip_init()
 	for _, node in ipairs(self.choices) do
-		node.parent = self.parent
-		node.next = self
-		node.prev = self
-		node.dependents = self.dependents
 		if node.type == types.snippetNode then
 			node.env = self.parent.env
 			node.ext_opts = util.increase_ext_prio(
@@ -44,11 +39,10 @@ function ChoiceNode:put_initial(pos)
 				conf.config.ext_prio_increase
 			)
 		end
-		node.indx = self.indx
-		node.pos = self.pos
 	end
-	self.inner = self.choices[self.current_choice]
+end
 
+function ChoiceNode:put_initial(pos)
 	local old_pos = vim.deepcopy(pos)
 
 	self.inner:put_initial(pos)

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -111,6 +111,10 @@ function ChoiceNode:get_static_text()
 	return self.choices[1]:get_static_text()
 end
 
+function ChoiceNode:get_docstring()
+	return util.string_wrap(self.choices[1]:get_docstring(), self.pos)
+end
+
 function ChoiceNode:jump_into(dir)
 	if self.active then
 		self:input_leave()

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -66,8 +66,8 @@ function ChoiceNode:populate_argnodes()
 		-- if function- or dynamicNode, dependents may need to be replaced with
 		-- actual nodes, until here dependents may only contain indices of nodes.
 		if
-			node.type == types.functionNode or node.type
-				== types.dynamicNode
+			node.type == types.functionNode
+			or node.type == types.dynamicNode
 		then
 			self.parent:populate_args(node)
 		end

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -44,6 +44,7 @@ function ChoiceNode:subsnip_init()
 				conf.config.ext_prio_increase
 			)
 		end
+		node:subsnip_init()
 	end
 end
 

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -88,10 +88,6 @@ function ChoiceNode:set_old_text()
 	self.inner.old_text = self.old_text
 end
 
-function ChoiceNode:has_static_text()
-	return self.choices[1]:has_static_text()
-end
-
 function ChoiceNode:get_static_text()
 	return self.choices[1]:get_static_text()
 end

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -66,8 +66,8 @@ function ChoiceNode:populate_argnodes()
 		-- if function- or dynamicNode, dependents may need to be replaced with
 		-- actual nodes, until here dependents may only contain indices of nodes.
 		if
-			node.type == types.functionNode
-			or node.type == types.dynamicNode
+			node.type == types.functionNode or node.type
+				== types.dynamicNode
 		then
 			self.parent:populate_args(node)
 		end

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -5,8 +5,20 @@ local conf = require("luasnip.config")
 local types = require("luasnip.util.types")
 local mark = require("luasnip.util.mark").mark
 
+function ChoiceNode:init_nodes()
+	for _, node in ipairs(self.choices) do
+		node.parent = self.parent
+		node.next = self
+		node.prev = self
+		node.dependents = self.dependents
+		node.indx = self.indx
+		node.pos = self.pos
+	end
+	self.inner = self.choices[self.current_choice]
+end
+
 local function C(pos, choices)
-	return ChoiceNode:new({
+	local c = ChoiceNode:new({
 		active = false,
 		pos = pos,
 		choices = choices,
@@ -15,6 +27,8 @@ local function C(pos, choices)
 		current_choice = 1,
 		dependents = {},
 	})
+	c:init_nodes()
+	return c
 end
 
 function ChoiceNode:put_initial(pos)

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -181,9 +181,9 @@ function ChoiceNode:copy()
 end
 
 function ChoiceNode:exit()
+	self.inner:exit()
 	self.mark:clear()
 	Luasnip_active_choice = self.prev_choice
-	self.inner:exit()
 end
 
 -- val_begin/end may be nil, in this case that gravity won't be changed.

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -32,14 +32,6 @@ function ChoiceNode:put_initial(pos)
 		end
 		node.indx = self.indx
 		node.pos = self.pos
-		-- if function- or dynamicNode, dependents may need to be replaced with
-		-- actual nodes, until here dependents may only contain indices of nodes.
-		if
-			node.type == types.functionNode
-			or node.type == types.dynamicNode
-		then
-			self.parent:populate_args(node)
-		end
 	end
 	self.inner = self.choices[self.current_choice]
 
@@ -53,6 +45,19 @@ function ChoiceNode:put_initial(pos)
 	}, self.parent.ext_opts[self.inner.type].passive)
 
 	self.inner.mark = mark(old_pos, pos, mark_opts)
+end
+
+function ChoiceNode:populate_argnodes()
+	for _, node in ipairs(self.choices) do
+		-- if function- or dynamicNode, dependents may need to be replaced with
+		-- actual nodes, until here dependents may only contain indices of nodes.
+		if
+			node.type == types.functionNode
+			or node.type == types.dynamicNode
+		then
+			self.parent:populate_args(node)
+		end
+	end
 end
 
 function ChoiceNode:indent(indentstr)

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -13,6 +13,11 @@ function ChoiceNode:init_nodes()
 		node.dependents = self.dependents
 		node.indx = self.indx
 		node.pos = self.pos
+		if node.type == types.choiceNode then
+			node:init_nodes()
+		elseif node.type == types.snippetNode then
+			node:init_choices()
+		end
 	end
 	self.inner = self.choices[self.current_choice]
 end

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -58,7 +58,7 @@ function DynamicNode:get_docstring()
 	-- cache static_text, no need to recalculate function.
 	if not self.docstring then
 		local tmp = self.fn(self:get_args_static(), nil, unpack(self.user_args))
-		self.docstring = tmp:get_docstring()
+		self.docstring = util.string_wrap(tmp:get_docstring(), self.pos)
 	end
 	return self.docstring
 end

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -36,10 +36,6 @@ function DynamicNode:input_leave()
 	self.mark:update_opts(self.parent.ext_opts[self.type].passive)
 end
 
-function DynamicNode:has_static_text()
-	return false
-end
-
 function DynamicNode:get_static_text()
 	return self.snip:get_static_text()
 end

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -54,6 +54,9 @@ function DynamicNode:get_static_text()
 	return self.static_text
 end
 
+-- alias these, snippets' get_docstring handles string_wrap.
+DynamicNode.get_docstring = DynamicNode.get_static_text
+
 -- DynamicNode's don't have static text, nop these.
 function DynamicNode:put_initial(_) end
 

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -54,11 +54,22 @@ function DynamicNode:get_static_text()
 	return self.static_text
 end
 
+local errorstring = [[
+Error while evaluating dynamicNode@%d for snippet '%s':
+%s
+ 
+:h luasnip-docstring for more info]]
 function DynamicNode:get_docstring()
 	-- cache static_text, no need to recalculate function.
 	if not self.docstring then
-		local tmp = self.fn(self:get_args_static(), nil, unpack(self.user_args))
-		self.docstring = util.string_wrap(tmp:get_docstring(), self.pos)
+		local success, tmp = pcall(self.fn, self:get_args_static(), nil, unpack(self.user_args))
+		if not success then
+		    local snip = util.find_outer_snippet(self)
+		    print(errorstring:format(self.indx, snip.name, tmp))
+		    self.docstring = {""}
+		else
+			self.docstring = util.string_wrap(tmp:get_docstring(), self.pos)
+		end
 	end
 	return self.docstring
 end

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -62,11 +62,16 @@ Error while evaluating dynamicNode@%d for snippet '%s':
 function DynamicNode:get_docstring()
 	-- cache static_text, no need to recalculate function.
 	if not self.docstring then
-		local success, tmp = pcall(self.fn, self:get_args_static(), nil, unpack(self.user_args))
+		local success, tmp = pcall(
+			self.fn,
+			self:get_args_static(),
+			nil,
+			unpack(self.user_args)
+		)
 		if not success then
-		    local snip = util.find_outer_snippet(self)
-		    print(errorstring:format(self.indx, snip.name, tmp))
-		    self.docstring = {""}
+			local snip = util.find_outer_snippet(self)
+			print(errorstring:format(self.indx, snip.name, tmp))
+			self.docstring = { "" }
 		else
 			self.docstring = util.string_wrap(tmp:get_docstring(), self.pos)
 		end

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -113,6 +113,10 @@ function DynamicNode:update()
 	)
 	tmp.dependents = self.dependents
 
+	tmp:populate_argnodes()
+	tmp:init_choices()
+	tmp:subsnip_init()
+
 	if vim.o.expandtab then
 		tmp:expand_tabs(util.tab_width())
 	end

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -54,8 +54,14 @@ function DynamicNode:get_static_text()
 	return self.static_text
 end
 
--- alias these, snippets' get_docstring handles string_wrap.
-DynamicNode.get_docstring = DynamicNode.get_static_text
+function DynamicNode:get_docstring()
+	-- cache static_text, no need to recalculate function.
+	if not self.docstring then
+		local tmp = self.fn(self:get_args_static(), nil, unpack(self.user_args))
+		self.docstring = tmp:get_docstring()
+	end
+	return self.docstring
+end
 
 -- DynamicNode's don't have static text, nop these.
 function DynamicNode:put_initial(_) end

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -25,6 +25,15 @@ function DynamicNode:get_args()
 	return args
 end
 
+function DynamicNode:get_args_static()
+	local args = {}
+	for i, node in ipairs(self.args) do
+		args[i] = util.dedent(node:get_static_text(), self.parent.indentstr)
+	end
+	args[#args + 1] = self.parent
+	return args
+end
+
 function DynamicNode:input_enter()
 	self.active = true
 	self.mark:update_opts(self.parent.ext_opts[self.type].active)
@@ -37,7 +46,12 @@ function DynamicNode:input_leave()
 end
 
 function DynamicNode:get_static_text()
-	return self.snip:get_static_text()
+	-- cache static_text, no need to recalculate function.
+	if not self.static_text then
+		local tmp = self.fn(self:get_args_static(), nil, unpack(self.user_args))
+		self.static_text = tmp:get_static_text()
+	end
+	return self.static_text
 end
 
 -- DynamicNode's don't have static text, nop these.

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -43,7 +43,7 @@ end
 function FunctionNode:get_static_text()
 	-- cache static_text, no need to recalculate function.
 	if not self.static_text then
-		self.static_text = util:wrap_value(self.fn(self:get_args(), unpack(self.user_args)))
+		self.static_text = util.wrap_value(self.fn(self:get_static_args(), unpack(self.user_args)))
 	end
 	return self.static_text
 end

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -39,12 +39,26 @@ function FunctionNode:input_enter()
 	util.normal_move_on_insert(self.mark:pos_begin())
 end
 
+local errorstring = [[
+Error while evaluating functionNode@%d for snippet '%s':
+%s
+ 
+:h luasnip-docstring for more info]]
 function FunctionNode:get_static_text()
 	-- cache static_text, no need to recalculate function.
 	if not self.static_text then
-		self.static_text = util.wrap_value(
-			self.fn(self:get_static_args(), unpack(self.user_args))
-		)
+        local success, static_text = pcall(
+            self.fn,
+            self:get_static_args(),
+            unpack(self.user_args))
+
+        if not success then
+            local snip = util.find_outer_snippet(self)
+            print(errorstring:format(
+                self.indx, snip.name, static_text))
+            static_text = {""}
+        end
+		self.static_text = util.wrap_value(static_text)
 	end
 	return self.static_text
 end

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -48,6 +48,9 @@ function FunctionNode:get_static_text()
 	return self.static_text
 end
 
+-- function-text will not stand out in any way in docstring.
+FunctionNode.get_docstring = FunctionNode.get_static_text
+
 function FunctionNode:update()
 	local text = util.wrap_value(
 		self.fn(self:get_args(), unpack(self.user_args))

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -21,6 +21,16 @@ function FunctionNode:get_args()
 	return args
 end
 
+function FunctionNode:get_static_args()
+	local args = {}
+	for i, node in ipairs(self.args) do
+		args[i] = util.dedent(node:get_static_text(), self.parent.indentstr)
+	end
+	args[#args + 1] = self.parent
+	return args
+end
+
+
 function FunctionNode:input_enter()
 	vim.api.nvim_feedkeys(
 		vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
@@ -28,6 +38,14 @@ function FunctionNode:input_enter()
 		true
 	)
 	util.normal_move_on_mark_insert(self.mark.id)
+end
+
+function FunctionNode:get_static_text()
+	-- cache static_text, no need to recalculate function.
+	if not self.static_text then
+		self.static_text = util:wrap_value(self.fn(self:get_args(), unpack(self.user_args)))
+	end
+	return self.static_text
 end
 
 function FunctionNode:update()

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -47,17 +47,17 @@ Error while evaluating functionNode@%d for snippet '%s':
 function FunctionNode:get_static_text()
 	-- cache static_text, no need to recalculate function.
 	if not self.static_text then
-        local success, static_text = pcall(
-            self.fn,
-            self:get_static_args(),
-            unpack(self.user_args))
+		local success, static_text = pcall(
+			self.fn,
+			self:get_static_args(),
+			unpack(self.user_args)
+		)
 
-        if not success then
-            local snip = util.find_outer_snippet(self)
-            print(errorstring:format(
-                self.indx, snip.name, static_text))
-            static_text = {""}
-        end
+		if not success then
+			local snip = util.find_outer_snippet(self)
+			print(errorstring:format(self.indx, snip.name, static_text))
+			static_text = { "" }
+		end
 		self.static_text = util.wrap_value(static_text)
 	end
 	return self.static_text

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -30,7 +30,6 @@ function FunctionNode:get_static_args()
 	return args
 end
 
-
 function FunctionNode:input_enter()
 	vim.api.nvim_feedkeys(
 		vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
@@ -43,7 +42,9 @@ end
 function FunctionNode:get_static_text()
 	-- cache static_text, no need to recalculate function.
 	if not self.static_text then
-		self.static_text = util.wrap_value(self.fn(self:get_static_args(), unpack(self.user_args)))
+		self.static_text = util.wrap_value(
+			self.fn(self:get_static_args(), unpack(self.user_args))
+		)
 	end
 	return self.static_text
 end

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -170,7 +170,8 @@ function InsertNode:exit()
 end
 
 function InsertNode:get_docstring()
-	return util.string_wrap(self.static_text, self.pos)
+	-- copy as to not in-place-modify static text.
+	return util.string_wrap(vim.deepcopy(self.static_text), self.pos)
 end
 
 return {

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -169,6 +169,10 @@ function InsertNode:exit()
 	self.mark:clear()
 end
 
+function InsertNode:get_docstring()
+	return util.string_wrap(self.static_text, self.pos)
+end
+
 return {
 	I = I,
 }

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -109,6 +109,8 @@ function Node:indent(indentstr)
 	util.indent(self.static_text, indentstr)
 end
 
+function Node:populate_argnodes() end
+
 Node.ext_gravities_active = { false, true }
 
 return {

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -9,21 +9,12 @@ function Node:new(o)
 	return o
 end
 
-function Node:has_static_text()
-	return self:get_static_text()
-		and not (
-			self:get_static_text()[1] == "" and #self:get_static_text() == 1
-		)
-end
-
 function Node:get_static_text()
 	return self.static_text
 end
 
 function Node:put_initial(pos)
-	if self:has_static_text() then
-		util.put(self:get_static_text(), pos)
-	end
+	util.put(self:get_static_text(), pos)
 end
 
 function Node:input_enter(no_move)

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -13,6 +13,10 @@ function Node:get_static_text()
 	return self.static_text
 end
 
+function Node:get_docstring()
+	return self.static_text
+end
+
 function Node:put_initial(pos)
 	util.put(self:get_static_text(), pos)
 end

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -111,6 +111,8 @@ end
 
 function Node:populate_argnodes() end
 
+function Node:subsnip_init() end
+
 Node.ext_gravities_active = { false, true }
 
 return {

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -558,8 +558,8 @@ end
 function Snippet:populate_argnodes()
 	for _, node in ipairs(self.nodes) do
 		if
-			node.type == types.functionNode or node.type
-				== types.dynamicNode
+			node.type == types.functionNode
+			or node.type == types.dynamicNode
 		then
 			self:populate_args(node)
 		else

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -558,8 +558,8 @@ end
 function Snippet:populate_argnodes()
 	for _, node in ipairs(self.nodes) do
 		if
-			node.type == types.functionNode
-			or node.type == types.dynamicNode
+			node.type == types.functionNode or node.type
+				== types.dynamicNode
 		then
 			self:populate_args(node)
 		else

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -557,6 +557,25 @@ function Snippet:put_initial(pos)
 	end
 end
 
+function Snippet:get_static_text()
+	if self.static_text then
+		return self.static_text
+	end
+	local text = {""}
+	for _, node in ipairs(self.nodes) do
+		local node_text = node:get_static_text()
+		-- append first line to last line of text so far.
+		text[#text] = text[#text]..node_text[1]
+		for i = 2, #node_text do
+			text[#text+1] = node_text[i]
+		end
+	end
+	-- cache computed text, may be called multiple times for
+	-- function/dynamicNodes.
+	self.static_text = text
+	return text
+end
+
 function Snippet:update()
 	for _, node in ipairs(self.nodes) do
 		node:update()

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -586,7 +586,7 @@ function Snippet:fake_expand()
 		-- This fills captures[1] with docTrig if no capture groups are defined
 		-- and therefore slightly differs from normal expansion where it won't
 		-- be filled, but that's alright.
-		self.captures = {self.docTrig:match(self.trigger)}
+		self.captures = { self.docTrig:match(self.trigger) }
 		self.trigger = self.docTrig
 	else
 		self.trigger = "$TRIGGER"

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -568,6 +568,32 @@ function Snippet:populate_argnodes()
 	end
 end
 
+-- populate env,inden,captures,trigger(regex),... but don't put any text.
+function Snippet:fake_expand()
+	-- set eg. env.TM_SELECTED_TEXT to $TM_SELECTED_TEXT
+	self.env = {}
+	setmetatable(self.env, {
+		__index = function(_, key)
+			return {"$"..key}
+		end
+	})
+
+	self.captures = {}
+	setmetatable(self.captures, {
+		__index = function(_, key)
+			return {"$CAPTURE"..tostring(key)}
+		end
+	})
+
+	if vim.o.expandtab then
+		self:expand_tabs(util.tab_width())
+	end
+	self:indent("")
+	self:subsnip_init()
+end
+
+-- to work correctly, this may require that the snippets' env,indent,captures? are
+-- set.
 function Snippet:get_static_text()
 	if self.static_text then
 		return self.static_text

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -130,7 +130,6 @@ local function S(context, nodes, condition, ...)
 		mark = nil,
 		dependents = {},
 		active = false,
-		env = {},
 		type = types.snippet,
 	})
 

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -286,6 +286,7 @@ local function insert_into_jumplist(snippet, start_node, current_node)
 end
 
 function Snippet:trigger_expand(current_node)
+	self:populate_argnodes()
 	-- expand tabs before indenting to keep indentstring unmodified
 	if vim.o.expandtab then
 		self:expand_tabs(util.tab_width())
@@ -546,13 +547,17 @@ function Snippet:put_initial(pos)
 		node.mark = mark(old_pos, pos, mark_opts)
 		node:set_old_text()
 	end
+end
 
+function Snippet:populate_argnodes()
 	for _, node in ipairs(self.nodes) do
 		if
 			node.type == types.functionNode or node.type
 				== types.dynamicNode
 		then
 			self:populate_args(node)
+		else
+			node:populate_argnodes()
 		end
 	end
 end
@@ -562,6 +567,7 @@ function Snippet:get_static_text()
 		return self.static_text
 	end
 	local text = {""}
+	self:populate_argnodes()
 	for _, node in ipairs(self.nodes) do
 		local node_text = node:get_static_text()
 		-- append first line to last line of text so far.

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -612,20 +612,28 @@ end
 function Snippet:get_docstring()
 	if self.docstring then
 		return self.docstring
+	elseif not self.env then
+		-- not a snippetNode and not yet initialized
+		local snipcop = self:copy()
+		-- sets env, captures, etc.
+		snipcop:fake_expand()
+		local docstring = snipcop:get_docstring()
+		self.docstring = docstring
+		return docstring
 	end
-	local text = { "" }
+	local docstring = { "" }
 	for _, node in ipairs(self.nodes) do
 		local node_text = node:get_docstring()
 		-- append first line to last line of text so far.
-		text[#text] = text[#text] .. node_text[1]
+		docstring[#docstring] = docstring[#docstring] .. node_text[1]
 		for i = 2, #node_text do
-			text[#text + 1] = node_text[i]
+			docstring[#docstring + 1] = node_text[i]
 		end
 	end
 	-- cache computed text, may be called multiple times for
 	-- function/dynamicNodes.
-	self.docstring = text
-	return text
+	self.docstring = docstring
+	return docstring
 end
 
 function Snippet:update()

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -592,6 +592,14 @@ end
 function Snippet:get_static_text()
 	if self.static_text then
 		return self.static_text
+	elseif not self.env then
+		-- not a snippetNode and not yet initialized
+		local snipcop = self:copy()
+		-- sets env, captures, etc.
+		snipcop:fake_expand()
+		local static_text = snipcop:get_static_text()
+		self.static_text = static_text
+		return static_text
 	end
 	local text = { "" }
 	for _, node in ipairs(self.nodes) do

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -67,6 +67,7 @@ function Snippet:init_nodes()
 	end
 
 	self.insert_nodes = insert_nodes
+	self:populate_argnodes()
 end
 
 local function wrap_nodes(nodes)
@@ -286,7 +287,6 @@ local function insert_into_jumplist(snippet, start_node, current_node)
 end
 
 function Snippet:trigger_expand(current_node)
-	self:populate_argnodes()
 	-- expand tabs before indenting to keep indentstring unmodified
 	if vim.o.expandtab then
 		self:expand_tabs(util.tab_width())
@@ -567,7 +567,6 @@ function Snippet:get_static_text()
 		return self.static_text
 	end
 	local text = {""}
-	self:populate_argnodes()
 	for _, node in ipairs(self.nodes) do
 		local node_text = node:get_static_text()
 		-- append first line to last line of text so far.

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -613,8 +613,8 @@ function Snippet:get_static_text()
 end
 
 function Snippet:get_docstring()
-	if self.doctext then
-		return self.doctext
+	if self.docstring then
+		return self.docstring
 	end
 	local text = { "" }
 	for _, node in ipairs(self.nodes) do

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -558,8 +558,8 @@ end
 function Snippet:populate_argnodes()
 	for _, node in ipairs(self.nodes) do
 		if
-			node.type == types.functionNode or node.type
-				== types.dynamicNode
+			node.type == types.functionNode
+			or node.type == types.dynamicNode
 		then
 			self:populate_args(node)
 		else
@@ -574,15 +574,15 @@ function Snippet:fake_expand()
 	self.env = {}
 	setmetatable(self.env, {
 		__index = function(_, key)
-			return {"$"..key}
-		end
+			return { "$" .. key }
+		end,
 	})
 
 	self.captures = {}
 	setmetatable(self.captures, {
 		__index = function(_, key)
-			return "$CAPTURE"..tostring(key)
-		end
+			return "$CAPTURE" .. tostring(key)
+		end,
 	})
 	self.ext_opts = vim.deepcopy(conf.config.ext_opts)
 
@@ -599,13 +599,13 @@ function Snippet:get_static_text()
 	if self.static_text then
 		return self.static_text
 	end
-	local text = {""}
+	local text = { "" }
 	for _, node in ipairs(self.nodes) do
 		local node_text = node:get_static_text()
 		-- append first line to last line of text so far.
-		text[#text] = text[#text]..node_text[1]
+		text[#text] = text[#text] .. node_text[1]
 		for i = 2, #node_text do
-			text[#text+1] = node_text[i]
+			text[#text + 1] = node_text[i]
 		end
 	end
 	-- cache computed text, may be called multiple times for
@@ -618,13 +618,13 @@ function Snippet:get_docstring()
 	if self.doctext then
 		return self.doctext
 	end
-	local text = {""}
+	local text = { "" }
 	for _, node in ipairs(self.nodes) do
 		local node_text = node:get_docstring()
 		-- append first line to last line of text so far.
-		text[#text] = text[#text]..node_text[1]
+		text[#text] = text[#text] .. node_text[1]
 		for i = 2, #node_text do
-			text[#text+1] = node_text[i]
+			text[#text + 1] = node_text[i]
 		end
 	end
 	-- cache computed text, may be called multiple times for

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -614,6 +614,25 @@ function Snippet:get_static_text()
 	return text
 end
 
+function Snippet:get_docstring()
+	if self.doctext then
+		return self.doctext
+	end
+	local text = {""}
+	for _, node in ipairs(self.nodes) do
+		local node_text = node:get_docstring()
+		-- append first line to last line of text so far.
+		text[#text] = text[#text]..node_text[1]
+		for i = 2, #node_text do
+			text[#text+1] = node_text[i]
+		end
+	end
+	-- cache computed text, may be called multiple times for
+	-- function/dynamicNodes.
+	self.docstring = text
+	return text
+end
+
 function Snippet:update()
 	for _, node in ipairs(self.nodes) do
 		node:update()

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -74,7 +74,7 @@ function Snippet:init_choices()
 	for _, node in ipairs(self.nodes) do
 		if node.type == types.choiceNode then
 			node:init_nodes()
-		elseif node.type == types.snippet then
+		elseif node.type == types.snippetNode then
 			node:init_choices()
 		end
 	end
@@ -581,9 +581,10 @@ function Snippet:fake_expand()
 	self.captures = {}
 	setmetatable(self.captures, {
 		__index = function(_, key)
-			return {"$CAPTURE"..tostring(key)}
+			return "$CAPTURE"..tostring(key)
 		end
 	})
+	self.ext_opts = vim.deepcopy(conf.config.ext_opts)
 
 	if vim.o.expandtab then
 		self:expand_tabs(util.tab_width())

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -103,14 +103,10 @@ local function S(context, nodes, condition, ...)
 
 	-- context.dscr could be nil, string or table.
 	context.dscr = util.wrap_value(context.dscr or context.trig)
+	local dscr = util.to_line_table(context.dscr)
 
-	-- split entries at \n.
-	local dscr = {}
-	for _, str in ipairs(context.dscr) do
-		local split = vim.split(str, "\n", true)
-		for i = 1, #split do
-			dscr[#dscr + 1] = split[i]
-		end
+	if context.docstring then
+		context.docstring = util.to_line_table(context.docstring)
 	end
 
 	-- default: true.
@@ -125,6 +121,7 @@ local function S(context, nodes, condition, ...)
 		name = context.name or context.trig,
 		wordTrig = context.wordTrig,
 		regTrig = context.regTrig,
+		docstring = context.docstring,
 		nodes = nodes,
 		insert_nodes = {},
 		current_insert = 0,

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -584,9 +584,6 @@ function Snippet:fake_expand()
 	})
 	self.ext_opts = vim.deepcopy(conf.config.ext_opts)
 
-	if vim.o.expandtab then
-		self:expand_tabs(util.tab_width())
-	end
 	self:indent("")
 	self:subsnip_init()
 end

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -122,6 +122,7 @@ local function S(context, nodes, condition, ...)
 		wordTrig = context.wordTrig,
 		regTrig = context.regTrig,
 		docstring = context.docstring,
+		docTrig = context.docTrig,
 		nodes = nodes,
 		insert_nodes = {},
 		current_insert = 0,
@@ -581,6 +582,15 @@ function Snippet:fake_expand()
 			return "$CAPTURE" .. tostring(key)
 		end,
 	})
+	if self.docTrig then
+		-- This fills captures[1] with docTrig if no capture groups are defined
+		-- and therefore slightly differs from normal expansion where it won't
+		-- be filled, but that's alright.
+		self.captures = {self.docTrig:match(self.trigger)}
+		self.trigger = self.docTrig
+	else
+		self.trigger = "$TRIGGER"
+	end
 	self.ext_opts = vim.deepcopy(conf.config.ext_opts)
 
 	self:indent("")

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -317,7 +317,8 @@ function Snippet:trigger_expand(current_node)
 			self.ext_opts = vim.deepcopy(conf.config.ext_opts)
 		end
 	end
-	Environ:new(self.env)
+
+	self.env = Environ:new()
 
 	self:subsnip_init()
 

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -731,6 +731,15 @@ function Snippet:populate_args(node)
 	end
 end
 
+function Snippet:text_only()
+	for _, node in ipairs(self.nodes) do
+		if node.type ~= types.textNode then
+			return false
+		end
+	end
+	return true
+end
+
 return {
 	Snippet = Snippet,
 	S = S,

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -352,7 +352,10 @@ parse_snippet = function(context, body, tab_stops, brackets)
 			if type(context) == "number" then
 				return snipNode.SN(context, fix_node_indices(nodes))
 			else
-				return snipNode.S(context, fix_node_indices(nodes))
+				if type(context) == "string" then
+					context = { trig = context }
+				end
+				return snipNode.S(vim.tbl_extend("keep", context, {docstring = body}) , fix_node_indices(nodes))
 			end
 		end
 	end

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -146,7 +146,14 @@ local function parse_placeholder(text, tab_stops, brackets)
 			else
 				if not snip:is_interactive() then
 					tab_stops[pos] = dNode.D(pos, function(args)
+						-- properly prepare snippet for get_static_text.
 						snip.env = args[1].env
+						snip.ext_opts = args[1].ext_opts
+						if vim.o.expandtab then
+							snip:expand_tabs(util.tab_width())
+						end
+						snip:indent(args[1].indentstr)
+						snip:subsnip_init()
 						local iText = snip:get_static_text()
 						return snipNode.SN(nil, iNode.I(1, iText))
 					end, {})

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -142,7 +142,7 @@ local function parse_placeholder(text, tab_stops, brackets)
 			-- SELECT Simple placeholder (static text or evaulated function that is not updated again),
 			-- behaviour mopre similar to eg. vscode.
 			if snip:text_only() then
-				tab_stops[pos] = iNode.I(pos, string.sub(text, stop+1, -1))
+				tab_stops[pos] = iNode.I(pos, string.sub(text, stop + 1, -1))
 			else
 				if not snip:is_interactive() then
 					tab_stops[pos] = dNode.D(pos, function(args)
@@ -162,7 +162,10 @@ local function parse_placeholder(text, tab_stops, brackets)
 					modify_nodes(snip)
 					snip:init_nodes()
 
-					tab_stops[pos] = cNode.C(pos, { snip, iNode.I(nil, { "" }) })
+					tab_stops[pos] = cNode.C(
+						pos,
+						{ snip, iNode.I(nil, { "" }) }
+					)
 				end
 				-- 0-node cannot be dynamic or choice, insert the actual 0-node behind it.
 				if pos == 0 then
@@ -240,7 +243,7 @@ local function fix_node_indices(nodes)
 
 	for i = 1, highest do
 		if not used_nodes[i] then
-			for j = i+1, highest do
+			for j = i + 1, highest do
 				if used_nodes[j] then
 					used_nodes[j].pos = used_nodes[j].pos - 1
 				end

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -355,7 +355,10 @@ parse_snippet = function(context, body, tab_stops, brackets)
 				if type(context) == "string" then
 					context = { trig = context }
 				end
-				return snipNode.S(vim.tbl_extend("keep", context, {docstring = body}) , fix_node_indices(nodes))
+				return snipNode.S(
+					vim.tbl_extend("keep", context, { docstring = body }),
+					fix_node_indices(nodes)
+				)
 			end
 		end
 	end

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -159,7 +159,6 @@ local function parse_placeholder(text, tab_stops, brackets)
 				end
 				-- 0-node cannot be dynamic or choice, insert the actual 0-node behind it.
 				if pos == 0 then
-					print("le")
 					-- should be high enough
 					tab_stops[pos].pos = 1000
 					i0_maybe = iNode.I(0)

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -382,6 +382,15 @@ local function increase_ext_prio(opts, amount)
 	return opts
 end
 
+local function string_wrap(lines, pos)
+	if #lines == 1 and #lines[1] == 0 then
+		return {"$"..(pos and tostring(pos) or "{}")}
+	end
+	lines[1] = "${"..(pos and (tostring(pos)..":") or "")..lines[1]
+	lines[#lines] = lines[#lines].."}"
+	return lines
+end
+
 -- Heuristic to extract the comment style from the commentstring
 local _comments_cache = {}
 local function buffer_comment_chars()
@@ -435,4 +444,5 @@ return {
 	increase_ext_prio = increase_ext_prio,
 	clear_invalid = clear_invalid,
 	buffer_comment_chars = buffer_comment_chars,
+	string_wrap = string_wrap
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -416,6 +416,21 @@ local function buffer_comment_chars()
 	return comments
 end
 
+local function to_line_table(table_or_string)
+	local tbl = wrap_value(table_or_string)
+
+	-- split entries at \n.
+	local line_table = {}
+	for _, str in ipairs(tbl) do
+		local split = vim.split(str, "\n", true)
+		for i = 1, #split do
+			line_table[#line_table + 1] = split[i]
+		end
+	end
+
+	return line_table
+end
+
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -445,4 +460,5 @@ return {
 	clear_invalid = clear_invalid,
 	buffer_comment_chars = buffer_comment_chars,
 	string_wrap = string_wrap,
+	to_line_table = to_line_table
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -431,6 +431,13 @@ local function to_line_table(table_or_string)
 	return line_table
 end
 
+local function find_outer_snippet(node)
+	while node.parent do
+		node = node.parent
+	end
+	return node
+end
+
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -460,5 +467,6 @@ return {
 	clear_invalid = clear_invalid,
 	buffer_comment_chars = buffer_comment_chars,
 	string_wrap = string_wrap,
-	to_line_table = to_line_table
+	to_line_table = to_line_table,
+	find_outer_snippet = find_outer_snippet
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -468,5 +468,5 @@ return {
 	buffer_comment_chars = buffer_comment_chars,
 	string_wrap = string_wrap,
 	to_line_table = to_line_table,
-	find_outer_snippet = find_outer_snippet
+	find_outer_snippet = find_outer_snippet,
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -384,10 +384,10 @@ end
 
 local function string_wrap(lines, pos)
 	if #lines == 1 and #lines[1] == 0 then
-		return {"$"..(pos and tostring(pos) or "{}")}
+		return { "$" .. (pos and tostring(pos) or "{}") }
 	end
-	lines[1] = "${"..(pos and (tostring(pos)..":") or "")..lines[1]
-	lines[#lines] = lines[#lines].."}"
+	lines[1] = "${" .. (pos and (tostring(pos) .. ":") or "") .. lines[1]
+	lines[#lines] = lines[#lines] .. "}"
 	return lines
 end
 
@@ -444,5 +444,5 @@ return {
 	increase_ext_prio = increase_ext_prio,
 	clear_invalid = clear_invalid,
 	buffer_comment_chars = buffer_comment_chars,
-	string_wrap = string_wrap
+	string_wrap = string_wrap,
 }


### PR DESCRIPTION
This adds a function (`luasnip.generate_snippet_docstring(snip-table)`) to generate docstrings for snippets. The string will be stored in each snippet (`snip.docstring`) upon calling (maybe persistence over sessions, with the command only to refresh?)
[docstrings for `Examples/snippets.lua` and `friendly-snippets`](https://github.com/L3MON4D3/LuaSnip/files/7015227/docstrings.log)

## Questions/Stuff to discuss:
- ~should LSP-snippets' docstrings also be generated? The generated string will be closer to the actual snippet, but may be less clear as some info cannot yet be represented. (`"${1:test} $1" generates "${1:test} test"`)~ The string used to parse the snippet is the docstring.
- ~For choices: Currently only the first choice is rendered, but it would be possible to show all possible choices (may get messy :/ )~ Only render the first choice for now, maybe provide option if wanted.
- ~Currently the positions are shown as defined in the snippet, eg. in a `snippetNode` the `insertNodes` start at 1 again as opposed to being numbered continuously (I prefer the current version, but I'm biased). Using both consecutive numbering and showing all choices will not really be possible as choices may have a variable number of `insertNodes`.~ Number as defined.
- ~`env` and `captures` are prepopulated (`env.TM_SELECTED_TEXT`->`$TM_SELECTED_TEXT`, `captures[1]` -> `$CAPTURE1` etc). This may lead to problems with dynamic/functionNodes where eg. a `%d` is matched and without checking converted with `tonumber` (works fine in regular operation, but would return `nil` here). For captures this can be solved by letting the user provide a trigger for failing snippets or for better results (consider [this snippet](https://github.com/L3MON4D3/Dotfiles/blob/master/.config/nvim/lua/snips.lua#L210), the docstring would be `{ "\\subsubsubsubsubsubsubsubsubsection{$1}", "$0" }` due to the `len($CAPTURE1)`), for `env` it could be problematic (date converted to number/some pattern doesn't match where it is expected to).~ Use `pcall` for the `function/dynamicNode`s' function and print informative error-message should it throw, for captures `docTrig` may be specified, see `:h luasnip-docstring`