### PR TITLE
fix: skip loading snippet file if parsing error

### DIFF
--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -63,6 +63,10 @@ local function load_snippet_file(langs, snippet_set_path)
 		true,
 		vim.schedule_wrap(function(data)
 			local snippet_set_data = json_decode(data)
+			if snippet_set_data == nil then
+				return
+			end
+
 			for _, lang in pairs(langs) do
 				local lang_snips = ls.snippets[lang] or {}
 


### PR DESCRIPTION
I'm using these commands to load all the snippets from vscode & its extensions:

```lua
vscodeLoader.load({
	paths = vim.fn.globpath("~/.vscode/extensions", "*", 0, 1),
})
vscodeLoader.load({
	paths = vim.fn.globpath("/opt/visual-studio-code/resources/app/extensions", "*", 0, 1),
})
```

[The snippet file for `markdown`](https://github.com/microsoft/vscode/blob/c16cd29d1012cbb67de5e77448695d5c9f83e1e6/extensions/markdown-basics/snippets/markdown.code-snippets#L91) has a trailing comma so `json_decode` is unable to parse it.

This PR add a check  to skip the file if it cannot be parsed.