### PR TITLE
fix(from_snipmate): remove extra blank line of the last snippet

### DIFF
--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -11,6 +11,7 @@ local function parse_snipmate(buffer, filename)
 
 	---@type string[]
 	local lines = vim.split(buffer, "\n")
+	lines[#lines] = nil
 	local i = 1
 
 	local function _parse()


### PR DESCRIPTION
```lua
snippet inc
    $1 = $1 + 1
```
The `\n` at the end of the file will add an extra blank line.
```lua
{"$1 = $1 + 1", ""}
```