### PR TITLE
Make loading synchronous.

### DIFF
--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -71,22 +71,18 @@ local function load_snippet_file(lang, path)
 		return
 	end
 
-	Path.async_read_file(
-		path,
-		vim.schedule_wrap(function(buffer)
-			local snippet, extends = parse_snipmate(buffer, path)
-			if not snippet then
-				return
-			end
-			table.insert(extends, lang)
-			for _, ft in ipairs(extends) do
-				local lang_snips = ls.snippets[ft] or {}
-				ls.snippets[ft] = vim.list_extend(lang_snips, snippet)
-				session.latest_load_ft = ft
-				vim.cmd("do User LuasnipSnippetsAdded")
-			end
-		end)
-	)
+	local buffer = Path.read_file(path)
+	local snippet, extends = parse_snipmate(buffer, path)
+	if not snippet then
+		return
+	end
+	table.insert(extends, lang)
+	for _, ft in ipairs(extends) do
+		local lang_snips = ls.snippets[ft] or {}
+		ls.snippets[ft] = vim.list_extend(lang_snips, snippet)
+		session.latest_load_ft = ft
+		vim.cmd("do User LuasnipSnippetsAdded")
+	end
 end
 
 local function filter(exclude, include)

--- a/lua/luasnip/util/path.lua
+++ b/lua/luasnip/util/path.lua
@@ -38,6 +38,16 @@ function Path.async_read_file(path, callback)
 	end)
 end
 
+-- takes path:string, returns content of file:string.
+function Path.read_file(path)
+	local fd = assert(uv.fs_open(path, "r", tonumber("0666", 8)))
+	local stat = assert(uv.fs_fstat(fd))
+	local buf = assert(uv.fs_read(fd, stat.size, 0))
+	uv.fs_close(fd)
+
+	return buf
+end
+
 local MYCONFIG_ROOT = vim.env.MYVIMRC
 -- if MYVIMRC is not set then it means nvim was called with -u
 -- therefore the first script is the configuration


### PR DESCRIPTION
Rip out all `vim.schedule` and luv-callbacks from loaders.
The problem with asynchronous loading is that race-conditions may occur when snippets are added after a call to `load()` (see #281)

@uga-rosa @leiserfg Could you take a look at these changes? I'm not completely sure if it's okay to remove the `vim.schedule`, but we don't call any `vim.api` in there so I guess it is..?