### PR TITLE
Improve ext_opts.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -963,55 +963,189 @@ sp("trig", "a snippet $1")
 
 # EXT\_OPTS
 
-`ext_opts` are probably best explained with a short example:
+`ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
+extmarks used for marking node-positions, either globally, per-snippet or
+per-node.
+This means that they allow highlighting the text inside of nodes, or adding
+virtual text to the line the node begins on.
+
+This is an example for the `node_ext_opts` used to set `ext_opts` of single nodes:
+```lua
+local ext_opts = {
+	-- these ext_opts are applied when the node is active (eg. it has been
+	-- jumped into, and not out yet).
+	active = 
+	-- this is the table actually passed to `nvim_buf_set_extmark`.
+	{
+		-- highlight the text inside the node red.
+		hl_group = "GruvboxRed"
+	},
+	-- these ext_opts are applied when the node is not active, but
+	-- the snippet still is.
+	passive = {
+		-- add virtual text on the line of the node, behind all text.
+		virt_text = {{"virtual text!!", "GruvboxBlue"}}
+	},
+	-- and these are applied when both the node and the snippet are inactive.
+	snippet_passive = {}
+}
+
+...
+
+s("trig", {
+	i(1, "text1", {
+		node_ext_opts = ext_opts
+	}),
+	i(2, "text2", {
+		node_ext_opts = ext_opts
+	})
+})
+```
+
+In the above example the text inside the insertNodes is higlighted in red while
+inside them, and the virtual text "virtual text!!" is visible as long as the
+snippet is active.
+
+It's important to note that `snippet_passive` applies to the states
+`snippet_passive`, `passive`, and `active`, `passive` to `passive` and `active`,
+and `active` only to `active`.
+
+To disable a key from a "lower" state, it has to be explicitly set to its
+default, eg. to disable highlighting inherited from `passive` when the node is
+`active`, `hl_group` could be set to `None` in `active`.
+
+---
+
+As stated earlier, these `ext_opts` can also be applied globally or for an
+entire snippet. For this it's necessary to specify which kind of node a given
+set of `ext_opts` should be applied to:
+
 ```lua
 local types = require("luasnip.util.types")
 
-vim.api.nvim_command("hi LuasnipChoiceNodePassive cterm=italic")
 ls.config.setup({
 	ext_opts = {
 		[types.insertNode] = {
+			active = {...},
+			passive = {...},
+			snippet_passive = {...}
+		},
+		[types.choiceNode] = {
+			active = {...}
+		},
+		[types.snippet] = {
+			passive = {...}
+		}
+	}
+})
+```
+
+The above applies the given `ext_opts` to all nodes of these types, in all
+snippets...
+
+```lua
+local types = require("luasnip.util.types")
+
+s("trig", { i(1, "text1"), i(2, "text2") }, {
+	child_ext_opts = {
+		[types.insertNode] = {
 			passive = {
-				hl_group = "GruvboxRed"
+				hl_group = "GruvboxAqua"
+			}
+		}
+	}
+})
+```
+... while the `ext_opts` here are only applied to the `insertNodes` inside this
+snippet.
+
+---
+
+By default, the `ext_opts` actually used for a node are created by extending the
+`node_ext_opts` with the `effective_child_ext_opts[node.type]` of the parent,
+which are in turn the `child_ext_opts` of the parent extended with the global
+`ext_opts` set in the config.
+
+It's possible to prevent both of these merges by passing
+`merge_node/child_ext_opts=false` to the snippet/node-opts:
+
+```lua
+ls.config.setup({
+	ext_opts = {
+		[types.insertNode] = {
+			active = {...}
+		}
+	}
+})
+
+...
+
+s("trig", {
+	i(1, "text1", {
+		node_ext_opts = {
+			active = {...}
+		},
+		merge_node_ext_opts = false
+	}), i(2, "text2") }, {
+	child_ext_opts = {
+		[types.insertNode] = {
+			passive = {...}
+		}
+	},
+	merge_child_ext_opts = false
+})
+```
+
+---
+
+The `hl_group` of the global `ext_opts` can also be set via standard
+highlight-groups:
+
+```lua
+vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
+vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
+
+-- needs to be called for resolving the actual ext_opts.
+ls.config.setup({})
+```
+The names for the used highlight groups are
+`"Luasnip<node>{Passive,Active,SnippetPassive}"`, where `<node>` can be any kind of
+node in PascalCase (or "Snippet").
+
+---
+
+One problem that might arise when nested nodes are highlighted, is that the
+highlight of inner nodes should be visible above that of nodes they are nested inside.
+
+This can be controlled using the `priority`-key in `ext_opts`. Normally, that
+value is an absolute value, but here it is relative to some base-priority, which
+is increased for each nesting level of snippets.
+
+Both the initial base-priority and its' increase and can be controlled using
+`ext_base_prio` and `ext_prio_increase`:
+```lua
+ls.config.setup({
+	ext_opts = {
+		[types.insertNode] = {
+			active = {
+				hl_group = "GruvboxBlue",
+				-- the priorities should be \in [0, ext_prio_increase).
+				priority = 1
 			}
 		},
 		[types.choiceNode] = {
 			active = {
-				virt_text = {{"choiceNode", "GruvboxOrange"}}
+				hl_group = "GruvboxRed"
+				-- priority defaults to 0
 			}
-		},
-		[types.textNode] = {
-			snippet_passive = {
-				hl_group = "GruvboxGreen"
-			}
-		},
-	},
+		}
+	}
 	ext_base_prio = 200,
-	ext_prio_increase = 3,
+	ext_prio_increase = 2
 })
 ```
-
-This highlights `insertNodes` red (both when active and passive) and adds
-virtualText and italics to `choiceNode` while it is active (both only if the
-snippet is active). `textNodes` are highlighted green, even if the snippet is
-no longer active. (unspecified values in `passive` are populated with values
-from `snippet_passive`, those in `active` with those from the new `passive`).
-
-The `active`/ `passive`-tables are passed to `nvim_buf_set_extmark` as `opts`
-which means only entries valid there can be used here. `priority`, while still
-affecting the priority of highlighting, is interpreted as a relative value here,
-not absolute (`0 <= priority < ext_prio_increase`).
-The absolute range of priorities can still be somewhat controlled using
-`ext_base_prio` and `ext_prio_increase` (all highlights start out with
-`ext_base_prio`+their own priority, for highlights belonging to a nested
-snippet(Node), `ext_base_prio` is increased by `ext_prio_increase`)).
-
-As a shortcut for setting `hl_group`, the highlight-groups
-`Luasnip*Node{Active,Passive,SnippetPassive}` may be defined (to be actually
-used by LuaSnip, `ls.config.setup` has to be called after defining). They are
-overridden by the values defined in `ext_opts` directly, but otherwise behave
-the same (active is extended by passive).
-
+Here the highlight of an insertNode nested directly inside a choiceNode is
+always visible on top of it.
 
 
 # DOCSTRING

--- a/Examples/snippets.lua
+++ b/Examples/snippets.lua
@@ -176,7 +176,7 @@ end
 
 -- Returns a snippet_node wrapped around an insert_node whose initial
 -- text value is set to the current date in the desired format.
-local date_input = function(args, state, fmt)
+local date_input = function(args, snip, old_state, fmt)
 	local fmt = fmt or "%Y-%m-%d"
 	return sn(nil, i(1, os.date(fmt)))
 end
@@ -297,7 +297,7 @@ ls.snippets = {
 		-- value of an insert_node.
 		s("novel", {
 			t("It was a dark and stormy night on "),
-			d(1, date_input, {}, "%A, %B %d of %Y"),
+			d(1, date_input, {}, { user_args = { "%A, %B %d of %Y" } }),
 			t(" and the clocks were striking thirteen."),
 		}),
 		-- Parsing snippets: First parameter: Snippet-Trigger, Second: Snippet body.
@@ -362,6 +362,7 @@ ls.snippets = {
 			-- This list will be applied in order to the first node given in the second argument.
 			l(l._1:match("[^i]*$"):gsub("i", "o"):gsub(" ", "_"):upper(), 1),
 		}),
+
 		s("transform2", {
 			i(1, "initial text"),
 			t("::"),

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -969,53 +969,177 @@ This will parse the snippet on startup...
 ================================================================================
 EXT_OPTS                                                        *luasnip-ext_opts*
 
-`ext_opts` are probably best explained with a short example:
+`ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
+extmarks used for marking node-positions, either globally, per-snippet or
+per-node.
+This means that they allow highlighting the text inside of nodes, or adding
+virtual text to the line the node begins on.
+
+This is an example for the `node_ext_opts` used to set `ext_opts` of single nodes:
+>
+    local ext_opts = {
+    	-- these ext_opts are applied when the node is active (eg. it has been
+    	-- jumped into, and not out yet).
+    	active = 
+    	-- this is the table actually passed to `nvim_buf_set_extmark`.
+    	{
+    		-- highlight the text inside the node red.
+    		hl_group = "GruvboxRed"
+    	},
+    	-- these ext_opts are applied when the node is not active, but
+    	-- the snippet still is.
+    	passive = {
+    		-- add virtual text on the line of the node, behind all text.
+    		virt_text = {{"virtual text!!", "GruvboxBlue"}}
+    	},
+    	-- and these are applied when both the node and the snippet are inactive.
+    	snippet_passive = {}
+    }
+    ...
+    s("trig", {
+    	i(1, "text1", {
+    		node_ext_opts = ext_opts
+    	}),
+    	i(2, "text2", {
+    		node_ext_opts = ext_opts
+    	})
+    })
+<
+
+In the above example the text inside the insertNodes is higlighted in red while
+inside them, and the virtual text "virtual text!!" is visible as long as the
+snippet is active.
+
+It's important to note that `snippet_passive` applies to the states
+`snippet_passive`, `passive`, and `active`, `passive` to `passive` and `active`,
+and `active` only to `active`.
+
+To disable a key from a "lower" state, it has to be explicitly set to its
+default, eg. to disable highlighting inherited from `passive` when the node is
+`active`, `hl_group` could be set to `None` in `active`.
+
+--------------------------------------------------------------------------------
+As stated earlier, these `ext_opts` can also be applied globally or for an
+entire snippet. For this it's necessary to specify which kind of node a given
+set of `ext_opts` should be applied to:
 >
     local types = require("luasnip.util.types")
