### PR TITLE
feat(init) exposes in_snippet function

### DIFF
--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -536,6 +536,7 @@ ls = {
 	expand_or_locally_jumpable = expand_or_locally_jumpable,
 	jumpable = jumpable,
 	expandable = expandable,
+	in_snippet = in_snippet,
 	expand = expand,
 	snip_expand = snip_expand,
 	expand_repeat = expand_repeat,


### PR DESCRIPTION
In my keymap I would like to base the action on whether the cursor is in a snippet or not, so this just exposes the `in_snippet` function to the user