### PR TITLE
fix(from_snipmate): extends

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -904,6 +904,9 @@ ls.filetype_extend("all", { "_" })
 
 Something similar may have to be done for other snippet-repos as well.
 
+Using both `extends OtherFileType` in `FileType.snippets` and
+`ls.filetype_extend("FileType", {"OtherFileType"})` leads to duplicate snippets.
+
 
 Lazy loading is also available with the snipmate-loader.
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -915,6 +915,9 @@ When using `honza/vim-snippets`, the file with the global snippets is
 
 Something similar may have to be done for other snippet-repos as well.
 
+Using both `extends OtherFileType` in `FileType.snippets` and
+`ls.filetype_extend("FileType", {"OtherFileType"})` leads to duplicate snippets.
+
 Lazy loading is also available with the snipmate-loader.
 >
      	require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -10,6 +10,8 @@ local function new_cache()
 	return setmetatable({
 		lazy_load_paths = {},
 		lazy_loaded_ft = {},
+		ft_paths = {}, -- key is file type, value are paths of .snippets files.
+		path_snippets = {}, -- key is file path, value are parsed snippets in it.
 	}, {
 		__index = Cache,
 	})

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -7,7 +7,7 @@ local session = require("luasnip.session")
 local sp = require("luasnip.nodes.snippetProxy")
 
 local function parse_snipmate(buffer, filename)
-	local snippet = {}
+	local snippets = {}
 	local extends = {}
 
 	---@type string[]
@@ -44,7 +44,7 @@ local function parse_snipmate(buffer, filename)
 			dscr = description,
 			wordTrig = true,
 		}, body)
-		table.insert(snippet, snip)
+		table.insert(snippets, snip)
 	end
 
 	while i <= #lines do
@@ -52,8 +52,7 @@ local function parse_snipmate(buffer, filename)
 		if vim.startswith(line, "snippet") then
 			_parse()
 		elseif vim.startswith(line, "extends") then
-			local scopes = vim.split(vim.trim(line:sub(8)), "[,%s]+")
-			vim.list_extend(extends, scopes)
+			extends = vim.split(vim.trim(line:sub(8)), "[,%s]+")
 			i = i + 1
 		elseif vim.startswith(line, "#") or line:find("^%s*$") then
 			-- comment and blank line
@@ -63,43 +62,67 @@ local function parse_snipmate(buffer, filename)
 		end
 	end
 
-	return snippet, extends
+	return snippets, extends
 end
 
-local function load_snippet_file(lang, path)
+local function load_snippet_file(path)
 	if not Path.exists(path) then
 		return
 	end
 
-	Path.async_read_file(
-		path,
-		vim.schedule_wrap(function(buffer)
-			local snippet, extends = parse_snipmate(buffer, path)
-			if not snippet then
-				return
+	local snippet, extends
+
+	if cache.path_snippets[path] then
+		snippet = cache.path_snippets[path].snippet
+		extends = cache.path_snippets[path].extends
+	else
+		local buffer = Path.read_file(path)
+		snippet, extends = parse_snipmate(buffer)
+		cache.path_snippets[path] = { snippet = snippet, extends = extends }
+	end
+
+	return snippet, extends
+end
+
+local function _append(tbl, name, elem)
+	if tbl[name] == nil then
+		tbl[name] = {}
+	end
+	table.insert(tbl[name], elem)
+end
+
+---Get paths of .snippets files
+---@param roots string[] @snippet directory paths
+---@return table @keys are file types, values are paths
+local function get_ft_paths(roots)
+	local ft_path = {}
+	for _, root in ipairs(roots) do
+		local files, dirs = Path.scandir(root)
+		for _, file in ipairs(files) do
+			local ft, ext = Path.basename(file, true)
+			if ext == "snippets" then
+				_append(ft_path, ft, file)
 			end
-			table.insert(extends, lang)
-			for _, ft in ipairs(extends) do
-				local lang_snips = ls.snippets[ft] or {}
-				ls.snippets[ft] = vim.list_extend(lang_snips, snippet)
-				session.latest_load_ft = ft
-				vim.cmd("do User LuasnipSnippetsAdded")
+		end
+		for _, dir in ipairs(dirs) do
+			local ft = dir
+			files, _ = Path.scandir(Path.join(root, dir))
+			for _, file in ipairs(files) do
+				if vim.endswith(file, ".snippets") then
+					_append(ft_path, ft, file)
+				end
 			end
-		end)
-	)
+		end
+	end
+	return ft_path
 end
 
 local function filter(exclude, include)
-	vim.validate({
-		exclude = { exclude, "table" },
-		include = { include, "table", true },
-	})
-
 	exclude = loader_util.filetypelist_to_set(exclude)
 	include = loader_util.filetypelist_to_set(include)
 
 	return function(lang)
-		if exclude[lang] then
+		if exclude and exclude[lang] then
 			return false
 		end
 		if include == nil or include[lang] then
@@ -108,60 +131,50 @@ local function filter(exclude, include)
 	end
 end
 
-local function get_paths(root)
-	local ret = {}
-	local files = Path.scandir(root, "file", true)
-	for _, file in ipairs(files) do
-		local name, ext = Path.basename(file, true)
-		if ext == "snippets" then
-			table.insert(ret, { path = Path.join(root, file), ft = name })
-		end
-	end
-	local dirs = Path.scandir(root, "directory")
-	for _, dir in ipairs(dirs) do
-		local name = dir
-		files = Path.scandir(Path.join(root, dir), "file")
-		for _, file in ipairs(files) do
-			if vim.endswith(file, ".snippets") then
-				table.insert(
-					ret,
-					{ path = Path.join(root, dir, file), ft = name }
-				)
-			end
-		end
-	end
-	return ret
-end
-
-local function load_snippet_folder(root, opts)
-	local paths = get_paths(root)
-	local ft_filter = filter(opts.exclude, opts.include)
-
-	for _, v in ipairs(paths) do
-		local path, ft = v.path, v.ft
-		if ft_filter(ft) then
-			load_snippet_file(ft, path)
-		end
-	end
-end
-
 local M = {}
