### PR TITLE
feat(snippet): optional show_condition to filter completion candidates

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -76,6 +76,14 @@ The third argument is a table with the following valid keys:
                (the function is called before the text is modified in any way).
                Some parameters are passed to the function: The line up to the
                cursor, the matched trigger and the captures (table).
+* `show_condition`: Function with signature `f(line_to_cursor) -> boolean`
+               being a hint for completion-engines indicating when the snippet
+               should be included in current completion candidates. Defaults to
+               a function returning always true. This is different than `condition`
+               because `condition` is evaluated by LuaSnip on snippet expansion
+               (and thus has access to the matched trigger and captures), while
+               `show_condition` is evaluated by the completion-engine when scanning
+               for available snippet candidates.
 - `callbacks`: Contains functions that are called upon enterin/leaving a node.
                To print text upon entering the second node of a snippet, set
                `callbacks` should be set as follows:
@@ -85,7 +93,7 @@ The third argument is a table with the following valid keys:
                The callbacks are passed only one argument, the node that
                triggered it.
 This `opts`-table can also be passed to eg.	`snippetNode` or `indentSnippetNode`,
-`condition` doesn't have any effect there, but `callbacks` are used.
+but only `callbacks` is used there.
 
 Snippets contain some interesting tables, eg. `snippet.env` contains variables
 used in the LSP-protocol like `TM_CURRENT_LINE` or `TM_FILENAME` or

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -91,6 +91,9 @@ local function init_opts(opts)
 	opts.condition = opts.condition or function()
 		return true
 	end
+	opts.show_condition = opts.show_condition or function()
+		return true
+	end
 	return opts
 end
 
@@ -127,6 +130,7 @@ local function S(context, nodes, opts)
 		insert_nodes = {},
 		current_insert = 0,
 		condition = opts.condition,
+		show_condition = opts.show_condition,
 		callbacks = opts.callbacks,
 		mark = nil,
 		dependents = {},


### PR DESCRIPTION
Allows to pass `show_condition` which can then be used by completion engines, as discussed in https://github.com/saadparwaiz1/cmp_luasnip/pull/26. 

It is named `show_condition` instead of `hide_condition` to be able to reuse the same condition function for both `condition` and `show_condition` without having to invert the logic.