### PR TITLE
add in_snippet to docs

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1085,6 +1085,9 @@ the lazy_load.
 # API-REFERENCE
 
 `require("luasnip")`:
+
+- `in_snippet()`: returns true if the cursor is inside the current snippet.
+
 - `jumpable(direction)`: returns true if the current node has a
   next(`direction` = 1) or previous(`direction` = -1), eg. whether it's
   possible to jump forward or backward to another node.


### PR DESCRIPTION
`in_snippet` was exposed in https://github.com/L3MON4D3/LuaSnip/pull/292 however, it was not placed in the docs.

Also, im not quite too sure what the two different bullet notations mean ... so it probably needs changes