### PR TITLE
fix(docs): md code block can't be indented

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -384,16 +384,16 @@ The third parameter is a table of options with the following keys:
 	possible to override the default by wrapping the `choiceNode`-constructor
 	in another function that sets `opts.restore_cursor` to `true` and then using
 	that to construct `choiceNode`s:
-	```lua
-	local function restore_cursor_choice(pos, choices, opts)
-		if opts then
-			opts.restore_cursor = true
-		else
-			opts = {restore_cursor = true}
-		end
-		return c(pos, choices, opts)
+```lua
+local function restore_cursor_choice(pos, choices, opts)
+	if opts then
+		opts.restore_cursor = true
+	else
+		opts = {restore_cursor = true}
 	end
-	```
+	return c(pos, choices, opts)
+end
+```
 
 Jumpable nodes that normally expect an index as their first parameter don't
 need one inside a choiceNode; their index is the same as the choiceNodes'.

--- a/DOC.md
+++ b/DOC.md
@@ -769,8 +769,8 @@ The complete signature for the node is `match(argnodes, condition, then, else)`,
     "ABC" exactly, nothing otherwise.
   * `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")` inserts
     "PALINDROME" if the nth jumpable node is a palindrome.
-  *
-    ```lua
+
+  * ```lua
     s("trig", {
     	i(1), t":",
     	i(2), t"::",

--- a/DOC.md
+++ b/DOC.md
@@ -384,16 +384,16 @@ The third parameter is a table of options with the following keys:
 	possible to override the default by wrapping the `choiceNode`-constructor
 	in another function that sets `opts.restore_cursor` to `true` and then using
 	that to construct `choiceNode`s:
-```lua
-local function restore_cursor_choice(pos, choices, opts)
-	if opts then
-		opts.restore_cursor = true
-	else
-		opts = {restore_cursor = true}
-	end
-	return c(pos, choices, opts)
-end
-```
+    ```lua
+    local function restore_cursor_choice(pos, choices, opts)
+        if opts then
+            opts.restore_cursor = true
+        else
+            opts = {restore_cursor = true}
+        end
+        return c(pos, choices, opts)
+    end
+    ```
 
 Jumpable nodes that normally expect an index as their first parameter don't
 need one inside a choiceNode; their index is the same as the choiceNodes'.
@@ -769,7 +769,8 @@ The complete signature for the node is `match(argnodes, condition, then, else)`,
     "ABC" exactly, nothing otherwise.
   * `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")` inserts
     "PALINDROME" if the nth jumpable node is a palindrome.
-  * ```lua
+  *
+    ```lua
     s("trig", {
     	i(1), t":",
     	i(2), t"::",


### PR DESCRIPTION
For the generation of docs from `md`, the code block cannot be indented, because it gets translated to
> `lua
> --- code
> `