-    vim.api.nvim_command("hi LuasnipChoiceNodePassive cterm=italic")
     ls.config.setup({
     	ext_opts = {
     		[types.insertNode] = {
+    			active = {...},
+    			passive = {...},
+    			snippet_passive = {...}
+    		},
+    		[types.choiceNode] = {
+    			active = {...}
+    		},
+    		[types.snippet] = {
+    			passive = {...}
+    		}
+    	}
+    })
+<
+
+The above applies the given `ext_opts` to all nodes of these types, in all
+snippets...
+>
+    local types = require("luasnip.util.types")
+    s("trig", { i(1, "text1"), i(2, "text2") }, {
+    	child_ext_opts = {
+    		[types.insertNode] = {
     			passive = {
-    				hl_group = "GruvboxRed"
+    				hl_group = "GruvboxAqua"
+    			}
+    		}
+    	}
+    })
+<
+
+... while the `ext_opts` here are only applied to the `insertNodes` inside this
+snippet.
+
+--------------------------------------------------------------------------------
+By default, the `ext_opts` actually used for a node are created by extending the
+`node_ext_opts` with the `effective_child_ext_opts[node.type]` of the parent,
+which are in turn the `child_ext_opts` of the parent extended with the global
+`ext_opts` set in the config.
+
+It's possible to prevent both of these merges by passing
+`merge_node/child_ext_opts=false` to the snippet/node-opts:
+>
+    ls.config.setup({
+    	ext_opts = {
+    		[types.insertNode] = {
+    			active = {...}
+    		}
+    	}
+    })
+    ...
+    s("trig", {
+    	i(1, "text1", {
+    		node_ext_opts = {
+    			active = {...}
+    		},
+    		merge_node_ext_opts = false
+    	}), i(2, "text2") }, {
+    	child_ext_opts = {
+    		[types.insertNode] = {
+    			passive = {...}
+    		}
+    	},
+    	merge_child_ext_opts = false
+    })
+<
+
+--------------------------------------------------------------------------------
+The `hl_group` of the global `ext_opts` can also be set via standard
+highlight-groups:
+>
+    vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
+    vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
+    -- needs to be called for resolving the actual ext_opts.
+    ls.config.setup({})
+<
+
+The names for the used highlight groups are
+`"Luasnip<node>{Passive,Active,SnippetPassive}"`, where `<node>` can be any kind of
+node in PascalCase (or "Snippet").
+
+--------------------------------------------------------------------------------
+One problem that might arise when nested nodes are highlighted, is that the
+highlight of inner nodes should be visible above that of nodes they are nested inside.
+
+This can be controlled using the `priority`-key in `ext_opts`. Normally, that
+value is an absolute value, but here it is relative to some base-priority, which
+is increased for each nesting level of snippets.
+
+Both the initial base-priority and its' increase and can be controlled using
+`ext_base_prio` and `ext_prio_increase`:
+>
+    ls.config.setup({
+    	ext_opts = {
+    		[types.insertNode] = {
+    			active = {
+    				hl_group = "GruvboxBlue",
+    				-- the priorities should be \in [0, ext_prio_increase).
+    				priority = 1
     			}
     		},
     		[types.choiceNode] = {
     			active = {
-    				virt_text = {{"choiceNode", "GruvboxOrange"}}
+    				hl_group = "GruvboxRed"
+    				-- priority defaults to 0
     			}
-    		},
-    		[types.textNode] = {
-    			snippet_passive = {
-    				hl_group = "GruvboxGreen"
-    			}
-    		},
-    	},
+    		}
+    	}
     	ext_base_prio = 200,
-    	ext_prio_increase = 3,
+    	ext_prio_increase = 2
     })
 <
 
-This highlights `insertNodes` red (both when active and passive) and adds
-virtualText and italics to `choiceNode` while it is active (both only if the
-snippet is active). `textNodes` are highlighted green, even if the snippet is
-no longer active. (unspecified values in `passive` are populated with values
-from `snippet_passive`, those in `active` with those from the new `passive`).
-
-The `active`/ `passive`-tables are passed to `nvim_buf_set_extmark` as `opts`
-which means only entries valid there can be used here. `priority`, while still
-affecting the priority of highlighting, is interpreted as a relative value here,
-not absolute (`0 <= priority < ext_prio_increase`).
-The absolute range of priorities can still be somewhat controlled using
-`ext_base_prio` and `ext_prio_increase` (all highlights start out with
-`ext_base_prio`+their own priority, for highlights belonging to a nested
-snippet(Node), `ext_base_prio` is increased by `ext_prio_increase`)).
-
-As a shortcut for setting `hl_group`, the highlight-groups
-`Luasnip*Node{Active,Passive,SnippetPassive}` may be defined (to be actually
-used by LuaSnip, `ls.config.setup` has to be called after defining). They are
-overridden by the values defined in `ext_opts` directly, but otherwise behave
-the same (active is extended by passive).
+Here the highlight of an insertNode nested directly inside a choiceNode is
+always visible on top of it.
 
 ================================================================================
 DOCSTRING                                                      *luasnip-docstring*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -5,30 +5,31 @@ luasnip.txt                                               Luasnip Snippet Engine
 CONTENTS                                                        *luasnip-contents*
 
 1. BASICS.........................................................|luasnip-basics|
