### PR TITLE
SnippetProxy (delay parsing of lsp-snippet)

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -909,6 +909,26 @@ compatible with luasnip
 - We do not implement eval using \` (backtick). This may be implemented in the future.
 
 
+# SNIPPETPROXY
+
+`SnippetProxy` is used internally to alleviate the upfront-cost of
+loading snippets from eg. a snipmate-library or a vscode-package. This is
+achieved by only parsing the snippet on expansion, not immediately after reading
+it from some file.  
+`SnippetProxy` may also be used from lua directly, to get the same benefits:
+
+This will parse the snippet on startup...
+```lua
+ls.parser.parse_snippet("trig", "a snippet $1!")
+```
+
+... and this will parse the snippet upon expansion.
+```lua
+local sp = require("luasnip.nodes.snippetProxy")
+sp("trig", "a snippet $1")
+```
+
+
 # EXT\_OPTS
 
 `ext_opts` are probably best explained with a short example:

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -21,12 +21,13 @@ CONTENTS                                                        *luasnip-content
 14. VARIABLES..................................................|luasnip-variables|
 15. VSCODE SNIPPETS LOADER........................|luasnip-vscode_snippets_loader|
 16. SNIPMATE SNIPPETS LOADER....................|luasnip-snipmate_snippets_loader|
-17. EXT_OPTS....................................................|luasnip-ext_opts|
-18. DOCSTRING..................................................|luasnip-docstring|
-19. DOCSTRING-CACHE......................................|luasnip-docstring-cache|
-20. EVENTS........................................................|luasnip-events|
-21. CLEANUP......................................................|luasnip-cleanup|
-22. API-REFERENCE..........................................|luasnip-api-reference|
+17. SNIPPETPROXY............................................|luasnip-snippetproxy|
+18. EXT_OPTS....................................................|luasnip-ext_opts|
+19. DOCSTRING..................................................|luasnip-docstring|
+20. DOCSTRING-CACHE......................................|luasnip-docstring-cache|
+21. EVENTS........................................................|luasnip-events|
+22. CLEANUP......................................................|luasnip-cleanup|
+23. API-REFERENCE..........................................|luasnip-api-reference|
 >
                 __                       ____
                /\ \                     /\  _`\           __
