### PR TITLE
Lazy_load on BufWinEnter,FileType to catch other ways of setting ft.

### DIFF
--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -247,7 +247,7 @@ function M.lazy_load(opts)
 	vim.cmd([[
 		augroup _luasnip_vscode_lazy_load
 		autocmd!
-		au BufEnter * lua require('luasnip.loaders.from_vscode')._luasnip_vscode_lazy_load()
+		au BufWinEnter,FileType * lua require('luasnip.loaders.from_vscode')._luasnip_vscode_lazy_load()
     au User LuasnipCleanup lua require('luasnip.loaders._caches').clean()
 		augroup END
 	]])


### PR DESCRIPTION
- `BufEnter -> BufWinEnter`: `BufWinEnter` seems to only be triggered upon displaying or reloading the buffer, but importantly, after modeline has been read.
- `FileType`: Plugins, specifically `Neogit` set ft of their windows pretty late using `set ft=...`, `BufEnter` is triggered before ft is set, so no snippets are loaded for the later-set ft. Loading on `FileType` will load snippets in these cases (also, if ft is modified later on, manually, which is a nice feature)