### PR TITLE
feat: add snippet completion for injected languages

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1,13 +1,13 @@
 ```
-            __                       ____                          
-           /\ \                     /\  _`\           __           
-           \ \ \      __  __     __ \ \,\L\_\    ___ /\_\  _____   
-            \ \ \  __/\ \/\ \  /'__`\\/_\__ \  /' _ `\/\ \/\ '__`\ 
+            __                       ____
+           /\ \                     /\  _`\           __
+           \ \ \      __  __     __ \ \,\L\_\    ___ /\_\  _____
+            \ \ \  __/\ \/\ \  /'__`\\/_\__ \  /' _ `\/\ \/\ '__`\
              \ \ \L\ \ \ \_\ \/\ \L\.\_/\ \L\ \/\ \/\ \ \ \ \ \L\ \
               \ \____/\ \____/\ \__/.\_\ `\____\ \_\ \_\ \_\ \ ,__/
-               \/___/  \/___/  \/__/\/_/\/_____/\/_/\/_/\/_/\ \ \/ 
-                                                             \ \_\ 
-                                                              \/_/ 
+               \/___/  \/___/  \/__/\/_/\/_____/\/_/\/_/\/_/\ \ \/
+                                                             \ \_\
+                                                              \/_/
 ```
 
 Luasnip is a snippet-engine written entirely in lua. It has some great
@@ -34,7 +34,7 @@ local events = require("luasnip.util.events")
 
 # SNIPPETS
 
-The most direct way to define snippets is `s`: 
+The most direct way to define snippets is `s`:
 ```lua
 s({trig="trigger"}, {})
 ```
@@ -157,7 +157,7 @@ s("trigger", {
 	t({"", "After jumping once more, the snippet is exited there ->"}), i(0),
 })
 ```
-The above snippet will use the same jump flow as above which is: 
+The above snippet will use the same jump flow as above which is:
 - After expansion, we will be at InsertNode 1.
 - After jumping forward, we will be at InsertNode 2.
 - After jumping forward again, we will be at InsertNode 0.
@@ -257,7 +257,7 @@ ChoiceNodes allow choosing between multiple nodes.
 `c()` expects as its first arg, as with any jumpable node, its position in the
 jumplist, and as its second a table with nodes, the choices. This table can
 either contain a single node or a table of nodes. In the latter case the table
-will be converted into a `snippetNode`.  
+will be converted into a `snippetNode`.
 The third parameter is a table of options with the following keys:
 - `restore_cursor`: `false` by default. If it is set and the node that was
 	being edited also appears in the switched-to choice (can be the case if a
@@ -399,7 +399,7 @@ local function lines(args, snip, old_state, initial_text)
 	else
 		nodes[1] = t("Enter a number!")
 	end
-	
+
 	local snip = sn(nil, nodes)
 	snip.old_state = old_state
 	return snip
@@ -547,10 +547,10 @@ ls.parser.parse_snippet({trig = "lsp"}, "$1 is ${2|hard,easy,challenging|}")
 ```
 
 Nested placeholders(`"${1:this is ${2:nested}}"`) will be turned into
-choiceNode's with:  
-	- the given snippet(`"this is ${1:nested}"`) and  
+choiceNode's with:
+	- the given snippet(`"this is ${1:nested}"`) and
 	- an empty insertNode
-	
+
 
 
 # VARIABLES
@@ -575,7 +575,7 @@ To use any `*SELECT*` variable, the `store_selection_keys` must be set via
 `require("luasnip").config.setup({store_selection_keys="<Tab>"})`. In this case,
 hitting `<Tab>` while in Visualmode will populate the `*SELECT*`-vars for the next
 snippet and then clear them.
- 
+
 
 
 # VSCODE SNIPPETS LOADER
@@ -613,12 +613,16 @@ In this case `opts` only accepts paths (`runtimepath` if any). That will load
 the general snippets (the ones of filetype 'all') and those of the filetype
 of the buffers, you open every time you open a new one (but it won't reload them).
 
-Apart from what is stipulated by the start each snippet in the json file can 
+Apart from what is stipulated by the start each snippet in the json file can
 contain a "luasnip" field which is a table for extra parameters for the snippet,
 till now the only valid one is autotrigger.
 
 After snippets were lazy-loaded, the `User LuasnipSnippetsAdded`-event will be
 triggered.
+
+Note load vscode-style packages using `require("luasnip.loaders.from_vscode").load()`, if 
+you've configured luasnip to detect the filetype based on the cursor position. Else the
+snippets won't be available to the `from_cursor_pos` function.
 
 # EXT\_OPTS
 
@@ -776,7 +780,7 @@ the lazy_load.
 - `expand_or_jumpable()`: returns `expandable() or jumpable(1)` (exists only
   because commonly, one key is used to both jump forward and expand).
 
-- `expand_or_locally_jumpable()`: same as `expand_or_jumpable()` except jumpable 
+- `expand_or_locally_jumpable()`: same as `expand_or_jumpable()` except jumpable
   is ignored if the cursor is not inside the current snippet.
 
 - `expand_or_jump()`: returns true if jump/expand was succesful.
@@ -792,15 +796,15 @@ the lazy_load.
       this function) as clearing before expansion will populate `TM_CURRENT_LINE`
       and `TM_CURRENT_WORD` with wrong values (they would miss the snippet trigger)
       and clearing after expansion may move the text currently under the cursor
-      and have it end up not at the `i(1)`, but a `#trigger` chars to it's right.  
+      and have it end up not at the `i(1)`, but a `#trigger` chars to it's right.
       The actual values used for clearing are `from` and `to`, both (0,0)-indexed
-      byte-positions.  
+      byte-positions.
       If the variables don't have to be populated with the correct values, it's
       safe to remove the text manually.
     - `expand_params`: table, for overriding the `trigger` used in the snippet
       and setting the `captures` (useful for pattern-triggered nodes where the
       trigger has to be changed from the pattern to the actual text triggering the
-      node).  
+      node).
       Pass as `trigger` and `captures`.
     - `pos`: position (`{line, col}`), (0,0)-indexed (in bytes, as returned by
       `nvim_win_get_cursor()`), where the snippet should be expanded. The