@@ -913,6 +914,26 @@ Here is a summary of the differences from the original snipmate format.
 *   `${VISUAL}` will be replaced by `$TM_SELECTED_TEXT` to make the snippets
     compatible with luasnip
 *   We do not implement eval using ` (backtick). This may be implemented in the future.
+
+================================================================================
+SNIPPETPROXY                                                *luasnip-snippetproxy*
+
+`SnippetProxy` is used internally to alleviate the upfront-cost of
+loading snippets from eg. a snipmate-library or a vscode-package. This is
+achieved by only parsing the snippet on expansion, not immediately after reading
+it from some file.
+`SnippetProxy` may also be used from lua directly, to get the same benefits:
+
+This will parse the snippet on startup...
+>
+    ls.parser.parse_snippet("trig", "a snippet $1!")
+<
+
+... and this will parse the snippet upon expansion.
+>
+    local sp = require("luasnip.nodes.snippetProxy")
+    sp("trig", "a snippet $1")
+<
 
 ================================================================================
 EXT_OPTS                                                        *luasnip-ext_opts*

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -4,6 +4,7 @@ local util = require("luasnip.util.util")
 local loader_util = require("luasnip.loaders.util")
 local Path = require("luasnip.util.path")
 local session = require("luasnip.session")
+local sp = require("luasnip.nodes.snippetProxy")
 
 local function parse_snipmate(buffer, filename)
 	local snippet = {}
@@ -38,7 +39,7 @@ local function parse_snipmate(buffer, filename)
 		end
 
 		body = table.concat(body, "\n")
-		local snip = ls.parser.parse_snippet({
+		local snip = sp({
 			trig = prefix,
 			dscr = description,
 			wordTrig = true,

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -3,7 +3,7 @@ local cache = require("luasnip.loaders._caches").vscode
 local util = require("luasnip.util.util")
 local loader_util = require("luasnip.loaders.util")
 local Path = require("luasnip.util.path")
-local session = require("luasnip.session")
+local sp = require("luasnip.nodes.snippetProxy")
 
 local function json_decode(data)
 	local status, result = pcall(util.json_decode, data)
@@ -42,7 +42,7 @@ local function load_snippet_file(langs, snippet_set_path)
 						for _, prefix in ipairs(prefixes) do
 							local ls_conf = parts.luasnip or {}
 
-							local snip = ls.parser.parse_snippet({
+							local snip = sp({
 								trig = prefix,
 								name = name,
 								dscr = parts.description or name,

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -1,0 +1,80 @@
+-- the idea of this class is to lazily parse snippet (eg. only on expansion).
+--
+-- This is achieved by returning a proxy that has enough information to tell
+-- whether the snippet should be expanded at a given point (eg. all fields
+-- necessary to perform Snippet:matches()), but doesn't actually
+-- have to parse the snippet, leaving up-front cost of loading a bunch of
+-- snippets at a minimum.
+
+local parse = require("luasnip.util.parser").parse_snippet
+local snip_mod = require("luasnip.nodes.snippet")
+
+local SnippetProxy = {}
+
+-- add Snippet-functions SnippetProxy can perform using the available data.
+SnippetProxy.matches = snip_mod.Snippet.matches
+
+function SnippetProxy:get_docstring()
+	return self.docstring
+end
+
+function SnippetProxy:instantiate()
+	-- self already contains initialized context and opts, can just be passed
+	-- here, no problem.
+	-- Bonus: if some keys are set on the snippets in the table (from the
+	-- outside, for whatever reason), they are also present in the expanded
+	-- snippet.
+	--
+	-- _S will copy self, so we can safely mutate (set metatables).
+	local snippet = snip_mod._S(self, parse(nil, self._snippet_string))
+	-- snippet will have snippetProxies `copy`, nil it in snippet so it calls
+	-- snippet-copy via metatable.
+	snippet.copy = nil
+
+	self._snippet = snippet
+	-- directly call into snippet on missing keys.
+	setmetatable(self, {
+		__index = self._snippet,
+	})
+
+	-- return snippet so it can provide a missing key.
+	return snippet
+end
+
+-- context and opts are the same objects as in s(contex, nodes, opts), snippet is a string representing the snippet.
+local function new(context, snippet, opts)
+	local sp = {}
+	-- "error": there should not be duplicate keys, don't silently overwrite/keep.
+	sp = vim.tbl_extend("error", sp, snip_mod.init_snippet_context(context))
+	sp = vim.tbl_extend("error", sp, snip_mod.init_snippet_opts(opts))
+	sp._snippet_string = snippet
+	-- override docstring
+	sp.docstring = snippet
+
+	setmetatable(sp, {
+		__index = function(t, k)
+			if SnippetProxy[k] then
+				-- if it is possible to perform this operation without actually parsing the snippet, just do it.
+				return SnippetProxy[k]
+			else
+				local snip = SnippetProxy.instantiate(t)
+				if k == "_snippet" then
+					return snip
+				else
+					return snip[k]
+				end
+			end
+		end,
+	})
+
+	-- snippetProxy has to be able to return snippet on copy even after parsing,
+	-- when the metatable has been changed. Therefore: set copy in each instance
+	-- of snippetProxy.
+	function sp:copy()
+		return self._snippet:copy()
+	end
+
+	return sp
+end
+
+return new

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -379,6 +379,11 @@ parse_snippet = function(context, body, tab_stops, brackets)
 			if type(context) == "number" then
 				return snipNode.SN(context, fix_node_indices(nodes))
 			else
+				-- return raw nodes.
+				if type(context) == "nil" then
+					return fix_node_indices(nodes)
+				end
+
 				if type(context) == "string" then
 					context = { trig = context }
 				end

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -38,6 +38,7 @@ function M.session_setup_luasnip()
 	n = require("luasnip.extras").nonempty
 	m = require("luasnip.extras").match
 	ai = require("luasnip.nodes.absolute_indexer")
+	sp = require("luasnip.nodes.snippetProxy")
 	]])
 end
 

--- a/tests/unit/snippetProxy_spec.lua
+++ b/tests/unit/snippetProxy_spec.lua
@@ -1,0 +1,103 @@
+local helpers = require("test.functional.helpers")(after_each)
+local exec_lua, feed = helpers.exec_lua, helpers.feed
+local ls_helpers = require("helpers")
+local Screen = require("test.functional.ui.screen")
+
+describe("snippetProxy", function()
+	before_each(function()
+		helpers.clear()
+		ls_helpers.session_setup_luasnip()
+		exec_lua("noop = function() end")
+	end)
+
+	local no_inst_on_access_test = function(key)
+		it("does not instantiate on accessing " .. key, function()
+			assert.is_true(
+				exec_lua(
+					[[local snip = sp("asd", "$1 asdf $2") noop(snip]]
+						.. key
+						.. [[) return rawget(snip, "_snippet") == nil]]
+				)
+			)
+		end)
+	end
+
+	for _, v in
+		ipairs({
+			".trigger",
+			".hidden",
+			".docstring",
+			".wordTrig",
+			".regTrig",
+			".dscr",
+			".name",
+			".callbacks",
+			".condition",
+			".show_condition",
+			".stored",
+			':matches("asd")',
+			":get_docstring()",
+		})
+	do
+		no_inst_on_access_test(v)
+	end
+
+	it("matches correctly", function()
+		assert.is_true(
+			exec_lua([[return sp("asdf", "$1 asdf $2"):matches("asd") == nil]])
+		)
+		assert.is_true(
+			exec_lua([[return sp("asdf", "$1 asdf $2"):matches("asdf") ~= nil]])
+		)
+	end)
+
+	it("expands correctly", function()
+		local screen = Screen.new(50, 3)
+		screen:attach()
+		screen:set_default_attr_ids({
+			[0] = { bold = true, foreground = Screen.colors.Blue },
+			[1] = { bold = true, foreground = Screen.colors.Brown },
+			[2] = { bold = true },
+			[3] = { background = Screen.colors.LightGray },
+		})
+
+		exec_lua([[ls.snip_expand(sp("", "$1 asdf $2"))]])
+
+		screen:expect({
+			grid = [[
+			^ asdf                                             |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
+
+	-- one integration test.
+	it("works for triggered expansion", function()
+		local screen = Screen.new(50, 3)
+		screen:attach()
+		screen:set_default_attr_ids({
+			[0] = { bold = true, foreground = Screen.colors.Blue },
+			[1] = { bold = true, foreground = Screen.colors.Brown },
+			[2] = { bold = true },
+			[3] = { background = Screen.colors.LightGray },
+		})
+
+		exec_lua([[ls.snippets[""] = { sp("trig", "$1 triggered! $2")}]])
+
+		exec_lua("ls.expand()")
+		-- make sure the snippet wasn't instantiated.
+		assert.is_true(
+			exec_lua([[return rawget(ls.snippets[""][1], "_snippet") == nil]])
+		)
+
+		feed("itrig")
+		exec_lua("ls.expand()")
+		-- snippet should be expanded now.
+		screen:expect({
+			grid = [[
+			^ triggered!                                       |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
+end)


### PR DESCRIPTION
This allows parsing textmate-style snippets on expand (currently on `matches()` because it's not present in `snippetProxy`, but that can be improved), not on startup, therefore (once that part is implemented) lowering startuptime when loading snippets from some package/library significantly, to only the time required to extract the snippet-definitions and trig/name/description from the files.

This reduced cost of parsing snippet will be required because of the synchronous loading, but it is definitely a nice-to-have as most snippets from big libraries aren't used even once in a session, so there's no reason to parse them.

Some parts are missing as of now, but it won't hurt to have the concept out in the open.

It's conceivable to implement something similar for lua-native snippets, although the effect is probably negligible.