### PR TITLE
Adding cmp description

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,62 @@ smap <silent><expr> <C-E> luasnip#choice_active() ? '<Plug>luasnip-next-choice' 
 ```
   </details>
    <details>
-   <summary>or in lua (includes supertab-like functionality with nvim-compe)</summary>
+   <summary>or in lua (includes supertab-like functionality with nvim-cmp)</summary>
+
+```lua
+local function prequire(...)
+local status, lib = pcall(require, ...)
+if (status) then return lib end
+    return nil
+end
+
+local luasnip = prequire('luasnip')
+local cmd = prequire("cmp")
+
+local t = function(str)
+    return vim.api.nvim_replace_termcodes(str, true, true, true)
+end
+
+local check_back_space = function()
+    local col = vim.fn.col('.') - 1
+    if col == 0 or vim.fn.getline('.'):sub(col, col):match('%s') then
+        return true
+    else
+        return false
+    end
+end
+
+_G.tab_complete = function()
+    if cmp and cmp.visible() == 1 then
+        cmp.select_next_item()
+    elseif luasnip and luasnip.expand_or_jumpable() then
+        return t "<Plug>luasnip-expand-or-jump"
+    elseif check_back_space() then
+        return t "<Tab>"
+    else
+        cmp.complete()
+    end
+end
+_G.s_tab_complete = function()
+    if cmp and cmp.visible() == 1 then
+        return cmp.select_prev_item()
+    elseif luasnip and luasnip.jumpable(-1) then
+        return t "<Plug>luasnip-jump-prev"
+    else
+        return t "<S-Tab>"
+    end
+end
+
+vim.api.nvim_set_keymap("i", "<Tab>", "v:lua.tab_complete()", {expr = true})
+vim.api.nvim_set_keymap("s", "<Tab>", "v:lua.tab_complete()", {expr = true})
+vim.api.nvim_set_keymap("i", "<S-Tab>", "v:lua.s_tab_complete()", {expr = true})
+vim.api.nvim_set_keymap("s", "<S-Tab>", "v:lua.s_tab_complete()", {expr = true})
+vim.api.nvim_set_keymap("i", "<C-E>", "<Plug>luasnip-next-choice", {})
+vim.api.nvim_set_keymap("s", "<C-E>", "<Plug>luasnip-next-choice", {})
+```
+  </details>
+   <details>
+   <summary>or in lua with nvim-compe</summary>
  
 ```lua
 local function prequire(...)


### PR DESCRIPTION
Until reasently Compe and Cmp had the same interfaces, but [that changed reasently](https://github.com/hrsh7th/nvim-cmp/issues/231) when they stopped using PUM in favor of floating window.

I stumbled upon this problem when my super-tab experience broke. It took a bit to figure out the issue, so this PR adds a description for getting supertab-behavior for cmp, as I assume others will likely stumble upon the same issue in the same way.