### PR TITLE
fix mode of <Plug>luasnip-expand-snippet keymap to select

### DIFF
--- a/plugin/luasnip.vim
+++ b/plugin/luasnip.vim
@@ -9,7 +9,7 @@ noremap <silent> <Plug>luasnip-delete-check <cmd>lua require'luasnip'.unlink_cur
 noremap! <silent> <Plug>luasnip-delete-check <cmd>lua require'luasnip'.unlink_current_if_deleted()<Cr>
 
 snoremap <silent> <Plug>luasnip-expand-or-jump <cmd>lua require'luasnip'.expand_or_jump()<Cr>
-inoremap <silent> <Plug>luasnip-expand-snippet <cmd>lua require'luasnip'.expand()<Cr>
+snoremap <silent> <Plug>luasnip-expand-snippet <cmd>lua require'luasnip'.expand()<Cr>
 snoremap <silent> <Plug>luasnip-next-choice <cmd>lua require'luasnip'.change_choice(1)<Cr>
 snoremap <silent> <Plug>luasnip-prev-choice <cmd>lua require'luasnip'.change_choice(-1)<Cr>
 snoremap <silent> <Plug>luasnip-jump-next <cmd>lua require'luasnip'.jump(1)<Cr>


### PR DESCRIPTION
The next two lines are the same.

## A

https://github.com/L3MON4D3/LuaSnip/blob/1db821efe7416483a7288ef86dbae6f63ab0221e/plugin/luasnip.vim#L2

## B

https://github.com/L3MON4D3/LuaSnip/blob/1db821efe7416483a7288ef86dbae6f63ab0221e/plugin/luasnip.vim#L12

Isn't the mode of the keymap of B a selection?