@@ -819,7 +823,7 @@ the lazy_load.
   if luasnip fails to automatically detect eg. deletion of a snippet) and
   sets the current node behind the snippet, or, if not possible, before it.
 
-- `lsp_expand(snip_string, opts)`: expand the lsp-syntax-snippet defined via 
+- `lsp_expand(snip_string, opts)`: expand the lsp-syntax-snippet defined via
   `snip_string` at the cursor.
   `opts` can have the same options as `opts` in `snip_expand`.
 

--- a/README.md
+++ b/README.md
@@ -176,5 +176,6 @@ The previously mentioned `Examples/snippets.lua` contains brief descriptions, ch
 - `enable_autosnippets`: Autosnippets are disabled by default to minimize performance penalty if unused. Set to `true` to enable.
 - `ext_opts`: Additional options passed to extmarks. Can be used to add passive/active highlight on a per-node-basis (more info in DOC.md)
 - `parser_nested_assembler`: Override the default behaviour of inserting a `choiceNode` containing the nested snippet and an empty `insertNode` for nested placeholders (`"${1: ${2: this is nested}}"`). For an example (behaviour more similar to vscode), check [here](https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#imitate-vscodes-behaviour-for-nested-placeholders)
+- `ft_func`: Source of possible filetypes for snippets. Defaults to a function, which returns `vim.split(vim.bo.filetype, ".", true)`, but check [filetype_functions](lua/luasnip/extras/filetype_functions.lua) for other options
 
 Inspired by [vsnip.vim](https://github.com/hrsh7th/vim-vsnip/)

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -1,5 +1,6 @@
 local types = require("luasnip.util.types")
 local util = require("luasnip.util.util")
+local ft_functions = require("luasnip.extras.filetype_functions")
 
 local defaults = {
 	history = false,
@@ -74,6 +75,8 @@ local defaults = {
 	-- default applied in util.parser, requires iNode, cNode
 	-- (Dependency cycle if here).
 	parser_nested_assembler = nil,
+	-- Function expected to return a list of filetypes (or empty list)
+	ft_func = ft_functions.from_filetype,
 }
 
 -- declare here to use in set_config.

--- a/lua/luasnip/extras/filetype_functions.lua
+++ b/lua/luasnip/extras/filetype_functions.lua
@@ -1,0 +1,44 @@
+-- Check if treesitter is available
+local ok_parsers, ts_parsers = pcall(require, "nvim-treesitter.parsers")
+if not ok_parsers then
+	ts_parsers = nil
+end
+
+local ok_utils, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
+if not ok_utils then
+	ts_utils = nil
+end
+
+local function from_cursor_pos()
+	if not ts_parsers or not ts_utils then
+		return {}
+	end
+
+	local parser = ts_parsers.get_parser()
+	local current_node = ts_utils.get_node_at_cursor()
+
+	if current_node then
+		return { parser:language_for_range({ current_node:range() }):lang() }
+	else
+		return {}
+	end
+end
+
+local from_filetype = function()
+	return vim.split(vim.bo.filetype, ".", true)
+end
+
+local from_pos_or_filetype = function()
+    local from_cursor = from_cursor_pos()
+    if not vim.tbl_isempty(from_cursor) then
+        return from_cursor
+    else
+        return from_filetype()
+    end
+end
+
+return {
+	from_filetype = from_filetype,
+	from_cursor_pos = from_cursor_pos,
+        from_pos_or_filetype = from_pos_or_filetype,
+}

--- a/lua/luasnip/extras/filetype_functions.lua
+++ b/lua/luasnip/extras/filetype_functions.lua
@@ -24,21 +24,21 @@ local function from_cursor_pos()
 	end
 end
 
-local from_filetype = function()
+local function from_filetype()
 	return vim.split(vim.bo.filetype, ".", true)
 end
 
-local from_pos_or_filetype = function()
-    local from_cursor = from_cursor_pos()
-    if not vim.tbl_isempty(from_cursor) then
-        return from_cursor
-    else
-        return from_filetype()
-    end
+local function from_pos_or_filetype()
+	local from_cursor = from_cursor_pos()
+	if not vim.tbl_isempty(from_cursor) then
+		return from_cursor
+	else
+		return from_filetype()
+	end
 end
 
 return {
 	from_filetype = from_filetype,
 	from_cursor_pos = from_cursor_pos,
-        from_pos_or_filetype = from_pos_or_filetype,
+	from_pos_or_filetype = from_pos_or_filetype,
 }

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -23,7 +23,7 @@ end
 -- no need to recalculate them.
 local function match_snippet(line, snippet_table)
 	local expand_params
-	local fts = util.get_snippet_filetypes(vim.bo.filetype)
+	local fts = util.get_snippet_filetypes()
 
 	-- search filetypes, then "all".
 	for _, ft in ipairs(fts) do
@@ -49,7 +49,7 @@ local function get_context(snip)
 end
 
 local function available()
-	local fts = util.get_snippet_filetypes(vim.bo.filetype)
+	local fts = util.get_snippet_filetypes()
 	local res = {}
 	for _, ft in ipairs(fts) do
 		res[ft] = {}

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -219,7 +219,7 @@ function M.load(opts)
 end
 
 function M._luasnip_vscode_lazy_load()
-	local fts = util.get_snippet_filetypes(vim.bo.filetype)
+	local fts = util.get_snippet_filetypes()
 	for _, ft in ipairs(fts) do
 		if not caches.lazy_loaded_ft[ft] then
 			caches.lazy_loaded_ft[ft] = true

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -1,16 +1,6 @@
 local events = require("luasnip.util.events")
 local session = require("luasnip.session")
 
--- Check if treesitter is available
-local ok_parsers, ts_parsers = pcall(require, "nvim-treesitter.parsers")
-if not ok_parsers then
-	ts_parsers = nil
-end
-
-local ok_utils, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
-if not ok_utils then
-	ts_utils = nil
-end
 
 local function get_cursor_0ind()
 	local c = vim.api.nvim_win_get_cursor(0)
@@ -487,64 +477,15 @@ local function find_outer_snippet(node)
 	return node
 end
 
-local get_language_at_cursor = function()
-	if not ts_parsers or not ts_utils then
-		return nil
-	end
 
-	local parser = ts_parsers.get_parser()
-	local current_node = ts_utils.get_node_at_cursor()
-
-	if current_node then
-		return parser:language_for_range({ current_node:range() }):lang()
-	else
-		return nil
-	end
-end
-
-local function get_snippet_filetype_from_cursor()
-	local snippet_fts = {}
-	local snippet_lang_cursor = get_language_at_cursor()
-
-	if
-		snippet_lang_cursor
-		and not vim.tbl_contains(snippet_fts, snippet_lang_cursor)
-	then
-		vim.list_extend(snippet_fts, session.ft_redirect[snippet_lang_cursor])
-	end
-
-	return snippet_fts
-end
-
-local function get_snippet_filetype_from_filetype(filetype)
-	local fts = vim.split(filetype, ".", true)
+-- filetype: string formatted like `'filetype'`.
+local function get_snippet_filetypes()
+        local config = require("luasnip.config").config
+	local fts = config.ft_func()
+         
 	local snippet_fts = {}
 	for _, ft in ipairs(fts) do
 		vim.list_extend(snippet_fts, session.ft_redirect[ft])
-	end
-
-	return snippet_fts
-end
-
--- filetype: string formatted like `'filetype'`.
--- from: "both", "cursor", "filetype" (default "cursor")
-local function get_snippet_filetypes(filetype, from)
-	-- default to snippets based on the cursors language, but if treesitter isn't available use filetype
-	from = from or "cursor"
-	if from == "cursor" and not (ts_parsers and ts_utils) then
-		from = "filetype"
-	end
-
-	local snippet_fts = {}
-	if from == "both" then
-		snippet_fts = get_snippet_filetype_from_filetype(filetype)
-		vim.list_extend(snippet_fts, get_snippet_filetype_from_cursor())
-	elseif from == "cursor" then
-		snippet_fts = get_snippet_filetype_from_cursor()
-	elseif from == "filetype" then
-		snippet_fts = get_snippet_filetype_from_filetype(filetype)
-	else
-		error("Cannot deduce snippet filetype from " .. from)
 	end
 
 	-- add all last.


### PR DESCRIPTION
This is the port of [this PR for cmp_luasnip](https://github.com/saadparwaiz1/cmp_luasnip/pull/28).

It uses the language at the cursor position by default and falls back to the filetype if treesitter isn't available. I'm not sure about the parameter if such a thing is good. I appreciate the feedback!