-2. SNIPPETS.....................................................|luasnip-snippets|
-3. TEXTNODE.....................................................|luasnip-textnode|
-4. INSERTNODE.................................................|luasnip-insertnode|
-5. FUNCTIONNODE.............................................|luasnip-functionnode|
-6. CHOICENODE.................................................|luasnip-choicenode|
-7. SNIPPETNODE...............................................|luasnip-snippetnode|
-8. INDENTSNIPPETNODE...................................|luasnip-indentsnippetnode|
-9. DYNAMICNODE...............................................|luasnip-dynamicnode|
-10. RESTORENODE..............................................|luasnip-restorenode|
-11. ABSOLUTE_INDEXER....................................|luasnip-absolute_indexer|
-12. EXTRAS........................................................|luasnip-extras|
-    12.1. On The Fly snippets........................|luasnip-on_the_fly_snippets|
-    12.2. Select_choice....................................|luasnip-select_choice|
-13. LSP-SNIPPETS............................................|luasnip-lsp-snippets|
-14. VARIABLES..................................................|luasnip-variables|
-15. VSCODE SNIPPETS LOADER........................|luasnip-vscode_snippets_loader|
-16. SNIPMATE SNIPPETS LOADER....................|luasnip-snipmate_snippets_loader|
-17. SNIPPETPROXY............................................|luasnip-snippetproxy|
-18. EXT_OPTS....................................................|luasnip-ext_opts|
-19. DOCSTRING..................................................|luasnip-docstring|
-20. DOCSTRING-CACHE......................................|luasnip-docstring-cache|
-21. EVENTS........................................................|luasnip-events|
-22. CLEANUP......................................................|luasnip-cleanup|
-23. API-REFERENCE..........................................|luasnip-api-reference|
+2. NODE.............................................................|luasnip-node|
+3. SNIPPETS.....................................................|luasnip-snippets|
+4. TEXTNODE.....................................................|luasnip-textnode|
+5. INSERTNODE.................................................|luasnip-insertnode|
+6. FUNCTIONNODE.............................................|luasnip-functionnode|
+7. CHOICENODE.................................................|luasnip-choicenode|
+8. SNIPPETNODE...............................................|luasnip-snippetnode|
+9. INDENTSNIPPETNODE...................................|luasnip-indentsnippetnode|
+10. DYNAMICNODE..............................................|luasnip-dynamicnode|
+11. RESTORENODE..............................................|luasnip-restorenode|
+12. ABSOLUTE_INDEXER....................................|luasnip-absolute_indexer|
+13. EXTRAS........................................................|luasnip-extras|
+    13.1. On The Fly snippets........................|luasnip-on_the_fly_snippets|
+    13.2. Select_choice....................................|luasnip-select_choice|
+14. LSP-SNIPPETS............................................|luasnip-lsp-snippets|
+15. VARIABLES..................................................|luasnip-variables|
+16. VSCODE SNIPPETS LOADER........................|luasnip-vscode_snippets_loader|
+17. SNIPMATE SNIPPETS LOADER....................|luasnip-snipmate_snippets_loader|
+18. SNIPPETPROXY............................................|luasnip-snippetproxy|
+19. EXT_OPTS....................................................|luasnip-ext_opts|
+20. DOCSTRING..................................................|luasnip-docstring|
+21. DOCSTRING-CACHE......................................|luasnip-docstring-cache|
+22. EVENTS........................................................|luasnip-events|
+23. CLEANUP......................................................|luasnip-cleanup|
+24. API-REFERENCE..........................................|luasnip-api-reference|
 >
                 __                       ____
                /\ \                     /\  _`\           __
@@ -99,6 +100,15 @@ It is possible to make snippets from one filetype available to another using
 `ls.filetype_extend`, more info on that here (#api-reference).
 
 ================================================================================
+NODE                                                                *luasnip-node*
+
+Every node accepts, as its' last parameter, an optional table of arguments.
+There are some common ones (eg. `node_ext_opts` (#ext_opts)), and some that
+only apply to some nodes (`user_args` for both function and dynamicNode).
+These `opts` are only mentioned if they accept options that are not common to
+all nodes.
+
+================================================================================
 SNIPPETS                                                        *luasnip-snippets*
 
 The most direct way to define snippets is `s`:
@@ -137,7 +147,7 @@ The second argument to `s` is a table containing all nodes that belong to the
 snippet. If the table only has a single node, it can be passed directly
 without wrapping it in a table.
 
-The third argument is a table with the following valid keys:
+The third argument (`opts`) is a table with the following valid keys:
 - `condition`: the condition-function `fn(line_to_cursor, matched_trigger,
   captures) -> bool`.
   The snippet will be expanded only if it returns true (default is a function
@@ -145,7 +155,7 @@ The third argument is a table with the following valid keys:
   The function is called before the text is modified in any way.
   Some parameters are passed to the function: The line up to the cursor, the
   matched trigger and the captures (table).
-* `show_condition`: Function with signature `f(line_to_cursor) -> bool`.
+- `show_condition`: Function with signature `f(line_to_cursor) -> bool`.
   It is a hint for completion-engines, indicating when the snippet should be
   included in current completion candidates.
   Defaults to a function returning `true`.
@@ -168,8 +178,11 @@ The third argument is a table with the following valid keys:
 To register a callback for the snippets' own events, the key `[-1]` may
   be used.
   The callbacks are passed only one argument, the node that triggered it.
+- `child_ext_opts`, `merge_child_ext_opts`: `ext_opts` applied to the children
+  of this snippet. More info here (#ext_opts).
+
 This `opts`-table can also be passed to eg. `snippetNode` or `indentSnippetNode`,
-but only `callbacks` is used there.
+but only `callbacks` and the `ext_opts`-related options are used there.
 
 Snippets contain some interesting tables, eg. `snippet.env` contains variables
 used in the LSP-protocol like `TM_CURRENT_LINE` or `TM_FILENAME` or
@@ -241,7 +254,7 @@ The above snippet will behave as follows:
 - After jumping forward again, we will be at InsertNode 0.
 
 An important (because here luasnip differs from other snippet-engines) detail
-is that the jump-order restarts at 1 in nested snippets:
+is that the jump-positions restart at 1 in nested snippets:
 >
     s("trigger", {
     	i(1, "First jump"),
@@ -256,7 +269,7 @@ is that the jump-order restarts at 1 in nested snippets:
 
 as opposed to eg. the textmate-syntax, where tabstops are snippet-global:
 >
-    ${1:First jump} :: ${2: ${3:Second jump} : ${4:Third jump}}
+    ${1:First jump} :: ${2: ${3:Third jump} : ${4:Fourth jump}}
 <
 
 (this is not exactly the same snippet of course, but as close as possible)
@@ -285,7 +298,7 @@ user-defined function:
      	i(1),
      	f(function(args, snip, user_arg_1) return args[1][1] .. user_arg_1 end,
      		{1},
-     		"Will be appended to text from i(0)"),
+     		{ user_args = {"Will be appended to text from i(0)"}}),
      	i(0)
      })
 <
@@ -302,8 +315,12 @@ The first parameter of `f` is the function. Its parameters are:
       but if a `functionNode` is nested within a `snippetNode`, the immediate
       parent (a `snippetNode`) will contain neither `captures` nor `env`. Those
       are only stored in the `snippet`, which can be accessed as `parent.snippet`.
-3.  Any parameters passed to `f` behind the second (included to more easily
-      reuse functions, ie. ternary if based on text in an insertNode).
+
+3-n. The `user_args` passed in `opts`.
+
+The function shall return a string, which will be inserted as-is, or a table
+of strings for multiline-string, here all lines following the first will be
+prefixed with the snippets' indentation.
 
 The second parameter is a table of indices of jumpable nodes whose text is
 passed to the function.
@@ -314,9 +331,23 @@ it in a table.
 The indices can be specified either as relative to the functionNodes' parent
 using numbers or as absolute, using the `absolute_indexer` (#absolute_indexer).
 
-The function shall return a string, which will be inserted as-is, or a table
-of strings for multiline-string, here all lines following the first will be
-prefixed with the snippets' indentation.
+The last parameter is, as with any node, `opts`.
+`functionNode` accepts one additional option: `user_args`, a table of values
+passed to the function.
+These exist to more easily reuse functionNode-functions, when applicable:
+>
+    local function reused_func(_,_, user_arg1)
+    	return user_arg1
+    end
+    s("trig", {
+    	f(reused_func, {}, {
+    		user_args = {"text"}
+    	}),
+    	f(reused_func, {}, {
+    		user_args = {"different text"}
+    	}),
+    })
+<
 
 Examples:
 Use captures from the regex-trigger using a functionNode:
@@ -474,7 +505,7 @@ which makes them very powerful as parts of the snippet can be changed based on
 user-input.
 
 The prototype for the dynamicNodes' constructor is
-`d(position:int, function, argnodes:table of nodes, user_args1, ..., user_argsn)`:
+`d(position:int, function, argnodes:table of nodes, opts: table)`:
 
 1.  `position`: just like all jumpable nodes, when this node will be jumped into.
 2.  `function`: `fn(args, parent, old_state, user_args1, ..., user_argsn) -> snippetNode`
@@ -494,14 +525,13 @@ The prototype for the dynamicNodes' constructor is
         The `old_state` table must be stored in `snippetNode` returned by
         the function (`snippetNode.old_state`).
         The second example below illustrates the usage of `old_state`.
-    *   `user_args1, ..., user_argsn`: passed through from `dynamicNode`-constructor.
+    *   `user_args1, ..., user_argsn`: passed through from `dynamicNode`-opts.
 3.  `argnodes`: Indices of nodes the dynamicNode depends on: if any of these trigger an
     update, the `dynamicNode`s' function will be executed and the result inserted at
     the `dynamicNodes` place.
     Can be a single index or a table of indices.
-4.  `user_args1, ..., user_argsn`: Anything passed here will also be passed to
-    the function (easy to reuse similar functions with small changes) (This may
-    be removed, alternatively use partial functions to reuse functions).
+4.  `opts`: Just like `functionNode`, `dynamicNode` also accepts `user_args` in
+    addition to options common to all nodes.
 
 Examples:
 >
@@ -558,8 +588,8 @@ first `insertNode`.
     ...
     s("trig", {
     	i(1, "1"),
-    	-- pos, function, argnodes, user_arg1
-    	d(2, lines, {1}, "Sample Text")
+    	-- pos, function, argnodes, opts (containing the user_arg).
+    	d(2, lines, {1}, {user_args = {"Sample Text"}})
     })
 <
 

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -71,7 +71,7 @@ local defaults = {
 		},
 	},
 	ext_base_prio = 200,
-	ext_prio_increase = 7,
+	ext_prio_increase = 9,
 	enable_autosnippets = false,
 	-- default applied in util.parser, requires iNode, cNode
 	-- (Dependency cycle if here).
@@ -90,10 +90,11 @@ c = {
 
 		-- remove unused highlights from default-ext_opts.
 		ext_util.clear_invalid(conf.ext_opts)
-		ext_util.complete(conf.ext_opts)
-		user_config.ext_opts = user_config.ext_opts or {}
-		ext_util.complete(user_config.ext_opts)
-		ext_util.extend(user_config.ext_opts, conf.ext_opts)
+		conf.ext_opts = ext_util.child_complete(conf.ext_opts)
+		user_config.ext_opts = ext_util.child_complete(
+			user_config.ext_opts or {}
+		)
+		ext_util.child_extend(user_config.ext_opts, conf.ext_opts)
 
 		for k, v in pairs(user_config) do
 			conf[k] = v

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -1,5 +1,6 @@
 local types = require("luasnip.util.types")
 local util = require("luasnip.util.util")
+local ext_util = require("luasnip.util.ext_opts")
 local ft_functions = require("luasnip.extras.filetype_functions")
 
 local defaults = {
@@ -87,13 +88,14 @@ c = {
 	set_config = function(user_config)
 		local conf = vim.deepcopy(defaults)
 
-		util.clear_invalid(conf.ext_opts)
+		-- remove unused highlights from default-ext_opts.
+		ext_util.clear_invalid(conf.ext_opts)
+		ext_util.complete(conf.ext_opts)
+		user_config.ext_opts = user_config.ext_opts or {}
+		ext_util.complete(user_config.ext_opts)
+		ext_util.extend(user_config.ext_opts, conf.ext_opts)
 
-		user_config.ext_opts = util.make_opts_valid(
-			user_config.ext_opts or {},
-			conf.ext_opts
-		)
-		util.increase_ext_prio(
+		ext_util.increase_prio(
 			user_config.ext_opts,
 			user_config.ext_base_prio or conf.ext_base_prio
 		)
@@ -101,6 +103,7 @@ c = {
 		for k, v in pairs(user_config) do
 			conf[k] = v
 		end
+
 		c.config = conf
 		c._setup()
 	end,

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -95,11 +95,6 @@ c = {
 		ext_util.complete(user_config.ext_opts)
 		ext_util.extend(user_config.ext_opts, conf.ext_opts)
 
-		ext_util.increase_prio(
-			user_config.ext_opts,
-			user_config.ext_base_prio or conf.ext_base_prio
-		)
-
 		for k, v in pairs(user_config) do
 			conf[k] = v
 		end

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -124,9 +124,9 @@ return {
 	end,
 	-- Insert the output of a function.
 	partial = function(func, ...)
-		return F(function(_, _, fn, ...)
-			return fn(...)
-		end, {}, func, ...)
+		return F(function(_, _, ...)
+			return func(...)
+		end, {}, { user_args = { ... } })
 	end,
 	nonempty = function(indx, text_if, text_if_not)
 		assert(

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -69,7 +69,7 @@ local function C(pos, choices, opts)
 		dependents = {},
 		-- default to true.
 		restore_cursor = opts.restore_cursor,
-	})
+	}, opts)
 	c:init_nodes()
 	return c
 end
@@ -112,7 +112,7 @@ function ChoiceNode:put_initial(pos)
 	local mark_opts = vim.tbl_extend("keep", {
 		right_gravity = false,
 		end_right_gravity = false,
-	}, self.parent.ext_opts[self.active_choice.type].passive)
+	}, self.active_choice.ext_opts.passive)
 
 	self.active_choice.mark = mark(old_pos, pos, mark_opts)
 	self.visible = true
@@ -131,7 +131,7 @@ function ChoiceNode:expand_tabs(tabwidth)
 end
 
 function ChoiceNode:input_enter()
-	self.mark:update_opts(self.parent.ext_opts[self.type].active)
+	self.mark:update_opts(self.ext_opts.active)
 	self.parent:enter_node(self.indx)
 
 	self.prev_choice_node = session.active_choice_node
@@ -144,7 +144,7 @@ end
 function ChoiceNode:input_leave()
 	self:event(events.leave)
 
-	self.mark:update_opts(self.parent.ext_opts[self.type].passive)
+	self.mark:update_opts(self.ext_opts.passive)
 	self:update_dependents()
 	session.active_choice_node = self.prev_choice_node
 	self.active = false
@@ -240,7 +240,7 @@ function ChoiceNode:set_choice(choice, current_node)
 	self.active_choice = choice
 
 	self.active_choice.mark = self.mark:copy_pos_gravs(
-		vim.deepcopy(self.parent.ext_opts[self.active_choice.type].passive)
+		vim.deepcopy(self.active_choice.ext_opts.passive)
 	)
 	self.active_choice:put_initial(self.mark:pos_begin_raw())
 
@@ -322,7 +322,7 @@ function ChoiceNode:set_mark_rgrav(rgrav_beg, rgrav_end)
 end
 
 function ChoiceNode:set_ext_opts(name)
-	self.mark:update_opts(self.parent.ext_opts[self.type][name])
+	self.mark:update_opts(self.ext_opts[name])
 	self.active_choice:set_ext_opts(name)
 end
 

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -9,22 +9,24 @@ local conf = require("luasnip.config")
 local FunctionNode = require("luasnip.nodes.functionNode").FunctionNode
 local SnippetNode = require("luasnip.nodes.snippet").SN
 
-local function D(pos, fn, args, ...)
+local function D(pos, fn, args, opts)
+	opts = opts or {}
+
 	return DynamicNode:new({
 		pos = pos,
 		fn = fn,
 		args = node_util.wrap_args(args),
 		type = types.dynamicNode,
 		mark = nil,
-		user_args = { ... },
+		user_args = opts.user_args or {},
 		dependents = {},
 		active = false,
-	})
+	}, opts)
 end
 
 function DynamicNode:input_enter()
 	self.active = true
-	self.mark:update_opts(self.parent.ext_opts[self.type].active)
+	self.mark:update_opts(self.ext_opts.active)
 
 	self:event(events.enter)
 end
@@ -34,7 +36,7 @@ function DynamicNode:input_leave()
 
 	self:update_dependents()
 	self.active = false
-	self.mark:update_opts(self.parent.ext_opts[self.type].passive)
+	self.mark:update_opts(self.ext_opts.passive)
 end
 
 local function snip_init(self, snip)
@@ -159,22 +161,18 @@ function DynamicNode:update()
 	tmp.next = self
 	tmp.prev = self
 
-	tmp.ext_opts = tmp.ext_opts
-		or ext_util.set_abs_prio(
-			vim.deepcopy(self.parent.ext_opts),
-			conf.config.ext_prio_increase
-		)
 	tmp.snippet = self.parent.snippet
-	tmp.mark = self.mark:copy_pos_gravs(
-		vim.deepcopy(self.parent.ext_opts[types.snippetNode].passive)
-	)
+
+	tmp:resolve_child_ext_opts()
+	tmp:resolve_node_ext_opts()
+	tmp:subsnip_init()
+
+	tmp.mark = self.mark:copy_pos_gravs(vim.deepcopy(tmp.ext_opts.passive))
 	tmp.dynamicNode = self
 	tmp.update_dependents = function(node)
 		node:_update_dependents()
 		node.dynamicNode:update_dependents()
 	end
-
-	tmp:subsnip_init()
 
 	tmp:init_positions(self.snip_absolute_position)
 	tmp:init_insert_positions(self.snip_absolute_insert_position)
@@ -275,6 +273,8 @@ function DynamicNode:update_static()
 		node.dynamicNode:update_dependents_static()
 	end
 
+	tmp:resolve_child_ext_opts()
+	tmp:resolve_node_ext_opts()
 	tmp:subsnip_init()
 
 	tmp:init_positions(self.snip_absolute_position)
@@ -317,7 +317,7 @@ function DynamicNode:exit()
 end
 
 function DynamicNode:set_ext_opts(name)
-	self.mark:update_opts(self.parent.ext_opts[self.type][name])
+	self.mark:update_opts(self.ext_opts[name])
 	-- might not have been generated (missing nodes).
 	if self.snip then
 		self.snip:set_ext_opts(name)
@@ -336,9 +336,7 @@ function DynamicNode:update_restore()
 		-- prevent entering the uninitialized snip in enter_node in a few lines.
 		local tmp = self.stored_snip
 
-		tmp.mark = self.mark:copy_pos_gravs(
-			vim.deepcopy(self.parent.ext_opts[types.snippetNode].passive)
-		)
+		tmp.mark = self.mark:copy_pos_gravs(vim.deepcopy(tmp.ext_opts.passive))
 		self.parent:enter_node(self.indx)
 		tmp:put_initial(self.mark:pos_begin_raw())
 		tmp:update_restore()

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -41,7 +41,7 @@ local function snip_init(self, snip)
 	snip.parent = self.parent
 	snip.pos = self.pos
 
-	snip.ext_opts = ext_util.increase_prio(
+	snip.ext_opts = ext_util.set_abs_prio(
 		vim.deepcopy(self.parent.ext_opts),
 		conf.config.ext_prio_increase
 	)
@@ -160,7 +160,7 @@ function DynamicNode:update()
 	tmp.prev = self
 
 	tmp.ext_opts = tmp.ext_opts
-		or ext_util.increase_prio(
+		or ext_util.set_abs_prio(
 			vim.deepcopy(self.parent.ext_opts),
 			conf.config.ext_prio_increase
 		)
@@ -263,7 +263,7 @@ function DynamicNode:update_static()
 	tmp.prev = self
 
 	tmp.ext_opts = tmp.ext_opts
-		or ext_util.increase_prio(
+		or ext_util.set_abs_prio(
 			vim.deepcopy(self.parent.ext_opts),
 			conf.config.ext_prio_increase
 		)

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -39,27 +39,6 @@ function DynamicNode:input_leave()
 	self.mark:update_opts(self.ext_opts.passive)
 end
 
-local function snip_init(self, snip)
-	snip.parent = self.parent
-	snip.pos = self.pos
-
-	snip.ext_opts = ext_util.set_abs_prio(
-		vim.deepcopy(self.parent.ext_opts),
-		conf.config.ext_prio_increase
-	)
-	snip.snippet = self.parent.snippet
-	snip:static_init()
-
-	snip:subsnip_init()
-	snip:init_positions(self.snip_absolute_position)
-	snip:init_insert_positions(self.snip_absolute_insert_position)
-
-	snip:make_args_absolute()
-
-	snip:set_dependents()
-	snip:set_argnodes(self.parent.snippet.dependents_dict)
-end
-
 function DynamicNode:get_static_text()
 	if not self.static_text then
 		if self.snip then
@@ -260,11 +239,8 @@ function DynamicNode:update_static()
 	tmp.next = self
 	tmp.prev = self
 
-	tmp.ext_opts = tmp.ext_opts
-		or ext_util.set_abs_prio(
-			vim.deepcopy(self.parent.ext_opts),
-			conf.config.ext_prio_increase
-		)
+	-- doesn't matter here, but they'll have to be set.
+	tmp.ext_opts = self.parent.ext_opts
 	tmp.snippet = self.parent.snippet
 
 	tmp.dynamicNode = self

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -1,5 +1,6 @@
 local DynamicNode = require("luasnip.nodes.node").Node:new()
 local util = require("luasnip.util.util")
+local ext_util = require("luasnip.util.ext_opts")
 local node_util = require("luasnip.nodes.util")
 local Node = require("luasnip.nodes.node").Node
 local types = require("luasnip.util.types")
@@ -40,7 +41,7 @@ local function snip_init(self, snip)
 	snip.parent = self.parent
 	snip.pos = self.pos
 
-	snip.ext_opts = util.increase_ext_prio(
+	snip.ext_opts = ext_util.increase_prio(
 		vim.deepcopy(self.parent.ext_opts),
 		conf.config.ext_prio_increase
 	)
@@ -159,7 +160,7 @@ function DynamicNode:update()
 	tmp.prev = self
 
 	tmp.ext_opts = tmp.ext_opts
-		or util.increase_ext_prio(
+		or ext_util.increase_prio(
 			vim.deepcopy(self.parent.ext_opts),
 			conf.config.ext_prio_increase
 		)
@@ -262,7 +263,7 @@ function DynamicNode:update_static()
 	tmp.prev = self
 
 	tmp.ext_opts = tmp.ext_opts
-		or util.increase_ext_prio(
+		or ext_util.increase_prio(
 			vim.deepcopy(self.parent.ext_opts),
 			conf.config.ext_prio_increase
 		)

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -6,14 +6,16 @@ local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local tNode = require("luasnip.nodes.textNode").textNode
 
-local function F(fn, args, ...)
+local function F(fn, args, opts)
+	opts = opts or {}
+
 	return FunctionNode:new({
 		fn = fn,
 		args = node_util.wrap_args(args),
 		type = types.functionNode,
 		mark = nil,
-		user_args = { ... },
-	})
+		user_args = opts.user_args or {},
+	}, opts)
 end
 
 FunctionNode.input_enter = tNode.input_enter

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -5,7 +5,7 @@ local config = require("luasnip.config")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 
-local function I(pos, static_text)
+local function I(pos, static_text, opts)
 	static_text = util.wrap_value(static_text)
 	if pos == 0 then
 		return ExitNode:new({
@@ -16,7 +16,7 @@ local function I(pos, static_text)
 			type = types.exitNode,
 			-- will only be needed for 0-node, -1-node isn't set with this.
 			ext_gravities_active = { false, false },
-		})
+		}, opts)
 	else
 		return InsertNode:new({
 			pos = pos,
@@ -25,7 +25,7 @@ local function I(pos, static_text)
 			dependents = {},
 			type = types.insertNode,
 			inner_active = false,
-		})
+		}, opts)
 	end
 end
 
@@ -90,7 +90,7 @@ function ExitNode:update_dependents_static() end
 function ExitNode:update_all_dependents_static() end
 
 function InsertNode:input_enter(no_move)
-	self.mark:update_opts(self.parent.ext_opts[self.type].active)
+	self.mark:update_opts(self.ext_opts.active)
 	if not no_move then
 		self.parent:enter_node(self.indx)
 
@@ -186,7 +186,7 @@ function InsertNode:input_leave()
 	self:event(events.leave)
 
 	self:update_dependents()
-	self.mark:update_opts(self.parent.ext_opts[self.type].passive)
+	self.mark:update_opts(self.ext_opts.passive)
 end
 
 function InsertNode:exit()

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -190,6 +190,9 @@ function InsertNode:input_leave()
 end
 
 function InsertNode:exit()
+	if self.inner_first then
+		self.inner_first:exit()
+	end
 	self.visible = false
 	self.inner_first = nil
 	self.inner_last = nil

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -320,18 +320,6 @@ end
 -- also have to be resolved.
 -- This function generates a nodes ext_opts (those actually used in highlighting).
 function Node:resolve_node_ext_opts(base_prio, parent_ext_opts)
-	-- if self.parent then
-	-- 	local ok, res = pcall(function()
-	-- 		local e = self.parent.effective_child_ext_opts[self.type]
-	-- 	end)
-	-- 	if not ok then
-	-- 		print(self.parent.type == types.snippetNode)
-	-- 		Insp(self.parent.child_ext_opts)
-	-- 		print(self.parent.snippet)
-	-- 		print(self.parent.absolute_position)
-	-- 	end
-	-- end
-
 	if self.merge_node_ext_opts then
 		self.ext_opts = ext_util.extend(
 			vim.deepcopy(self.node_ext_opts),

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -154,10 +154,6 @@ end
 local function snip_init(self, snip)
 	snip.parent = self.parent
 
-	snip.ext_opts = ext_util.set_abs_prio(
-		vim.deepcopy(self.parent.ext_opts),
-		conf.config.ext_prio_increase
-	)
 	snip.snippet = self.parent.snippet
 	snip.pos = self.pos
 

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -11,7 +11,7 @@ local ext_util = require("luasnip.util.ext_opts")
 local conf = require("luasnip.config")
 local mark = require("luasnip.util.mark").mark
 
-local function R(pos, key, nodes)
+local function R(pos, key, nodes, opts)
 	-- don't create nested snippetNodes, unnecessary.
 	nodes = nodes and wrap_nodes_in_snippetNode(nodes)
 
@@ -24,7 +24,7 @@ local function R(pos, key, nodes)
 		dependents = {},
 		-- TODO: find out why it's necessary only for this node.
 		active = false,
-	})
+	}, opts)
 end
 
 function RestoreNode:exit()
@@ -41,7 +41,7 @@ end
 
 function RestoreNode:input_enter()
 	self.active = true
-	self.mark:update_opts(self.parent.ext_opts[self.type].active)
+	self.mark:update_opts(self.ext_opts.active)
 
 	self:event(events.enter)
 end
@@ -51,7 +51,7 @@ function RestoreNode:input_leave()
 
 	self:update_dependents()
 	self.active = false
-	self.mark:update_opts(self.parent.ext_opts[self.type].passive)
+	self.mark:update_opts(self.ext_opts.passive)
 end
 
 -- set snippetNode for this key here.
@@ -81,11 +81,6 @@ function RestoreNode:put_initial(pos)
 	tmp.next = self
 	tmp.prev = self
 
-	tmp.ext_opts = tmp.ext_opts
-		or ext_util.set_abs_prio(
-			vim.deepcopy(self.parent.ext_opts),
-			conf.config.ext_prio_increase
-		)
 	tmp.snippet = self.parent.snippet
 
 	tmp.restore_node = self
@@ -95,6 +90,8 @@ function RestoreNode:put_initial(pos)
 		node.restore_node:update_dependents()
 	end
 
+	tmp:resolve_child_ext_opts()
+	tmp:resolve_node_ext_opts()
 	tmp:subsnip_init()
 
 	tmp:init_positions(self.snip_absolute_position)
@@ -114,7 +111,7 @@ function RestoreNode:put_initial(pos)
 	local mark_opts = vim.tbl_extend("keep", {
 		right_gravity = false,
 		end_right_gravity = false,
-	}, self.parent.ext_opts[types.snippetNode].passive)
+	}, tmp.ext_opts.passive)
 
 	local old_pos = vim.deepcopy(pos)
 	tmp:put_initial(pos)
@@ -142,7 +139,7 @@ function RestoreNode:jump_into(dir, no_move)
 end
 
 function RestoreNode:set_ext_opts(name)
-	self.mark:update_opts(self.parent.ext_opts[self.type][name])
+	self.mark:update_opts(self.ext_opts[name])
 	self.snip:set_ext_opts(name)
 end
 
@@ -164,6 +161,8 @@ local function snip_init(self, snip)
 	snip.snippet = self.parent.snippet
 	snip.pos = self.pos
 
+	snip:resolve_child_ext_opts()
+	snip:resolve_node_ext_opts()
 	snip:subsnip_init()
 
 	snip:init_positions(self.snip_absolute_position)

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -82,7 +82,7 @@ function RestoreNode:put_initial(pos)
 	tmp.prev = self
 
 	tmp.ext_opts = tmp.ext_opts
-		or ext_util.increase_prio(
+		or ext_util.set_abs_prio(
 			vim.deepcopy(self.parent.ext_opts),
 			conf.config.ext_prio_increase
 		)
@@ -157,7 +157,7 @@ end
 local function snip_init(self, snip)
 	snip.parent = self.parent
 
-	snip.ext_opts = ext_util.increase_prio(
+	snip.ext_opts = ext_util.set_abs_prio(
 		vim.deepcopy(self.parent.ext_opts),
 		conf.config.ext_prio_increase
 	)

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -7,6 +7,7 @@ local RestoreNode = Node:new()
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local util = require("luasnip.util.util")
+local ext_util = require("luasnip.util.ext_opts")
 local conf = require("luasnip.config")
 local mark = require("luasnip.util.mark").mark
 
@@ -81,7 +82,7 @@ function RestoreNode:put_initial(pos)
 	tmp.prev = self
 
 	tmp.ext_opts = tmp.ext_opts
-		or util.increase_ext_prio(
+		or ext_util.increase_prio(
 			vim.deepcopy(self.parent.ext_opts),
 			conf.config.ext_prio_increase
 		)
@@ -156,7 +157,7 @@ end
 local function snip_init(self, snip)
 	snip.parent = self.parent
 
-	snip.ext_opts = util.increase_ext_prio(
+	snip.ext_opts = ext_util.increase_prio(
 		vim.deepcopy(self.parent.ext_opts),
 		conf.config.ext_prio_increase
 	)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -2,6 +2,7 @@ local node_mod = require("luasnip.nodes.node")
 local iNode = require("luasnip.nodes.insertNode")
 local tNode = require("luasnip.nodes.textNode")
 local util = require("luasnip.util.util")
+local ext_util = require("luasnip.util.ext_opts")
 local node_util = require("luasnip.nodes.util")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
@@ -360,7 +361,7 @@ function Snippet:trigger_expand(current_node, pos)
 		-- use those of that snippet and increase priority.
 		-- for now do a check for .indx, TODO: maybe only expand in insertNodes.
 		if current_node and (current_node.indx and current_node.indx > 1) then
-			self.ext_opts = util.increase_ext_prio(
+			self.ext_opts = ext_util.increase_prio(
 				vim.deepcopy(current_node.parent.ext_opts),
 				conf.config.ext_prio_increase
 			)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -126,7 +126,9 @@ local function init_snippetNode_opts(opts)
 
 	opts = opts or {}
 
-	in_node.child_ext_opts = ext_util.child_complete(opts.child_ext_opts or {})
+	in_node.child_ext_opts = ext_util.child_complete(
+		vim.deepcopy(opts.child_ext_opts or {})
+	)
 
 	if opts.merge_child_ext_opts == nil then
 		in_node.merge_child_ext_opts = true

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -130,6 +130,8 @@ local function init_snippetNode_opts(opts)
 
 	if opts.merge_child_ext_opts == nil then
 		in_node.merge_child_ext_opts = true
+	else
+		in_node.merge_child_ext_opts = opts.merge_child_ext_opts
 	end
 
 	in_node.callbacks = opts.callbacks or {}
@@ -374,29 +376,26 @@ function Snippet:trigger_expand(current_node, pos)
 	end
 	self:indent(util.line_chars_before(pos):match("^%s*"))
 
-	local parent_ext_opts
-	local parent_ext_base_prio
-	-- if inside another snippet, increase priority accordingly.
-	-- for now do a check for .indx.
-	if current_node and (current_node.indx and current_node.indx > 1) then
-		parent_ext_base_prio = current_node.parent.ext_opts.base_prio
-		parent_ext_opts = current_node.parent.effective_child_ext_opts
-	else
-		parent_ext_base_prio = conf.config.ext_base_prio
-		parent_ext_opts = conf.config.ext_opts
-	end
-
 	-- (possibly) keep user-set opts.
 	if self.merge_child_ext_opts then
 		self.effective_child_ext_opts = ext_util.child_extend(
 			vim.deepcopy(self.child_ext_opts),
-			parent_ext_opts
+			conf.config.ext_opts
 		)
 	else
 		self.effective_child_ext_opts = vim.deepcopy(self.child_ext_opts)
 	end
 
-	-- own highlight can come from self.child_ext_opts.snippet.
+	local parent_ext_base_prio
+	-- if inside another snippet, increase priority accordingly.
+	-- for now do a check for .indx.
+	if current_node and (current_node.indx and current_node.indx > 1) then
+		parent_ext_base_prio = current_node.parent.ext_opts.base_prio
+	else
+		parent_ext_base_prio = conf.config.ext_base_prio
+	end
+
+	-- own highlight comes from self.child_ext_opts.snippet.
 	self:resolve_node_ext_opts(
 		parent_ext_base_prio,
 		self.effective_child_ext_opts[self.type]

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -369,13 +369,13 @@ function Snippet:trigger_expand(current_node, pos)
 	-- for now do a check for .indx.
 	-- TODO: maybe allow expand only inside insertNodes.
 	if current_node and (current_node.indx and current_node.indx > 1) then
-		ext_util.increase_prio(
+		ext_util.set_abs_prio(
 			self.ext_opts,
 			current_node.parent.ext_opts.increased_by
 				+ conf.config.ext_prio_increase
 		)
 	else
-		ext_util.increase_prio(self.ext_opts, conf.config.ext_base_prio)
+		ext_util.set_abs_prio(self.ext_opts, conf.config.ext_base_prio)
 	end
 
 	self.env = Environ:new(pos)

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -8,6 +8,7 @@
 
 local parse = require("luasnip.util.parser").parse_snippet
 local snip_mod = require("luasnip.nodes.snippet")
+local node_util = require("luasnip.nodes.util")
 
 local SnippetProxy = {}
 
@@ -43,10 +44,15 @@ end
 
 -- context and opts are the same objects as in s(contex, nodes, opts), snippet is a string representing the snippet.
 local function new(context, snippet, opts)
-	local sp = {}
 	-- "error": there should not be duplicate keys, don't silently overwrite/keep.
-	sp = vim.tbl_extend("error", sp, snip_mod.init_snippet_context(context))
-	sp = vim.tbl_extend("error", sp, snip_mod.init_snippet_opts(opts))
+	local sp = vim.tbl_extend(
+		"error",
+		{},
+		snip_mod.init_snippet_context(context),
+		snip_mod.init_snippet_opts(opts),
+		node_util.init_node_opts(opts)
+	)
+
 	sp._snippet_string = snippet
 	-- override docstring
 	sp.docstring = snippet

--- a/lua/luasnip/nodes/textNode.lua
+++ b/lua/luasnip/nodes/textNode.lua
@@ -14,6 +14,7 @@ local function T(static_text, opts)
 end
 
 function TextNode:input_enter(no_move)
+	self.mark:update_opts(self.ext_opts.active)
 	if not no_move then
 		local mark_begin_pos = self.mark:pos_begin_raw()
 		if vim.fn.mode() == "i" then

--- a/lua/luasnip/nodes/textNode.lua
+++ b/lua/luasnip/nodes/textNode.lua
@@ -5,12 +5,12 @@ local events = require("luasnip.util.events")
 
 local TextNode = node_mod.Node:new()
 
-local function T(static_text)
+local function T(static_text, opts)
 	return TextNode:new({
 		static_text = util.wrap_value(static_text) or { "" },
 		mark = nil,
 		type = types.textNode,
-	})
+	}, opts)
 end
 
 function TextNode:input_enter(no_move)

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -1,11 +1,12 @@
 local util = require("luasnip.util.util")
+local ext_util = require("luasnip.util.ext_opts")
 local types = require("luasnip.util.types")
 local conf = require("luasnip.config")
 
 local function subsnip_init_children(parent, children)
 	for _, child in ipairs(children) do
 		if child.type == types.snippetNode then
-			child.ext_opts = util.increase_ext_prio(
+			child.ext_opts = ext_util.increase_prio(
 				vim.deepcopy(parent.ext_opts),
 				conf.config.ext_prio_increase
 			)

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -6,13 +6,10 @@ local conf = require("luasnip.config")
 local function subsnip_init_children(parent, children)
 	for _, child in ipairs(children) do
 		if child.type == types.snippetNode then
-			child.ext_opts = ext_util.set_abs_prio(
-				vim.deepcopy(parent.ext_opts),
-				conf.config.ext_prio_increase
-			)
 			child.snippet = parent.snippet
+			child:resolve_child_ext_opts()
 		end
-
+		child:resolve_node_ext_opts()
 		child:subsnip_init()
 	end
 end
@@ -109,6 +106,23 @@ local function print_dict(dict)
 	}))
 end
 
+local function init_node_opts(opts)
+	local in_node = {}
+	if not opts then
+		opts = {}
+	end
+
+	in_node.node_ext_opts = ext_util.complete(opts.node_ext_opts or {})
+
+	if opts.merge_node_ext_opts == nil then
+		in_node.merge_node_ext_opts = true
+	else
+		in_node.merge_node_ext_opts = opts.merge_node_ext_opts
+	end
+
+	return in_node
+end
+
 return {
 	subsnip_init_children = subsnip_init_children,
 	init_child_positions_func = init_child_positions_func,
@@ -119,4 +133,5 @@ return {
 	enter_nodes_between = enter_nodes_between,
 	select_node = select_node,
 	print_dict = print_dict,
+	init_node_opts = init_node_opts,
 }

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -112,7 +112,10 @@ local function init_node_opts(opts)
 		opts = {}
 	end
 
-	in_node.node_ext_opts = ext_util.complete(opts.node_ext_opts or {})
+	-- copy once here, the opts might be reused.
+	in_node.node_ext_opts = ext_util.complete(
+		vim.deepcopy(opts.node_ext_opts or {})
+	)
 
 	if opts.merge_node_ext_opts == nil then
 		in_node.merge_node_ext_opts = true

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -6,7 +6,7 @@ local conf = require("luasnip.config")
 local function subsnip_init_children(parent, children)
 	for _, child in ipairs(children) do
 		if child.type == types.snippetNode then
-			child.ext_opts = ext_util.increase_prio(
+			child.ext_opts = ext_util.set_abs_prio(
 				vim.deepcopy(parent.ext_opts),
 				conf.config.ext_prio_increase
 			)

--- a/lua/luasnip/util/ext_opts.lua
+++ b/lua/luasnip/util/ext_opts.lua
@@ -1,5 +1,9 @@
 -- eventually turn ext_opts into proper objects, mainly for
 -- default-construction eg. assured `complete`.
+--
+-- child_*-functions perform the same operation as theiry non-child
+-- counterparts, but on a collection (eg.
+-- `{[types.insertNode={...}, [types.textNode]= {...}]}`) of ext_opts.
 
 local types = require("luasnip.util.types")
 
@@ -7,6 +11,8 @@ local types = require("luasnip.util.types")
 -- always pass this empty table, which will (has to!) stay empty.
 local shared_empty_table = {}
 
+-- opts: child_ext_opts, have to have hl_group set for all combinations of
+-- node-type and active,passive,snippet_passive.
 local function clear_invalid(opts)
 	for _, node_type in pairs(types.node_types) do
 		local act_group, pas_group, snip_pas_group =
@@ -28,73 +34,94 @@ local function clear_invalid(opts)
 	end
 end
 
+local function _complete_ext_opts(ext_opts)
+	if not ext_opts then
+		ext_opts = {}
+	end
+	ext_opts.snippet_passive = ext_opts.snippet_passive or {}
+	ext_opts.passive = vim.tbl_extend(
+		"keep",
+		ext_opts.passive or shared_empty_table,
+		ext_opts.snippet_passive or shared_empty_table
+	)
+	ext_opts.active = vim.tbl_extend(
+		"keep",
+		ext_opts.active or shared_empty_table,
+		ext_opts.passive or shared_empty_table
+	)
+
+	--stylua: ignore start
+	if ext_opts.snippet_passive.hl_group and not
+	   ext_opts.snippet_passive.priority then
+		ext_opts.snippet_passive.priority = 0
+	end
+
+	if ext_opts.passive.hl_group and not
+	   ext_opts.passive.priority then
+		ext_opts.passive.priority = 0
+	end
+
+	if ext_opts.active.hl_group and not
+	   ext_opts.active.priority then
+		ext_opts.active.priority = 0
+	end
+	--stylua: ignore end
+
+	return ext_opts
+end
+
 -- active inherits unset values from passive, which in turn inherits from
 -- snippet_passive.
 -- Also make sure that all keys have a table, and are not nil!
-local function complete(ext_opts)
-	ext_opts.increased_by = 0
+local function child_complete(ext_opts)
 	for _, node_type in pairs(types.node_types) do
-		local node_opts
-		if not ext_opts[node_type] then
-			node_opts = {}
-			ext_opts[node_type] = node_opts
-		else
-			node_opts = ext_opts[node_type]
-		end
-		node_opts.snippet_passive = node_opts.snippet_passive or {}
-		node_opts.passive = vim.tbl_extend(
-			"keep",
-			node_opts.passive or shared_empty_table,
-			node_opts.snippet_passive or shared_empty_table
-		)
-		node_opts.active = vim.tbl_extend(
-			"keep",
-			node_opts.active or shared_empty_table,
-			node_opts.passive or shared_empty_table
-		)
-
-		--stylua: ignore start
-		if node_opts.snippet_passive.hl_group and not
-		   node_opts.snippet_passive.priority then
-			node_opts.snippet_passive.priority = 0
-		end
-
-		if node_opts.passive.hl_group and not
-		   node_opts.passive.priority then
-			node_opts.passive.priority = 0
-		end
-
-		if node_opts.active.hl_group and not
-		   node_opts.active.priority then
-			node_opts.active.priority = 0
-		end
-		--stylua: ignore end
+		ext_opts[node_type] = _complete_ext_opts(ext_opts[node_type])
 	end
+	ext_opts.base_prio = 0
+
+	return ext_opts
+end
+
+local function complete(ext_opts)
+	_complete_ext_opts(ext_opts)
+	ext_opts.base_prio = 0
+
+	return ext_opts
 end
 
 -- in-place adds opts of b to a, doesn't override.
 -- a/b: completed ext_opts, not nil.
 local function extend(opts_a, opts_b)
-	for _, node_type in ipairs(types.node_types) do
-		local node_opts_a = opts_a[node_type]
-		local node_opts_b = opts_b[node_type]
+	opts_a.snippet_passive = vim.tbl_extend(
+		"keep",
+		opts_a.snippet_passive,
+		opts_b.snippet_passive
+	)
+	opts_a.passive = vim.tbl_extend("keep", opts_a.passive, opts_b.passive)
+	opts_a.active = vim.tbl_extend("keep", opts_a.active, opts_b.active)
 
-		node_opts_a.snippet_passive = vim.tbl_extend(
-			"keep",
-			node_opts_a.snippet_passive,
-			node_opts_b.snippet_passive
-		)
-		node_opts_a.passive = vim.tbl_extend(
-			"keep",
-			node_opts_a.passive,
-			node_opts_b.passive
-		)
-		node_opts_a.active = vim.tbl_extend(
-			"keep",
-			node_opts_a.active,
-			node_opts_b.active
-		)
+	return opts_a
+end
+
+-- in-place adds opts of b to a, doesn't override.
+-- a/b: completed child_ext_opts, not nil.
+local function child_extend(opts_a, opts_b)
+	for _, node_type in ipairs(types.node_types) do
+		extend(opts_a[node_type], opts_b[node_type])
 	end
+
+	return opts_a
+end
+
+local function increase_prio(opts, inc)
+	-- increase only if there is a priority.
+	opts.active.priority = opts.active.priority and (opts.active.priority + inc)
+
+	opts.passive.priority = opts.passive.priority
+		and (opts.passive.priority + inc)
+
+	opts.snippet_passive.priority = opts.snippet_passive.priority
+		and (opts.snippet_passive.priority + inc)
 end
 
 -- ext_opts-priorities are defined relative to some base-priority.
@@ -105,26 +132,30 @@ end
 local function set_abs_prio(opts, new_base_prio)
 	-- undo previous increase.
 	-- base_prio is initialized with 0.
-	new_base_prio = new_base_prio - opts.base_prio
+	local prio_offset = new_base_prio - opts.base_prio
 	opts.base_prio = new_base_prio
-	for _, node_type in pairs(types.node_types) do
-		local node_opts = opts[node_type]
-		node_opts.active.priority = node_opts.active.priority
-			and node_opts.active.priority + new_base_prio
+	increase_prio(opts, prio_offset)
 
-		node_opts.passive.priority = node_opts.passive.priority
-			and node_opts.passive.priority + new_base_prio
+	return opts
+end
 
-		node_opts.snippet_passive.priority = node_opts.snippet_passive.priority
-			and node_opts.snippet_passive.priority + new_base_prio
+local function child_set_abs_prio(opts, new_base_prio)
+	-- undo previous increase.
+	-- base_prio is initialized with 0.
+	local prio_offset = new_base_prio - opts.base_prio
+	opts.base_prio = new_base_prio
+	for _, node_type in ipairs(types.node_types) do
+		increase_prio(opts[node_type], prio_offset)
 	end
-	-- modifies in-place, but utilizing that may be cumbersome.
 	return opts
 end
 
 return {
 	clear_invalid = clear_invalid,
 	complete = complete,
+	child_complete = child_complete,
 	extend = extend,
+	child_extend = child_extend,
 	set_abs_prio = set_abs_prio,
+	child_set_abs_prio = child_set_abs_prio,
 }

--- a/lua/luasnip/util/ext_opts.lua
+++ b/lua/luasnip/util/ext_opts.lua
@@ -1,0 +1,100 @@
+-- eventually turn ext_opts into proper objects, mainly for
+-- default-construction eg. assured `complete`.
+
+local types = require("luasnip.util.types")
+
+-- vim.tbl_extend always creates a new table, but doesn't accept nil, so we
+-- always pass this empty table, which will (has to!) stay empty.
+local shared_empty_table = {}
+
+local function clear_invalid(opts)
+	for _, node_type in pairs(types.node_types) do
+		local act_group, pas_group, snip_pas_group =
+			opts[node_type].active.hl_group,
+			opts[node_type].passive.hl_group,
+			opts[node_type].snippet_passive.hl_group
+
+		--stylua: ignore start
+		opts[node_type].snippet_passive.hl_group =
+			vim.fn.hlexists(snip_pas_group) == 1 and snip_pas_group
+			or nil
+		opts[node_type].passive.hl_group =
+			vim.fn.hlexists(pas_group) == 1 and pas_group
+			or nil
+		opts[node_type].active.hl_group =
+			vim.fn.hlexists(act_group) == 1 and act_group
+			or nil
+		--stylua: ignore end
+	end
+end
+
+-- active inherits unset values from passive, which in turn inherits from
+-- snippet_passive.
+-- Also make sure that all keys have a table, and are not nil!
+local function complete(ext_opts)
+	for _, node_type in pairs(types.node_types) do
+		local node_opts
+		if not ext_opts[node_type] then
+			node_opts = {}
+			ext_opts[node_type] = node_opts
+		else
+			node_opts = ext_opts[node_type]
+		end
+		node_opts.snippet_passive = node_opts.snippet_passive or {}
+		node_opts.passive = vim.tbl_extend(
+			"keep",
+			node_opts.passive or shared_empty_table,
+			node_opts.snippet_passive or shared_empty_table
+		)
+		node_opts.active = vim.tbl_extend(
+			"keep",
+			node_opts.active or shared_empty_table,
+			node_opts.passive or shared_empty_table
+		)
+	end
+end
+
+-- in-place adds opts of b to a, doesn't override.
+-- a/b: completed ext_opts, not nil.
+local function extend(opts_a, opts_b)
+	for _, node_type in ipairs(types.node_types) do
+		local node_opts_a = opts_a[node_type]
+		local node_opts_b = opts_b[node_type]
+
+		node_opts_a.snippet_passive = vim.tbl_extend(
+			"keep",
+			node_opts_a.snippet_passive,
+			node_opts_b.snippet_passive
+		)
+		node_opts_a.passive = vim.tbl_extend(
+			"keep",
+			node_opts_a.passive,
+			node_opts_b.passive
+		)
+		node_opts_a.active = vim.tbl_extend(
+			"keep",
+			node_opts_a.active,
+			node_opts_b.active
+		)
+	end
+end
+
+local function increase_prio(opts, amount)
+	for _, node_type in pairs(types.node_types) do
+		local node_opts = opts[node_type]
+		node_opts.active.priority = (node_opts.active.priority or 0) + amount
+		node_opts.passive.priority = (node_opts.passive.priority or 0) + amount
+		node_opts.snippet_passive.priority = (
+				node_opts.snippet_passive.priority or 0
+			) + amount
+	end
+	-- modifies in-place, but utilizing that may be cumbersome.
+	return opts
+end
+
+return {
+	clear_invalid = clear_invalid,
+	complete = complete,
+	extend = extend,
+	increase_prio = increase_prio,
+}

--- a/lua/luasnip/util/ext_opts.lua
+++ b/lua/luasnip/util/ext_opts.lua
@@ -102,18 +102,21 @@ end
 -- set the absolute priorities, which can vary depending on nesting-level
 -- of a given snippet, during runtime, by increasing the relative priorities by
 -- either the conf.base_prio or the base-prio used in the previous nesting-level.
-local function increase_prio(opts, amount)
-	opts.increased_by = opts.increased_by + amount
+local function set_abs_prio(opts, new_base_prio)
+	-- undo previous increase.
+	-- base_prio is initialized with 0.
+	new_base_prio = new_base_prio - opts.base_prio
+	opts.base_prio = new_base_prio
 	for _, node_type in pairs(types.node_types) do
 		local node_opts = opts[node_type]
 		node_opts.active.priority = node_opts.active.priority
-			and node_opts.active.priority + amount
+			and node_opts.active.priority + new_base_prio
 
 		node_opts.passive.priority = node_opts.passive.priority
-			and node_opts.passive.priority + amount
+			and node_opts.passive.priority + new_base_prio
 
 		node_opts.snippet_passive.priority = node_opts.snippet_passive.priority
-			and node_opts.snippet_passive.priority + amount
+			and node_opts.snippet_passive.priority + new_base_prio
 	end
 	-- modifies in-place, but utilizing that may be cumbersome.
 	return opts
@@ -123,5 +126,5 @@ return {
 	clear_invalid = clear_invalid,
 	complete = complete,
 	extend = extend,
-	increase_prio = increase_prio,
+	set_abs_prio = set_abs_prio,
 }

--- a/lua/luasnip/util/ext_opts.lua
+++ b/lua/luasnip/util/ext_opts.lua
@@ -51,6 +51,23 @@ local function complete(ext_opts)
 			node_opts.active or shared_empty_table,
 			node_opts.passive or shared_empty_table
 		)
+
+		--stylua: ignore start
+		if node_opts.snippet_passive.hl_group and not
+		   node_opts.snippet_passive.priority then
+			node_opts.snippet_passive.priority = 0
+		end
+
+		if node_opts.passive.hl_group and not
+		   node_opts.passive.priority then
+			node_opts.passive.priority = 0
+		end
+
+		if node_opts.active.hl_group and not
+		   node_opts.active.priority then
+			node_opts.active.priority = 0
+		end
+		--stylua: ignore end
 	end
 end
 
@@ -82,11 +99,14 @@ end
 local function increase_prio(opts, amount)
 	for _, node_type in pairs(types.node_types) do
 		local node_opts = opts[node_type]
-		node_opts.active.priority = (node_opts.active.priority or 0) + amount
-		node_opts.passive.priority = (node_opts.passive.priority or 0) + amount
-		node_opts.snippet_passive.priority = (
-				node_opts.snippet_passive.priority or 0
-			) + amount
+		node_opts.active.priority = node_opts.active.priority
+			and node_opts.active.priority + amount
+
+		node_opts.passive.priority = node_opts.passive.priority
+			and node_opts.passive.priority + amount
+
+		node_opts.snippet_passive.priority = node_opts.snippet_passive.priority
+			and node_opts.snippet_passive.priority + amount
 	end
 	-- modifies in-place, but utilizing that may be cumbersome.
 	return opts

--- a/lua/luasnip/util/ext_opts.lua
+++ b/lua/luasnip/util/ext_opts.lua
@@ -32,6 +32,7 @@ end
 -- snippet_passive.
 -- Also make sure that all keys have a table, and are not nil!
 local function complete(ext_opts)
+	ext_opts.increased_by = 0
 	for _, node_type in pairs(types.node_types) do
 		local node_opts
 		if not ext_opts[node_type] then
@@ -96,7 +97,13 @@ local function extend(opts_a, opts_b)
 	end
 end
 
+-- ext_opts-priorities are defined relative to some base-priority.
+-- As nvim_api_buf_set_extmark takes absolute values only, we have to
+-- set the absolute priorities, which can vary depending on nesting-level
+-- of a given snippet, during runtime, by increasing the relative priorities by
+-- either the conf.base_prio or the base-prio used in the previous nesting-level.
 local function increase_prio(opts, amount)
+	opts.increased_by = opts.increased_by + amount
 	for _, node_type in pairs(types.node_types) do
 		local node_opts = opts[node_type]
 		node_opts.active.priority = node_opts.active.priority

--- a/lua/luasnip/util/types.lua
+++ b/lua/luasnip/util/types.lua
@@ -8,6 +8,7 @@ return {
 	snippet = 7,
 	exitNode = 8,
 	restoreNode = 9,
+	node_types = { 1, 2, 3, 4, 5, 6, 7, 8, 9 },
 	names = {
 		"textNode",
 		"insertNode",

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -376,71 +376,6 @@ local function pos_equal(p1, p2)
 	return p1[1] == p2[1] and p1[2] == p2[2]
 end
 
-local function clear_invalid(opts)
-	for key, val in pairs(opts) do
-		local act_group, pas_group, snip_pas_group =
-			val.active.hl_group,
-			val.passive.hl_group,
-			val.snippet_passive.hl_group
-		opts[key].snippet_passive.hl_group = vim.fn.hlexists(snip_pas_group)
-					== 1
-				and snip_pas_group
-			or nil
-		opts[key].passive.hl_group = vim.fn.hlexists(pas_group) == 1
-				and pas_group
-			or nil
-		opts[key].active.hl_group = vim.fn.hlexists(act_group) == 1
-				and act_group
-			or nil
-	end
-end
-
-local function make_opts_valid(user_opts, default_opts)
-	local opts = vim.deepcopy(default_opts)
-	for key, default_val in pairs(opts) do
-		-- prevent nil-indexing error.
-		user_opts[key] = user_opts[key] or {}
-
-		-- override defaults with user for snippet_passive.
-		default_val.snippet_passive = vim.tbl_extend(
-			"force",
-			default_val.snippet_passive,
-			user_opts[key].snippet_passive or {}
-		)
-		-- override default-passive with user, get missing values from default
-		-- snippet_passive
-		default_val.passive = vim.tbl_extend(
-			"force",
-			user_opts[key].snippet_passive or {},
-			vim.tbl_extend(
-				"force",
-				default_val.passive,
-				user_opts[key].passive or {}
-			)
-		)
-		-- same here, but with passive and active
-		default_val.active = vim.tbl_extend(
-			"force",
-			default_val.passive,
-			vim.tbl_extend(
-				"force",
-				default_val.active,
-				user_opts[key].active or {}
-			)
-		)
-	end
-	return opts
-end
-
-local function increase_ext_prio(opts, amount)
-	for _, val in pairs(opts) do
-		val.active.priority = (val.active.priority or 0) + amount
-		val.passive.priority = (val.passive.priority or 0) + amount
-	end
-	-- modifies in-place, but utilizing that may be cumbersome.
-	return opts
-end
-
 local function string_wrap(lines, pos)
 	local new_lines = vim.deepcopy(lines)
 	if #new_lines == 1 and #new_lines[1] == 0 then
@@ -611,8 +546,6 @@ return {
 	indent = indent,
 	expand_tabs = expand_tabs,
 	tab_width = tab_width,
-	make_opts_valid = make_opts_valid,
-	increase_ext_prio = increase_ext_prio,
 	clear_invalid = clear_invalid,
 	buffer_comment_chars = buffer_comment_chars,
 	string_wrap = string_wrap,


### PR DESCRIPTION
The goal of this PR is to allow specifying `ext_opts` on a per-node/snippet-basis (useful for highlighting eg. choices differently, see #291)

This means that
* the global config may be overriden by specifying `opts.ext_opts` in a snippet/snippetNode (`s("trig", {...}, {child_ext_opts = {...}})`). The values given here are applied to all nodes of the snippet(Node).
* the snippet(Node)s' `ext_opts` may be overriden by specifying `opts.node_ext_opts` (name debatable) in any given nodes constructor, eg. `i(1, "some text", {node_ext_opts = {active = {...}, passive = {...}}})`.
This requires a breaking change to `dynamic/functionNode` where we currently accept a vararg for `user_args` (`f(func, argnodes, ...)` -> `f(func, argnodes, {user_args = {...}, node_ext_opts = {...}})`) (I don't see breaking that as a downside, varargs instead of a table as the last arg weren't really the best idea)

~Right now only the per-snippet-override is implemented.~
should pretty much work now.
Feel free to constructively criticise :)