### PR TITLE
docs(README.md): make it easier for newbs to load custom vscode snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,16 @@ For nvim-cmp, it is also possible to follow the [example recommendation](https:/
 
 ## Add Snippets
 
-- **Vscode-like**: For using snippets from a plugin (eg. [rafamadriz/friendly-snippets](https://github.com/rafamadriz/friendly-snippets)) install it and add
+- **Vscode-like**: To use existing vs-code style snippets from a plugin (eg. [rafamadriz/friendly-snippets](https://github.com/rafamadriz/friendly-snippets)) simply install the friendly-snippets plugin and then add
     ```lua
     require("luasnip.loaders.from_vscode").load()
     ```
-	somewhere in your config.  
+	somewhere in your nvim config. LuaSnip will then automatically load the snippets contained in the friendly-snippets plugin.
+  You can also easily **load your own custom vscode style snippets** by stating the path to the custom snippets folder within the load function:
+    ```lua
+    -- in your nvim folder
+    require("luasnip.loaders.from_vscode").load({ paths = { "./my-cool-snippets" } })
+    ```
 	For more info on the vscode-loader, check the [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L501) or [documentation](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#vscode-snippets-loader).
 
 - **Snipmate-like**: Very similar to Vscode-packages: install a plugin that provides snippets and call the `load`-function:


### PR DESCRIPTION
I almost didn't use this great plugin because I couldn't get easily started with the snippets I already had, coming from vs-code. Going into a second page of docs almost scared me off. Perhaps just having it explicitly stated in the front page README.md on how to get up and running with existing snippets might help new users of the plugin? Great great plugin by the way. I've almost got the courage up to start coding some lua snips : )