### PR TITLE
adds 'expand_or_locally_jumpable'

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -630,6 +630,9 @@ the lazy_load.
 - `expand_or_jumpable()`: returns `expandable() or jumpable(1)` (exists only
   because commonly, one key is used to both jump forward and expand).
 
+- `expand_or_locally_jumpable()`: same as `expand_or_jumpable()` except jumpable 
+  is ignored if the cursor is not inside the current snippet.
+
 - `expand_or_jump()`: returns true if jump/expand was succesful.
 
 - `expand_auto()`: expands the autosnippets before the cursor (not necessary

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -634,6 +634,8 @@ API-REFERENCE                                              *luasnip-api-referenc
 *   `expand()`: expands the snippet at(before) the cursor.
 *   `expand_or_jumpable()`: returns `expandable() or jumpable(1)` (exists only
     because commonly, one key is used to both jump forward and expand).
+*   `expand_or_locally_jumpable()`: same as `expand_or_jumpable` except jumpable
+	is ignored if the cursor is not inside a snippet. 
 *   `expand_or_jump()`: returns true if jump/expand was succesful.
 *   `expand_auto()`: expands the autosnippets before the cursor (not necessary
     to call manually, will be called via autocmd if `enable_autosnippet` is set

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -633,7 +633,7 @@ API-REFERENCE                                              *luasnip-api-referenc
 *   `expandable()`: true if a snippet can be expanded at the current cursor position.
 *   `expand()`: expands the snippet at(before) the cursor.
 *   `expand_or_jumpable()`: returns `expandable() or jumpable(1)` (exists only
-	because commonly, one key is used to both jump forward and expand).
+    because commonly, one key is used to both jump forward and expand).
 *   `expand_or_locally_jumpable()`: same as `expand_or_jumpable()` except jumpable
     is ignored if the cursor is not inside a snippet. 
 *   `expand_or_jump()`: returns true if jump/expand was succesful.

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -633,9 +633,9 @@ API-REFERENCE                                              *luasnip-api-referenc
 *   `expandable()`: true if a snippet can be expanded at the current cursor position.
 *   `expand()`: expands the snippet at(before) the cursor.
 *   `expand_or_jumpable()`: returns `expandable() or jumpable(1)` (exists only
-    because commonly, one key is used to both jump forward and expand).
-*   `expand_or_locally_jumpable()`: same as `expand_or_jumpable` except jumpable
-	is ignored if the cursor is not inside a snippet. 
+	because commonly, one key is used to both jump forward and expand).
+*   `expand_or_locally_jumpable()`: same as `expand_or_jumpable()` except jumpable
+    is ignored if the cursor is not inside a snippet. 
 *   `expand_or_jump()`: returns true if jump/expand was succesful.
 *   `expand_auto()`: expands the autosnippets before the cursor (not necessary
     to call manually, will be called via autocmd if `enable_autosnippet` is set

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -127,6 +127,24 @@ local function expand_or_jumpable()
 	return expandable() or jumpable(1)
 end
 
+local function in_snippet()
+	-- check if the cursor on a row inside a snippet.
+	local node = session.current_nodes[vim.api.nvim_get_current_buf()]
+	if not node then
+		return false
+	end
+	local snippet = node.parent.snippet
+	local snip_begin_pos, snip_end_pos = snippet.mark:pos_begin_end()
+	local pos = vim.api.nvim_win_get_cursor(0)
+	if pos[1] - 1 >= snip_begin_pos[1] and pos[1] - 1 <= snip_end_pos[1] then
+		return true -- cursor not on row inside snippet
+	end
+end
+
+local function expand_or_locally_jumpable()
+	return expandable() or (in_snippet() and jumpable())
+end
+
 local function expand()
 	if next_expand ~= nil then
 		no_region_check_wrap(
@@ -393,6 +411,7 @@ end
 
 ls = {
 	expand_or_jumpable = expand_or_jumpable,
+	expand_or_locally_jumpable = expand_or_locally_jumpable,
 	jumpable = jumpable,
 	expandable = expandable,
 	expand = expand,


### PR DESCRIPTION
as alternative for 'expand_or_jumpable' which is true if you can jump into
a snippet from outside fo it. This restricts the jumping feature to only
work from inside the function.
For more see #213