### PR TITLE
Allow use of env-variables in (dynamic)LambdaNode

### DIFF
--- a/lua/luasnip/extras/_lambda.lua
+++ b/lua/luasnip/extras/_lambda.lua
@@ -68,8 +68,12 @@ end
 setmetatable(lambda, {
 	__index = function(_, key)
 		-- \\n to be correctly interpreted in `load()`.
-		return P({op="X", repr = "table.concat(snip.env."..key..", \"\\n\")", index = 0})
-	end
+		return P({
+			op = "X",
+			repr = "table.concat(snip.env." .. key .. ', "\\n")',
+			index = 0,
+		})
+	end,
 })
 
 local repr

--- a/lua/luasnip/extras/_lambda.lua
+++ b/lua/luasnip/extras/_lambda.lua
@@ -64,6 +64,14 @@ function lambda._(value)
 	return P({ op = "X", repr = value, index = "wrap" })
 end
 
+-- unknown keys are some named variable.
+setmetatable(lambda, {
+	__index = function(_, key)
+		-- \\n to be correctly interpreted in `load()`.
+		return P({op="X", repr = "table.concat(snip.env."..key..", \"\\n\")", index = 0})
+	end
+})
+
 local repr
 
 lambda.Nil = lambda.Var("nil")
@@ -334,6 +342,8 @@ function lambda.instantiate(e)
 	for i = 1, n do
 		append(parms, "_" .. i)
 	end
+	append(parms, "snip")
+
 	consts = concat(consts, ",")
 	parms = concat(parms, ",")
 	rep = repr(e)

--- a/lua/luasnip/extras/_lambda.lua
+++ b/lua/luasnip/extras/_lambda.lua
@@ -76,6 +76,16 @@ setmetatable(lambda, {
 	end,
 })
 
+lambda.captures = {}
+setmetatable(lambda.captures, {
+	__index = function(_, key)
+		local indx = tonumber(key)
+		-- captures are already strings, no multiline.
+		-- empty string for invalid key.
+		return P({op="X", repr = indx and "snip.captures["..indx.."]" or "", index = 0})
+	end
+})
+
 local repr
 
 lambda.Nil = lambda.Var("nil")

--- a/lua/luasnip/extras/_lambda.lua
+++ b/lua/luasnip/extras/_lambda.lua
@@ -82,8 +82,12 @@ setmetatable(lambda.captures, {
 		local indx = tonumber(key)
 		-- captures are already strings, no multiline.
 		-- empty string for invalid key.
-		return P({op="X", repr = indx and "snip.captures["..indx.."]" or "", index = 0})
-	end
+		return P({
+			op = "X",
+			repr = indx and "snip.captures[" .. indx .. "]" or "",
+			index = 0,
+		})
+	end,
 })
 
 local repr

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -71,12 +71,15 @@ local function to_function(val, use_re)
 		end
 	end
 	if type(val) == "string" and use_re then
-		return function(arg)
-			return arg:match(val)
+		return function(args)
+			return _concat(args[1]):match(val)
 		end
 	end
 	if lambda.isPE(val) then
-		return lambda.instantiate(val)
+		local lmb = lambda.instantiate(val)
+		return function(args)
+			return lmb(make_lambda_args(args))
+		end
 	end
 	assert(false, "Can't convert argument to function")
 end
@@ -92,13 +95,12 @@ local function match(index, _match, _then, _else)
 	end)
 	_else = to_function(_else or "")
 
-	local function func(arg)
-		local text = _concat(arg[1])
+	local function func(args)
 		local out = nil
-		if _match(text) then
-			out = _then(text)
+		if _match(args) then
+			out = _then(args)
 		else
-			out = _else(text)
+			out = _else(args)
 		end
 		return vim.split(out, "\n")
 	end

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -26,7 +26,7 @@ local function make_lambda_args(node_args)
 				val = snip.captures[tonumber(num)]
 			else
 				-- env may be string or table.
-				if type(snip.env[key] == "table") then
+				if type(snip.env[key]) == "table" then
 					val = _concat(snip.env[key])
 				else
 					val = snip.env[key]

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -15,6 +15,8 @@ local function expr_to_fn(expr)
 	local fn_code = _lambda.instantiate(expr)
 	local function fn(args)
 		local inputs = vim.tbl_map(_concat, args)
+		-- set snippet raw, no concat here.
+		inputs[#inputs] = args[#args]
 		-- to be sure, lambda may end with a `match` returning nil.
 		local out = fn_code(unpack(inputs)) or ""
 		return vim.split(out, "\n")

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -34,7 +34,7 @@ local function make_lambda_args(node_args)
 			end
 			rawset(table, key, val)
 			return val
-		end
+		end,
 	})
 	return args
 end

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -29,7 +29,7 @@ local function expr_to_fn(expr)
 				end
 				rawset(table, key, val)
 				return val
-			end
+			end,
 		})
 		-- to be sure, lambda may end with a `match` returning nil.
 		local out = fn_code(inputs) or ""

--- a/lua/luasnip/util/pattern_tokenizer.lua
+++ b/lua/luasnip/util/pattern_tokenizer.lua
@@ -90,7 +90,11 @@ return {
 				next_is_text = false
 				-- if not found, just exit loop now, pattern is malformed.
 				next_indx = (charset_end_indx(pattern, indx) or #pattern) + 1
-			elseif char == "(" or char == ")" or (char == "^" and indx == 1) then
+			elseif
+				char == "("
+				or char == ")"
+				or (char == "^" and indx == 1)
+			then
 				-- ^ is interpreted literally if not at beginning.
 				-- $ will always be interpreted literally in triggers.
 


### PR DESCRIPTION
Should allow usage as eg.
```lua
s("transform", {
	l(l.TM_SELECTED_TEXT:gsub("a", "e"), {}),
}),
```
@leiserfg What do you think of the implementation? I'm still not that sure around lambdas, so no idea if this is the best way to do it.