+
+local function normarize_paths(paths)
+	if not paths then
+		paths = vim.api.nvim_get_runtime_file("snippets", true)
+	elseif type(paths) == "string" then
+		paths = vim.split(paths, ",")
+	end
+
+	paths = vim.tbl_map(Path.expand, paths)
+	paths = util.deduplicate(paths)
+
+	cache.ft_paths = get_ft_paths(paths)
+end
+
+function M._load(ft)
+	local snippets = {}
+	for _, path in ipairs(cache.ft_paths[ft]) do
+		local snippet, extends = load_snippet_file(path)
+		vim.list_extend(snippets, snippet)
+		for _, extend in ipairs(extends) do
+			vim.list_extend(snippets, M._load(extend))
+		end
+	end
+	return snippets
+end
 
 function M.load(opts)
 	opts = opts or {}
-	opts.exclude = opts.exclude or {}
 
-	if not opts.paths then
-		opts.paths = vim.api.nvim_get_runtime_file("snippets", true)
-	elseif type(opts.paths) == "string" then
-		opts.paths = vim.split(opts.paths, ",")
+	if not opts.is_lazy then
+		normarize_paths(opts.paths)
 	end
 
-	opts.paths = vim.tbl_map(Path.expand, opts.paths)
-	opts.paths = util.deduplicate(opts.paths)
+	local ft_filter = filter(opts.exclude, opts.include)
 
-	for _, path in ipairs(opts.paths) do
-		load_snippet_folder(path, opts)
+	for ft, _ in pairs(cache.ft_paths) do
+		if ft_filter(ft) then
+			local snippets = M._load(ft)
+			local lang_snips = ls.snippets[ft] or {}
+			ls.snippets[ft] = vim.list_extend(lang_snips, snippets)
+			session.latest_load_ft = ft
+			vim.cmd("do User LuasnipSnippetsAdded")
+		end
 	end
 end
 
@@ -170,7 +183,7 @@ function M._lazyload()
 	for _, ft in ipairs(fts) do
 		if not cache.lazy_loaded_ft[ft] then
 			cache.lazy_loaded_ft[ft] = true
-			M.load({ paths = cache.lazy_load_paths, include = { ft } })
+			M.load({ include = { ft }, is_lazy = true })
 		end
 	end
 end
@@ -178,20 +191,13 @@ end
 function M.lazy_load(opts)
 	opts = opts or {}
 
-	if not opts.paths then
-		opts.paths = vim.api.nvim_get_runtime_file("snippets", true)
-	elseif type(opts.paths) == "string" then
-		opts.paths = vim.split(opts.paths, ",")
-	end
-	vim.list_extend(cache.lazy_load_paths, opts.paths)
-
-	cache.lazy_load_paths = util.deduplicate(cache.lazy_load_paths)
+	normarize_paths(opts.paths)
 
 	vim.cmd([[
     augroup _luasnip_snipmate_lazy_load
         au!
         au BufWinEnter,FileType * lua require("luasnip.loaders.from_snipmate")._lazyload()
-        au User LuasnipCleanup lua require("luasnip.loaders._caches").snipmate.clean()
+        au User LuasnipCleanup lua require("luasnip.loaders._caches").snipmate:clean()
     augroup END
     ]])
 end

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -1,5 +1,3 @@
-local session = require("luasnip.session")
-
 local function filetypelist_to_set(list)
 	vim.validate({ list = { list, "table", true } })
 	if not list then
@@ -7,10 +5,7 @@ local function filetypelist_to_set(list)
 	end
 	local out = {}
 	for _, ft in ipairs(list) do
-		-- include redirected filetypes.
-		for _, resolved_ft in ipairs(session.ft_redirect[ft]) do
-			out[resolved_ft] = true
-		end
+		out[ft] = true
 	end
 	return out
 end

--- a/tests/data/snipmate-snippets/snippets/vim.snippets
+++ b/tests/data/snipmate-snippets/snippets/vim.snippets
@@ -1,0 +1,3 @@
+extends lua
+snippet snipmate_vim1 A vim snippet
+	snipmate$1vimvimvim

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -117,4 +117,14 @@ describe("loaders:", function()
 		-- one snippet from snipmate, one from vscode.
 		assert.are.same(2, exec_lua("return #require('luasnip').snippets.lua"))
 	end)
+
+	it("Can load with extends (snipmate)", function()
+		loaders["snipmate(lazy)"]()
+		-- triggers actual load for `lazy_load()`s'
+		exec("set ft=vim")
+		-- wait a bit for async-operations to finish
+		exec('call wait(200, "0")')
+		-- one snippet from vim.snippets, one from lua.snippets
+		assert.are.same(2, exec_lua("return #require('luasnip').snippets.vim"))
+	end)
 end)


### PR DESCRIPTION
This PR is incomplete.
If you use load to load all the snippets at once, this is fine, but if you use lazy_load, there is a bug where the snippets are loaded repeatedly when the filetype changes, resulting in duplicate candidates.
If you prepare sh.snippets as follows and open hoge.sh, then run `:set ft=zsh`, you should be able to reproduce the problem.
```snippets
extends zsh
snippet test
    hi!
```
Furthermore, with lazy_load, if you open a file with ft=zsh without going through ft=sh, the snippet will not be added.