### PR TITLE
Add printf-like snippet formatting 

### DIFF
--- a/Examples/snippets.lua
+++ b/Examples/snippets.lua
@@ -13,6 +13,8 @@ local p = require("luasnip.extras").partial
 local m = require("luasnip.extras").match
 local n = require("luasnip.extras").nonempty
 local dl = require("luasnip.extras").dynamic_lambda
+local fmt = require("luasnip.extras.fmt").fmt
+local fmta = require("luasnip.extras.fmt").fmta
 local types = require("luasnip.util.types")
 
 -- Every unspecified option will be set to the default.
@@ -343,6 +345,40 @@ ls.snippets = {
 			t({ "", "" }),
 			dl(3, l._1:gsub("\n", " linebreak ") .. l._2, { 1, 2 }),
 		}),
+		-- Alternative printf-like notation for defining snippets. It uses format
+		-- string with placeholders similar to the ones used with Python's .format().
+		s("fmt1", fmt("To {title} {} {}.", {
+			i(2, "Name"),
+			i(3, "Surname"),
+			title = c(1, {t("Mr."), t("Ms.")}),
+		})),
+		-- To escape delimiters use double them, e.g. `{}` -> `{{}}`.
+		-- Multi-line format strings by default have empty first/last line removed.
+		-- Indent common to all lines is also removed. Use the third `opts` argument
+		-- to control this behaviour.
+		s("fmt2", fmt([[
+			foo({1}, {3}) {{
+				return {2} * {4}
+			}}
+			]], {
+			i(1, "x"),
+			r(1),
+			i(2, "y"),
+			r(2),
+		})),
+		-- Empty placeholders are numbered automatically starting from 1 or the last
+		-- value of a numbered placeholder. Named placeholders do not affect numbering.
+		s("fmt3", fmt("{} {a} {} {1} {}", {
+			t("1"),
+			t("2"),
+			a = t("A"),
+		})),
+		-- The delimiters can be changed from the default `{}` to something else.
+		s("fmt4", fmt("foo() { return []; }", i(1, "x"), { delimiters = '[]' })),
+		-- `fmta` is a convenient wrapper that uses `<>` instead of `{}`.
+		s("fmt5", fmta("foo() { return <>; }", i(1, "x"))),
+		-- By default all args must be used. Use strict=false to disable the check
+		s("fmt6", fmt("use {} only", { t("this"), t("not this") }, { strict = false })),
 	},
 	java = {
 		-- Very long example for a java class.

--- a/lua/luasnip/extras/_lambda.lua
+++ b/lua/luasnip/extras/_lambda.lua
@@ -7,7 +7,7 @@ local map = vim.tbl_map
 
 local _DEBUG = rawget(_G, "_DEBUG")
 
-function assert_arg(n, val, tp, verify, msg, lev)
+local function assert_arg(n, val, tp, verify, msg, lev)
 	if type(val) ~= tp then
 		error(
 			("argument %d expected a '%s', got a '%s'"):format(n, tp, type(val)),

--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -1,0 +1,203 @@
+local text_node = require("luasnip.nodes.textNode").T
+local wrap_nodes = require('luasnip.util.util').wrap_nodes
+
+-- Interpolate elements from `args` into format string with placeholders.
+--
+-- The placeholder syntax for selecting from `args` is similar to fmtlib and
+-- Python's .format(), with some notable differences:
+-- * no format options (like `{:.2f}`)
+-- * 1-based indexing
+-- * numbered/auto-numbered placeholders can be mixed; numbered ones set the
+--   current index to new value, so following auto-numbered placeholders start
+--   counting from the new value (e.g. `{} {3} {}` is `{1} {3} {4}`)
+--
+-- Arguments:
+--   fmt: string with placeholders
+--   args: table with list-like and/or map-like keys
+--   opts:
+--     delimiters: string, 2 distinct characters (left, right), default "{}"
+--     strict: boolean, set to false to allow for unused `args`, default true
+-- Returns: a list of strings and elements of `args` inserted into placeholders
+local function interpolate(fmt, args, opts)
+    local defaults = {
+        delimiters = '{}',
+        strict = true,
+    }
+    opts = vim.tbl_extend('force', defaults, opts or {})
+
+    -- sanitize delimiters
+    assert(#opts.delimiters == 2,
+        'Currently only single-char delimiters are supported, e.g. delimiters="{}" (left, right)')
+    assert(opts.delimiters:sub(1, 1) ~= opts.delimiters:sub(2, 2),
+        "Delimiters must be two _different_ characters")
+    local delimiters = {
+        left = opts.delimiters:sub(1, 1),
+        right = opts.delimiters:sub(2, 2),
+        esc_left = vim.pesc(opts.delimiters:sub(1, 1)),
+        esc_right = vim.pesc(opts.delimiters:sub(2, 2)),
+    }
+
+    -- manage insertion of text/args
+    local elements = {}
+    local last_index = 0
+    local used_keys = {}
+
+    local add_text = function(text)
+        if #text > 0 then
+            table.insert(elements, text)
+        end
+    end
+    local add_arg = function(placeholder)
+        local num = tonumber(placeholder)
+        local key
+        if num then  -- numbered placeholder
+            last_index = num
+            key = last_index
+        elseif placeholder == '' then  -- auto-numbered placeholder
+            key = last_index + 1
+            last_index = key
+        else  -- named placeholder
+            key = placeholder
+        end
+        assert(args[key], string.format('Missing key `%s` in format arguments: `%s`', key, fmt))
+        table.insert(elements, args[key])
+        used_keys[key] = true
+    end
+
+    -- iterate keeping a range from previous match, e.g. (not in_placeholder vs in_placeholder)
+    -- "Sample {2} string {3}."   OR  "Sample {2} string {3}."
+    --       left^--------^right  OR      left^-^right
+    local pattern = string.format('[%s%s]', delimiters.esc_left, delimiters.esc_right)
+    local in_placeholder = false
+    local left = 0
+
+    while true do
+        local right = fmt:find(pattern, left + 1)
+        -- if not found, add the remaining part of string and finish
+        if right == nil then
+            assert(not in_placeholder, string.format('Missing closing delimiter: "%s"', fmt:sub(left)))
+            add_text(fmt:sub(left + 1))
+            break
+        end
+        -- check if the delimiters are escaped
+        local delim = fmt:sub(right, right)
+        local next_char = fmt:sub(right + 1, right + 1)
+        if not in_placeholder and delim == next_char then
+            -- add the previous part of the string with a single delimiter
+            add_text(fmt:sub(left + 1, right))
+            -- and jump over the second one
+            left = right + 1
+            -- "continue"
+        else  -- non-escaped delimiter
+            assert(delim == (in_placeholder and delimiters.right or delimiters.left),
+                string.format('Found unescaped %s %s placeholder; format[%d:%d]="%s"',
+                    delim, in_placeholder and 'inside' or 'outside', left, right, fmt:sub(left, right)))
+            -- add arg/text depending on current state
+            local add = in_placeholder and add_arg or add_text
+            add(fmt:sub(left + 1, right - 1))
+            -- update state
+            left = right
+            in_placeholder = delim == delimiters.left
+        end
+    end
+
+    -- sanity check: all arguments were used
+    if opts.strict then
+        for key, _ in pairs(args) do
+            assert(used_keys[key], string.format("Unused argument: args[%s]", key))
+        end
+    end
+
+    return elements
+end
+
+-- Find the largest common indent in a list of lines and remove it.
+local function remove_common_indent(lines)
+    local max_indent = math.huge
+    for _, line in ipairs(lines) do
+        -- ignore lines with whitespace only
+        local match = line:match('^(%s*)%S')
+        if match then
+            max_indent = math.min(max_indent, #match)
+        end
+    end
+    if max_indent > 0 then
+        lines = vim.tbl_map(function(line)
+            return line:sub(max_indent + 1)
+        end, lines)
+    end
+    return lines
+end
+
+-- Use a format string with placeholders to interpolate nodes.
+--
+-- See `interpolate` documentation for details on the format.
+--
+-- Arguments:
+--   str: format string
+--   nodes: snippet node or list of nodes
+--   opts: optional table
+--     trim_empty: boolean, remove whitespace-only first/last lines, default true
+--     dedent: boolean, remove all common indent in `str`, default true
+--     ... the rest is passed to `interpolate`
+-- Returns: list of snippet nodes
+local function format_nodes(str, nodes, opts)
+    local defaults = {
+        trim_empty = true,
+        dedent = true,
+    }
+    opts = vim.tbl_extend('force', defaults, opts or {})
+
+    -- allow to pass a single node
+    nodes = wrap_nodes(nodes)
+
+    -- optimization: avoid splitting multiple times
+    local lines = nil
+
+    -- this allows to use [[...]] strings ignoring the first and last lines
+    if opts.trim_empty then
+        lines = vim.split(str, '\n', true)
+        if lines[1]:match('^%s*$') then
+            table.remove(lines, 1)
+        end
+        if lines[#lines]:match('^%s*$') then
+            table.remove(lines)
+        end
+    end
+
+    -- remove common indent
+    if opts.dedent then
+        lines = lines or vim.split(str, '\n', true)
+        lines = remove_common_indent(lines)
+    end
+
+    if lines then
+        str = table.concat(lines, '\n')
+    end
+
+    -- pop format_nodes's opts
+    for key, _ in ipairs(defaults) do
+        opts[key] = nil
+    end
+
+    local parts = interpolate(str, nodes, opts)
+    return vim.tbl_map(function(part)
+        -- wrap strings in text nodes
+        if type(part) == 'string' then
+            return text_node(vim.split(part, '\n', true))
+        else
+            return part
+        end
+    end, parts)
+end
+
+return {
+    interpolate = interpolate,
+    format_nodes = format_nodes,
+    -- alias
+    fmt = format_nodes,
+    fmta = function(str, nodes, opts)  -- fmt with angle brackets
+        opts = vim.tbl_extend('force', opts or {}, { delimiters = '<>' })
+        return format_nodes(str, nodes, opts)
+    end,
+}

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -79,16 +79,6 @@ function Snippet:init_nodes()
 	self:populate_argnodes()
 end
 
-local function wrap_nodes(nodes)
-	-- safe to assume, if nodes has a metatable, it is a single node, not a
-	-- table.
-	if getmetatable(nodes) then
-		return { nodes }
-	else
-		return nodes
-	end
-end
-
 local function init_opts(opts)
 	opts = opts or {}
 
@@ -126,7 +116,7 @@ local function S(context, nodes, opts)
 
 	opts = init_opts(opts)
 
-	nodes = wrap_nodes(nodes)
+	nodes = util.wrap_nodes(nodes)
 	local snip = Snippet:new({
 		trigger = context.trig,
 		dscr = dscr,
@@ -168,7 +158,7 @@ local function SN(pos, nodes, opts)
 
 	local snip = Snippet:new({
 		pos = pos,
-		nodes = wrap_nodes(nodes),
+		nodes = util.wrap_nodes(nodes),
 		insert_nodes = {},
 		current_insert = 0,
 		callbacks = opts.callbacks,

--- a/lua/luasnip/util/mark.lua
+++ b/lua/luasnip/util/mark.lua
@@ -8,7 +8,7 @@ function Mark:new(o)
 end
 
 -- opts just like in nvim_buf_set_extmark.
-function mark(pos_begin, pos_end, opts)
+local function mark(pos_begin, pos_end, opts)
 	return Mark:new({
 		id = vim.api.nvim_buf_set_extmark(
 			0,

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -193,6 +193,17 @@ local function wrap_value(value)
 	return { value }
 end
 
+-- Wrap node in a table if it is not one
+local function wrap_nodes(nodes)
+	-- safe to assume, if nodes has a metatable, it is a single node, not a
+	-- table.
+	if getmetatable(nodes) then
+		return { nodes }
+	else
+		return nodes
+	end
+end
+
 local SELECT_RAW = "LUASNIP_SELECT_RAW"
 local SELECT_DEDENT = "LUASNIP_SELECT_DEDENT"
 local TM_SELECT = "LUASNIP_TM_SELECT"
@@ -444,6 +455,7 @@ return {
 	word_under_cursor = word_under_cursor,
 	put = put,
 	wrap_value = wrap_value,
+	wrap_nodes = wrap_nodes,
 	store_selection = store_selection,
 	get_selection = get_selection,
 	pos_equal = pos_equal,

--- a/tests/fmt_spec.lua
+++ b/tests/fmt_spec.lua
@@ -1,0 +1,108 @@
+local interpolate = require('luasnip.extras.fmt').interpolate
+
+local works = function(msg, fmt, args, expected, opts)
+    it(msg, function()
+        local result = interpolate(fmt, args, opts)
+        assert.are.same(expected, table.concat(result))
+    end)
+end
+
+local fails = function(msg, fmt, args, opts)
+    it(msg, function()
+        assert.has_error(function()
+            interpolate(fmt, args, opts)
+        end)
+    end)
+end
+
+describe('fmt.interpolate', function()
+    works('expands with no numbers',
+        'a{}b{}c{}d', {4, 5, 6},
+        'a4b5c6d')
+
+    works('expands with explicit numbers',
+        'a{2}b{1}c{3}d', {4, 5, 6},
+        'a5b4c6d')
+
+    works('expands with mixed numbering',
+        'a{}b{3}c{}d{2}e', {1, 2, 3, 4},
+        'a1b3c4d2e')
+
+    works('expands named placeholders',
+        'a{A}b{B}c{C}d', {A = 1, B = 2, C = 3},
+        'a1b2c3d')
+
+    works('expands all mixed',
+        'a {A} b {} c {3} d {} e {B} f {A} g {2} h', {1, 2, 3, 4, A = 10, B = 20},
+        'a 10 b 1 c 3 d 4 e 20 f 10 g 2 h')
+
+    works('current index changed by numbered nodes',
+        '{} {} {1} {} {}', {1, 2, 3},
+        '1 2 1 2 3')
+
+    works('excludes trailing text',
+        '{}abcd{}', {1, 2},
+        '1abcd2')
+
+    works('escapes empty double-braces',
+        'a{{}}b{}c{{}}d{}e', {2, 4},
+        'a{}b2c{}d4e')
+
+    works('escapes non-empty double-braces',
+        'a{{d}}b{}c', {2},
+        'a{d}b2c')
+
+    works('do not trim placeholders with whitespace',
+        'a{ something}b{}c', {2, [' something'] = 1},
+        'a1b2c')
+
+    works('replaces nested escaped braces',
+        'a{{{{}}}}b{}c{{ {{ }}}}d', {2},
+        'a{{}}b2c{ { }}d')
+
+    works('replaces umatched escaped braces',
+        'a{{{{b{}c', {2},
+        'a{{b2c')
+
+    works('replaces in braces inside escaped braces',
+        'a{{{}}}b{{ {}}}c{{{} }}d{{ {} }}e', {1, 2, 3, 4},
+        'a{1}b{ 2}c{3 }d{ 4 }e')
+
+    fails('fails for unbalanced braces',
+        'a{b', {})
+
+    fails('fails for nested braces',
+        'a{ { } }b', {})
+
+    works('can use different delimiters',
+        'foo() { return <>; };', {10},
+        'foo() { return 10; };', { delimiters = '<>' })
+
+    local delimiters = {'()', '[]', '<>', '%$', '#@', '?!'}
+    for _, delims in ipairs(delimiters) do
+        local left, right = delims:sub(1, 1), delims:sub(2, 2)
+        describe('can use custom delimiters', function()
+            works(delims,
+                string.format('{ return %s%s; };', left, right), {10},
+                '{ return 10; };', { delimiters = delims })
+        end)
+    end
+
+    works('can escape custom delimiters',
+        'foo((x)) { return x + (); };', {10},
+        'foo(x) { return x + 10; };', { delimiters = '()' })
+
+    works('can use named placeholders with custom delimiters',
+        'foo(x) { return x + [y]; };', {y = 10},
+        'foo(x) { return x + 10; };', { delimiters = '[]' })
+
+    fails('dissallows unused list args',
+        'a {} b {} c', {1, 2, 3})
+
+    fails('dissallows unused map args',
+        'a {A} b {B} c {} d', {1, A = 10, B = 20, C = 30})
+
+    works('allows unused with strict=false',
+        'a {A} b {B} c {} d', {1, 2, A = 10, B = 20, C = 30},
+        'a 10 b 20 c 1 d', { strict = false })
+end)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,6 @@
+-- plenary.vim must be installed
+vim.cmd [[set runtimepath+=.]]
+vim.cmd [[runtime! plugin/plenary.vim]]
+vim.cmd [[runtime! plugin/luasnip.vim]]
+
+require('luasnip.config').setup {}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+cd "$HERE/.."
+
+init=tests/minimal_init.lua
+dir=tests
+
+nvim --headless --noplugin -u "$init" \
+    -c "PlenaryBustedDirectory $dir { minimal_init = '$init' }"


### PR DESCRIPTION
I recently discovered LuaSnip and it is really cool. One thing I was missing was to be able to combine the flexibility of snippets defined in Lua with some kind of string interpolation. Lsp-style snippets allow for interpolation but they lack more advanced features. This PR is an attempt to add an alternative method for defining snippets using format strings similar to the Python ones. It's easiest to show as an example:
```lua
s("echoe", fmt('echo {} 1>&2', i(1, 'msg')),
s("fmtlines", fmt([[
	foo({1}, {3}) {
		# ignore {{}} these {{braces}}
		return {2} * {4}
	}
	]], {
	i(1, "x"),
	r(1),
	i(2, "y"),
	r(2),
})),
```
`fmt` parses the format string, splits it into text nodes and inserts nodes from the second argument (`nodes`) in place of placeholders. Placeholders can be numbers (indexing `nodes` with numbers), strings (then indexes `nodes` as key-value map) or can be empty, then uses last number+1.

I also added unit tests that make use of plenary.nvim's busted. You can run these with `tests/run.sh`.