### PR TITLE
Add snippets via function only.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -49,18 +49,16 @@ It is explained in more detail in [SNIPPETS](#snippets), but the gist is that
 it creates a snippet that contains the nodes specified in `nodes`, which will be
 inserted into a buffer if the text before the cursor matches `trigger` when
 `expand` is called.
-The snippets for a given filetype have to be appended to the
-`ls.snippets.<filetype>`-table. Snippets that should be accessible globally (in
-all filetypes) will be read from the `ls.snippets.all`-table:
+The snippets for a given filetype have to be added to luasnip via
+`ls.add_snippets(filetype, snippets)`. Snippets that should be accessible
+globally (in all filetypes) have to be added to the special filetype `all`.
 ```lua
-ls.snippets = {
-	all = {
-		s("ternary", {
-			-- equivalent to "${1:cond} ? ${2:then} : ${3:else}"
-			i(1, "cond"), t(" ? "), i(2, "then"), t(" : "), i(3, "else")
-		})
-	}
-}
+ls.add_snippets("all", {
+	s("ternary", {
+		-- equivalent to "${1:cond} ? ${2:then} : ${3:else}"
+		i(1, "cond"), t(" ? "), i(2, "then"), t(" : "), i(3, "else")
+	})
+})
 ```
 It is possible to make snippets from one filetype available to another using
 `ls.filetype_extend`, more info on that [here](#api-reference).
@@ -1233,11 +1231,12 @@ s({trig = "(%d)", regTrig = true, docstring = "repeatmerepeatmerepeatme"}, {
 
 Although generation of docstrings is pretty fast, it's preferable to not
 redo it as long as the snippets haven't changed. Using
-`ls.store_snippet_docstrings(ls.snippets)` and its counterpart
-`ls.load_snippet_docstrings(ls.snippets)`, they may be serialized from or
+`ls.store_snippet_docstrings(snippets)` and its counterpart
+`ls.load_snippet_docstrings(snippets)`, they may be serialized from or
 deserialized into the snippets.
-Both functions accept a table structured like `ls.snippets`, ie.
-`{ft1={snippets}, ft2={snippets}}`.
+Both functions accept a table structsured like this: `{ft1={snippets},
+ft2={snippets}}`. Such a table containing all snippets can be obtained via
+`ls.get_snippets()`.
 `load` should be called before any of the `loader`-functions as snippets loaded
 from vscode-style packages already have their `docstring` set (`docstrings`
 wouldn't be overwritten, but there'd be unnecessary calls).

--- a/DOC.md
+++ b/DOC.md
@@ -155,6 +155,14 @@ Additionally, the string that was used to trigger the snippet is stored in
 dynamic/functionNodes, where the snippet can be accessed through the immediate
 parent (`parent.snippet`), which is passed to the function.
 
+## Api:
+
+- `invalidate()`: call this method to effectively remove the snippet. The
+  snippet will no longer be able to expand via `expand` or `expand_auto`. It
+  will also be hidden from lists (at least if the plugin creating the list
+  respects the `hidden`-key), but it might be necessary to call
+  `ls.refresh_notify(ft)` after invalidating snippets.
+
 
 # TEXTNODE
 

--- a/DOC.md
+++ b/DOC.md
@@ -1322,6 +1322,18 @@ the lazy_load.
   `opts` may contain the following keys:
   - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
 
+- `clean_invalidated(opts: table or nil)`: clean invalidated snippets from
+  internal snippet storage.
+  Invalidated snippets are still stored, it might be useful to actually remove
+  them, as they still have to be iterated during expansion.
+  `opts` may contain:
+
+  - `inv_limit`: how many invalidated snippets are allowed. If the number of
+  	invalid snippets doesn't exceed this threshold, they are not yet cleaned up.
+
+	A small number of invalidated snippets (<100) probably doesn't affect
+	runtime at all, whereas recreating the internal snippet storage might.
+
 - `in_snippet()`: returns true if the cursor is inside the current snippet.
 
 - `jumpable(direction)`: returns true if the current node has a

--- a/DOC.md
+++ b/DOC.md
@@ -1321,6 +1321,12 @@ the lazy_load.
   the keys are corresponding filetypes.  
   `opts` may contain the following keys:
   - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
+  - `key`: Key that identifies snippets added via this call.  
+	If `add_snippets` is called with a key that was already used, the snippets
+	from that previous call will be removed.  
+	This can be used to reload snippets: pass an unique key to each
+	`add_snippets` and just re-do the `add_snippets`-call when the snippets have
+	changed.
 
 - `clean_invalidated(opts: table or nil) -> bool`: clean invalidated snippets
   from internal snippet storage.  

--- a/DOC.md
+++ b/DOC.md
@@ -891,7 +891,7 @@ snippet and then clear them.
 As luasnip is capable of loading the same format of plugins as vscode, it also
 includes an easy way for loading those automatically. You just have to call:
 ```lua
- 	require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
+require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
 ```
 
 Where `opts` is a table containing the keys:
@@ -914,7 +914,7 @@ your snippets or you will have to extend the table as well.
 Another way of using the loader is making it lazily
 
 ```lua
- 	require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
+require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
 ```
 
 In this case `opts` only accepts paths (`runtimepath` if any). That will load
@@ -938,7 +938,7 @@ As the snipmate snippet format is fundamentally the same as vscode, it can also
 be loaded.
 
 ```lua
- 	require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
+require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
 ```
 
 See `from_vscode` for an explanation of opts.
@@ -964,7 +964,7 @@ Using both `extends OtherFileType` in `FileType.snippets` and
 Lazy loading is also available with the snipmate-loader.
 
 ```lua
- 	require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
+require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
 ```
 
 
@@ -976,6 +976,44 @@ Here is a summary of the differences from the original snipmate format.
 - `${VISUAL}` will be replaced by `$TM_SELECTED_TEXT` to make the snippets
 compatible with luasnip
 - We do not implement eval using \` (backtick). This may be implemented in the future.
+
+
+# LUA SNIPPETS LOADER
+
+Instead of adding all snippets via `add_snippets`, it's possible to store them
+in separate files (each for one filetype) and load all of those.
+
+For this, the files need to be
+
+- in a single directory. The directory may be passed directly to `load()`, or it
+  can be named `luasnippets` and in the `runtimepath`, in which case it will be
+  automatically detected.
+- named `<filetype>.lua`.
+- return two lists of snippets (either may be `nil`). The snippets in the first
+  are regular snippets for `<filetype>`, the ones in the second are autosnippets
+  (make sure they are enabled if this table is used).
+
+As defining all of the snippet-constructors (`s`, `c`, `t`, ...) in every file
+is rather cumbersome, luasnip will bring some globals into scope for executing
+these files.  
+By default the names from `Examples/snippets.lua` will be used, but it's
+possible to customize them by setting `snip_env` in `setup`.  
+
+These collections can be loaded directly
+(`require("luasnip.loaders.from_lua").load(opts)`) or lazily
+(`require("luasnip.loaders.from_lua.lazy_load(opts)")`).
+
+lua-`opts` may contain the same keys as vscode-`opts`, but here `include` and
+`exclude` can be used in `lazy_load`.
+
+Apart from loading, `from_lua` also exposes functions to edit files associated
+with the currently active filetypes, which could be called via an command, for
+example:
+
+```vim
+command! LuaSnipEdit :lua require("luasnip.loaders.from_lua").edit_snippet_files()
+```
+Once loaded, files will be reloaded on save (`BufWritePost`).
 
 
 # SNIPPETPROXY

--- a/DOC.md
+++ b/DOC.md
@@ -1323,9 +1323,10 @@ the lazy_load.
   - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
 
 - `clean_invalidated(opts: table or nil)`: clean invalidated snippets from
-  internal snippet storage.
+  internal snippet storage.  
   Invalidated snippets are still stored, it might be useful to actually remove
   them, as they still have to be iterated during expansion.
+
   `opts` may contain:
 
   - `inv_limit`: how many invalidated snippets are allowed. If the number of

--- a/DOC.md
+++ b/DOC.md
@@ -1322,10 +1322,12 @@ the lazy_load.
   `opts` may contain the following keys:
   - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
 
-- `clean_invalidated(opts: table or nil)`: clean invalidated snippets from
-  internal snippet storage.  
+- `clean_invalidated(opts: table or nil) -> bool`: clean invalidated snippets
+  from internal snippet storage.  
   Invalidated snippets are still stored, it might be useful to actually remove
   them, as they still have to be iterated during expansion.
+
+  It will be necessary to call `ls.refresh_notify()` after invalidating snippets.
 
   `opts` may contain:
 
@@ -1334,6 +1336,9 @@ the lazy_load.
 
 	A small number of invalidated snippets (<100) probably doesn't affect
 	runtime at all, whereas recreating the internal snippet storage might.
+
+  The function returns whether snippets were removed, which may be used to only
+  conditionally `refresh_notify`.
 
 - `in_snippet()`: returns true if the cursor is inside the current snippet.
 

--- a/DOC.md
+++ b/DOC.md
@@ -1315,6 +1315,13 @@ the lazy_load.
 
 `require("luasnip")`:
 
+- `add_snippets(ft:string or nil, snippets:list or table, opts:table or nil)`:
+  Makes `snippets` available in `ft`.  
+  If `ft` is `nil`, `snippets` should be a table containing lists of snippets,
+  the keys are corresponding filetypes.  
+  `opts` may contain the following keys:
+  - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
+
 - `in_snippet()`: returns true if the cursor is inside the current snippet.
 
 - `jumpable(direction)`: returns true if the current node has a

--- a/Examples/snippets.lua
+++ b/Examples/snippets.lua
@@ -181,336 +181,329 @@ local date_input = function(args, snip, old_state, fmt)
 	return sn(nil, i(1, os.date(fmt)))
 end
 
-ls.snippets = {
-	-- When trying to expand a snippet, luasnip first searches the tables for
-	-- each filetype specified in 'filetype' followed by 'all'.
-	-- If ie. the filetype is 'lua.c'
-	--     - luasnip.lua
-	--     - luasnip.c
-	--     - luasnip.all
-	-- are searched in that order.
-	all = {
-		-- trigger is `fn`, second argument to snippet-constructor are the nodes to insert into the buffer on expansion.
-		s("fn", {
-			-- Simple static text.
-			t("//Parameters: "),
-			-- function, first parameter is the function, second the Placeholders
-			-- whose text it gets as input.
-			f(copy, 2),
-			t({ "", "function " }),
-			-- Placeholder/Insert.
-			i(1),
-			t("("),
-			-- Placeholder with initial text.
-			i(2, "int foo"),
-			-- Linebreak
-			t({ ") {", "\t" }),
-			-- Last Placeholder, exit Point of the snippet.
-			i(0),
-			t({ "", "}" }),
+-- snippets are added via ls.add_snippets(filetype, snippets[, opts]), where
+-- opts may specify the `type` of the snippets ("snippets" or "autosnippets",
+-- for snippets that should expand directly after the trigger is typed).
+ls.add_snippets("all", {
+	-- trigger is `fn`, second argument to snippet-constructor are the nodes to insert into the buffer on expansion.
+	s("fn", {
+		-- Simple static text.
+		t("//Parameters: "),
+		-- function, first parameter is the function, second the Placeholders
+		-- whose text it gets as input.
+		f(copy, 2),
+		t({ "", "function " }),
+		-- Placeholder/Insert.
+		i(1),
+		t("("),
+		-- Placeholder with initial text.
+		i(2, "int foo"),
+		-- Linebreak
+		t({ ") {", "\t" }),
+		-- Last Placeholder, exit Point of the snippet.
+		i(0),
+		t({ "", "}" }),
+	}),
+	s("class", {
+		-- Choice: Switch between two different Nodes, first parameter is its position, second a list of nodes.
+		c(1, {
+			t("public "),
+			t("private "),
 		}),
-		s("class", {
-			-- Choice: Switch between two different Nodes, first parameter is its position, second a list of nodes.
-			c(1, {
-				t("public "),
-				t("private "),
+		t("class "),
+		i(2),
+		t(" "),
+		c(3, {
+			t("{"),
+			-- sn: Nested Snippet. Instead of a trigger, it has a position, just like insert-nodes. !!! These don't expect a 0-node!!!!
+			-- Inside Choices, Nodes don't need a position as the choice node is the one being jumped to.
+			sn(nil, {
+				t("extends "),
+				-- restoreNode: stores and restores nodes.
+				-- pass position, store-key and nodes.
+				r(1, "other_class", i(1)),
+				t(" {"),
 			}),
-			t("class "),
-			i(2),
-			t(" "),
-			c(3, {
-				t("{"),
-				-- sn: Nested Snippet. Instead of a trigger, it has a position, just like insert-nodes. !!! These don't expect a 0-node!!!!
-				-- Inside Choices, Nodes don't need a position as the choice node is the one being jumped to.
-				sn(nil, {
-					t("extends "),
-					-- restoreNode: stores and restores nodes.
-					-- pass position, store-key and nodes.
-					r(1, "other_class", i(1)),
-					t(" {"),
-				}),
-				sn(nil, {
-					t("implements "),
-					-- no need to define the nodes for a given key a second time.
-					r(1, "other_class"),
-					t(" {"),
-				}),
+			sn(nil, {
+				t("implements "),
+				-- no need to define the nodes for a given key a second time.
+				r(1, "other_class"),
+				t(" {"),
 			}),
-			t({ "", "\t" }),
-			i(0),
-			t({ "", "}" }),
 		}),
-		-- Alternative printf-like notation for defining snippets. It uses format
-		-- string with placeholders similar to the ones used with Python's .format().
-		s(
-			"fmt1",
-			fmt("To {title} {} {}.", {
-				i(2, "Name"),
-				i(3, "Surname"),
-				title = c(1, { t("Mr."), t("Ms.") }),
-			})
-		),
-		-- To escape delimiters use double them, e.g. `{}` -> `{{}}`.
-		-- Multi-line format strings by default have empty first/last line removed.
-		-- Indent common to all lines is also removed. Use the third `opts` argument
-		-- to control this behaviour.
-		s(
-			"fmt2",
-			fmt(
-				[[
-			foo({1}, {3}) {{
-				return {2} * {4}
-			}}
-			]],
-				{
-					i(1, "x"),
-					rep(1),
-					i(2, "y"),
-					rep(2),
-				}
-			)
-		),
-		-- Empty placeholders are numbered automatically starting from 1 or the last
-		-- value of a numbered placeholder. Named placeholders do not affect numbering.
-		s(
-			"fmt3",
-			fmt("{} {a} {} {1} {}", {
-				t("1"),
-				t("2"),
-				a = t("A"),
-			})
-		),
-		-- The delimiters can be changed from the default `{}` to something else.
-		s(
-			"fmt4",
-			fmt("foo() { return []; }", i(1, "x"), { delimiters = "[]" })
-		),
-		-- `fmta` is a convenient wrapper that uses `<>` instead of `{}`.
-		s("fmt5", fmta("foo() { return <>; }", i(1, "x"))),
-		-- By default all args must be used. Use strict=false to disable the check
-		s(
-			"fmt6",
-			fmt("use {} only", { t("this"), t("not this") }, { strict = false })
-		),
-		-- Use a dynamic_node to interpolate the output of a
-		-- function (see date_input above) into the initial
-		-- value of an insert_node.
-		s("novel", {
-			t("It was a dark and stormy night on "),
-			d(1, date_input, {}, { user_args = { "%A, %B %d of %Y" } }),
-			t(" and the clocks were striking thirteen."),
-		}),
-		-- Parsing snippets: First parameter: Snippet-Trigger, Second: Snippet body.
-		-- Placeholders are parsed into choices with 1. the placeholder text(as a snippet) and 2. an empty string.
-		-- This means they are not SELECTed like in other editors/Snippet engines.
-		ls.parser.parse_snippet(
-			"lspsyn",
-			"Wow! This ${1:Stuff} really ${2:works. ${3:Well, a bit.}}"
-		),
+		t({ "", "\t" }),
+		i(0),
+		t({ "", "}" }),
+	}),
+	-- Alternative printf-like notation for defining snippets. It uses format
+	-- string with placeholders similar to the ones used with Python's .format().
+	s(
+		"fmt1",
+		fmt("To {title} {} {}.", {
+			i(2, "Name"),
+			i(3, "Surname"),
+			title = c(1, { t("Mr."), t("Ms.") }),
+		})
+	),
+	-- To escape delimiters use double them, e.g. `{}` -> `{{}}`.
+	-- Multi-line format strings by default have empty first/last line removed.
+	-- Indent common to all lines is also removed. Use the third `opts` argument
+	-- to control this behaviour.
+	s(
+		"fmt2",
+		fmt(
+			[[
+		foo({1}, {3}) {{
+			return {2} * {4}
+		}}
+		]],
+			{
+				i(1, "x"),
+				rep(1),
+				i(2, "y"),
+				rep(2),
+			}
+		)
+	),
+	-- Empty placeholders are numbered automatically starting from 1 or the last
+	-- value of a numbered placeholder. Named placeholders do not affect numbering.
+	s(
+		"fmt3",
+		fmt("{} {a} {} {1} {}", {
+			t("1"),
+			t("2"),
+			a = t("A"),
+		})
+	),
+	-- The delimiters can be changed from the default `{}` to something else.
+	s("fmt4", fmt("foo() { return []; }", i(1, "x"), { delimiters = "[]" })),
+	-- `fmta` is a convenient wrapper that uses `<>` instead of `{}`.
+	s("fmt5", fmta("foo() { return <>; }", i(1, "x"))),
+	-- By default all args must be used. Use strict=false to disable the check
+	s(
+		"fmt6",
+		fmt("use {} only", { t("this"), t("not this") }, { strict = false })
+	),
+	-- Use a dynamic_node to interpolate the output of a
+	-- function (see date_input above) into the initial
+	-- value of an insert_node.
+	s("novel", {
+		t("It was a dark and stormy night on "),
+		d(1, date_input, {}, { user_args = { "%A, %B %d of %Y" } }),
+		t(" and the clocks were striking thirteen."),
+	}),
+	-- Parsing snippets: First parameter: Snippet-Trigger, Second: Snippet body.
+	-- Placeholders are parsed into choices with 1. the placeholder text(as a snippet) and 2. an empty string.
+	-- This means they are not SELECTed like in other editors/Snippet engines.
+	ls.parser.parse_snippet(
+		"lspsyn",
+		"Wow! This ${1:Stuff} really ${2:works. ${3:Well, a bit.}}"
+	),
 
-		-- When wordTrig is set to false, snippets may also expand inside other words.
-		ls.parser.parse_snippet(
-			{ trig = "te", wordTrig = false },
-			"${1:cond} ? ${2:true} : ${3:false}"
-		),
+	-- When wordTrig is set to false, snippets may also expand inside other words.
+	ls.parser.parse_snippet(
+		{ trig = "te", wordTrig = false },
+		"${1:cond} ? ${2:true} : ${3:false}"
+	),
 
-		-- When regTrig is set, trig is treated like a pattern, this snippet will expand after any number.
-		ls.parser.parse_snippet({ trig = "%d", regTrig = true }, "A Number!!"),
-		-- Using the condition, it's possible to allow expansion only in specific cases.
-		s("cond", {
-			t("will only expand in c-style comments"),
-		}, {
-			condition = function(line_to_cursor, matched_trigger, captures)
-				-- optional whitespace followed by //
-				return line_to_cursor:match("%s*//")
-			end,
-		}),
-		-- there's some built-in conditions in "luasnip.extras.expand_conditions".
-		s("cond2", {
-			t("will only expand at the beginning of the line"),
-		}, {
-			condition = conds.line_begin,
-		}),
-		-- The last entry of args passed to the user-function is the surrounding snippet.
-		s(
-			{ trig = "a%d", regTrig = true },
-			f(function(_, snip)
-				return "Triggered with " .. snip.trigger .. "."
-			end, {})
-		),
-		-- It's possible to use capture-groups inside regex-triggers.
-		s(
-			{ trig = "b(%d)", regTrig = true },
-			f(function(_, snip)
-				return "Captured Text: " .. snip.captures[1] .. "."
-			end, {})
-		),
-		s({ trig = "c(%d+)", regTrig = true }, {
-			t("will only expand for even numbers"),
-		}, {
-			condition = function(line_to_cursor, matched_trigger, captures)
-				return tonumber(captures[1]) % 2 == 0
-			end,
-		}),
-		-- Use a function to execute any shell command and print its text.
-		s("bash", f(bash, {}, "ls")),
-		-- Short version for applying String transformations using function nodes.
-		s("transform", {
-			i(1, "initial text"),
-			t({ "", "" }),
-			-- lambda nodes accept an l._1,2,3,4,5, which in turn accept any string transformations.
-			-- This list will be applied in order to the first node given in the second argument.
-			l(l._1:match("[^i]*$"):gsub("i", "o"):gsub(" ", "_"):upper(), 1),
-		}),
+	-- When regTrig is set, trig is treated like a pattern, this snippet will expand after any number.
+	ls.parser.parse_snippet({ trig = "%d", regTrig = true }, "A Number!!"),
+	-- Using the condition, it's possible to allow expansion only in specific cases.
+	s("cond", {
+		t("will only expand in c-style comments"),
+	}, {
+		condition = function(line_to_cursor, matched_trigger, captures)
+			-- optional whitespace followed by //
+			return line_to_cursor:match("%s*//")
+		end,
+	}),
+	-- there's some built-in conditions in "luasnip.extras.expand_conditions".
+	s("cond2", {
+		t("will only expand at the beginning of the line"),
+	}, {
+		condition = conds.line_begin,
+	}),
+	-- The last entry of args passed to the user-function is the surrounding snippet.
+	s(
+		{ trig = "a%d", regTrig = true },
+		f(function(_, snip)
+			return "Triggered with " .. snip.trigger .. "."
+		end, {})
+	),
+	-- It's possible to use capture-groups inside regex-triggers.
+	s(
+		{ trig = "b(%d)", regTrig = true },
+		f(function(_, snip)
+			return "Captured Text: " .. snip.captures[1] .. "."
+		end, {})
+	),
+	s({ trig = "c(%d+)", regTrig = true }, {
+		t("will only expand for even numbers"),
+	}, {
+		condition = function(line_to_cursor, matched_trigger, captures)
+			return tonumber(captures[1]) % 2 == 0
+		end,
+	}),
+	-- Use a function to execute any shell command and print its text.
+	s("bash", f(bash, {}, "ls")),
+	-- Short version for applying String transformations using function nodes.
+	s("transform", {
+		i(1, "initial text"),
+		t({ "", "" }),
+		-- lambda nodes accept an l._1,2,3,4,5, which in turn accept any string transformations.
+		-- This list will be applied in order to the first node given in the second argument.
+		l(l._1:match("[^i]*$"):gsub("i", "o"):gsub(" ", "_"):upper(), 1),
+	}),
 
-		s("transform2", {
-			i(1, "initial text"),
-			t("::"),
-			i(2, "replacement for e"),
-			t({ "", "" }),
-			-- Lambdas can also apply transforms USING the text of other nodes:
-			l(l._1:gsub("e", l._2), { 1, 2 }),
-		}),
-		s({ trig = "trafo(%d+)", regTrig = true }, {
-			-- env-variables and captures can also be used:
-			l(l.CAPTURE1:gsub("1", l.TM_FILENAME), {}),
-		}),
-		-- Set store_selection_keys = "<Tab>" (for example) in your
-		-- luasnip.config.setup() call to populate
-		-- TM_SELECTED_TEXT/SELECT_RAW/SELECT_DEDENT.
-		-- In this case: select a URL, hit Tab, then expand this snippet.
-		s("link_url", {
-			t('<a href="'),
-			f(function(_, snip)
-				-- TM_SELECTED_TEXT is a table to account for multiline-selections.
-				-- In this case only the first line is inserted.
-				return snip.env.TM_SELECTED_TEXT[1] or {}
-			end, {}),
-			t('">'),
-			i(1),
-			t("</a>"),
-			i(0),
-		}),
-		-- Shorthand for repeating the text in a given node.
-		s("repeat", { i(1, "text"), t({ "", "" }), rep(1) }),
-		-- Directly insert the ouput from a function evaluated at runtime.
-		s("part", p(os.date, "%Y")),
-		-- use matchNodes (`m(argnode, condition, then, else)`) to insert text
-		-- based on a pattern/function/lambda-evaluation.
-		-- It's basically a shortcut for simple functionNodes:
-		s("mat", {
-			i(1, { "sample_text" }),
-			t(": "),
-			m(1, "%d", "contains a number", "no number :("),
-		}),
-		-- The `then`-text defaults to the first capture group/the entire
-		-- match if there are none.
-		s("mat2", {
-			i(1, { "sample_text" }),
-			t(": "),
-			m(1, "[abc][abc][abc]"),
-		}),
-		-- It is even possible to apply gsubs' or other transformations
-		-- before matching.
-		s("mat3", {
-			i(1, { "sample_text" }),
-			t(": "),
-			m(
-				1,
-				l._1:gsub("[123]", ""):match("%d"),
-				"contains a number that isn't 1, 2 or 3!"
-			),
-		}),
-		-- `match` also accepts a function in place of the condition, which in
-		-- turn accepts the usual functionNode-args.
-		-- The condition is considered true if the function returns any
-		-- non-nil/false-value.
-		-- If that value is a string, it is used as the `if`-text if no if is explicitly given.
-		s("mat4", {
-			i(1, { "sample_text" }),
-			t(": "),
-			m(1, function(args)
-				-- args is a table of multiline-strings (as usual).
-				return (#args[1][1] % 2 == 0 and args[1]) or nil
-			end),
-		}),
-		-- The nonempty-node inserts text depending on whether the arg-node is
-		-- empty.
-		s("nempty", {
-			i(1, "sample_text"),
-			n(1, "i(1) is not empty!"),
-		}),
-		-- dynamic lambdas work exactly like regular lambdas, except that they
-		-- don't return a textNode, but a dynamicNode containing one insertNode.
-		-- This makes it easier to dynamically set preset-text for insertNodes.
-		s("dl1", {
-			i(1, "sample_text"),
-			t({ ":", "" }),
-			dl(2, l._1, 1),
-		}),
-		-- Obviously, it's also possible to apply transformations, just like lambdas.
-		s("dl2", {
-			i(1, "sample_text"),
-			i(2, "sample_text_2"),
-			t({ "", "" }),
-			dl(3, l._1:gsub("\n", " linebreak ") .. l._2, { 1, 2 }),
-		}),
-	},
-	java = {
-		-- Very long example for a java class.
-		s("fn", {
-			d(6, jdocsnip, { 2, 4, 5 }),
-			t({ "", "" }),
-			c(1, {
-				t("public "),
-				t("private "),
-			}),
-			c(2, {
-				t("void"),
-				t("String"),
-				t("char"),
-				t("int"),
-				t("double"),
-				t("boolean"),
-				i(nil, ""),
-			}),
-			t(" "),
-			i(3, "myFunc"),
-			t("("),
-			i(4),
-			t(")"),
-			c(5, {
-				t(""),
-				sn(nil, {
-					t({ "", " throws " }),
-					i(1),
-				}),
-			}),
-			t({ " {", "\t" }),
-			i(0),
-			t({ "", "}" }),
-		}),
-	},
-	tex = {
-		-- rec_ls is self-referencing. That makes this snippet 'infinite' eg. have as many
-		-- \item as necessary by utilizing a choiceNode.
-		s("ls", {
-			t({ "\\begin{itemize}", "\t\\item " }),
-			i(1),
-			d(2, rec_ls, {}),
-			t({ "", "\\end{itemize}" }),
-		}),
-	},
-}
+	s("transform2", {
+		i(1, "initial text"),
+		t("::"),
+		i(2, "replacement for e"),
+		t({ "", "" }),
+		-- Lambdas can also apply transforms USING the text of other nodes:
+		l(l._1:gsub("e", l._2), { 1, 2 }),
+	}),
+	s({ trig = "trafo(%d+)", regTrig = true }, {
+		-- env-variables and captures can also be used:
+		l(l.CAPTURE1:gsub("1", l.TM_FILENAME), {}),
+	}),
+	-- Set store_selection_keys = "<Tab>" (for example) in your
+	-- luasnip.config.setup() call to populate
+	-- TM_SELECTED_TEXT/SELECT_RAW/SELECT_DEDENT.
+	-- In this case: select a URL, hit Tab, then expand this snippet.
+	s("link_url", {
+		t('<a href="'),
+		f(function(_, snip)
+			-- TM_SELECTED_TEXT is a table to account for multiline-selections.
+			-- In this case only the first line is inserted.
+			return snip.env.TM_SELECTED_TEXT[1] or {}
+		end, {}),
+		t('">'),
+		i(1),
+		t("</a>"),
+		i(0),
+	}),
+	-- Shorthand for repeating the text in a given node.
+	s("repeat", { i(1, "text"), t({ "", "" }), rep(1) }),
+	-- Directly insert the ouput from a function evaluated at runtime.
+	s("part", p(os.date, "%Y")),
+	-- use matchNodes (`m(argnode, condition, then, else)`) to insert text
+	-- based on a pattern/function/lambda-evaluation.
+	-- It's basically a shortcut for simple functionNodes:
+	s("mat", {
+		i(1, { "sample_text" }),
+		t(": "),
+		m(1, "%d", "contains a number", "no number :("),
+	}),
+	-- The `then`-text defaults to the first capture group/the entire
+	-- match if there are none.
+	s("mat2", {
+		i(1, { "sample_text" }),
+		t(": "),
+		m(1, "[abc][abc][abc]"),
+	}),
+	-- It is even possible to apply gsubs' or other transformations
+	-- before matching.
+	s("mat3", {
+		i(1, { "sample_text" }),
+		t(": "),
+		m(
+			1,
+			l._1:gsub("[123]", ""):match("%d"),
+			"contains a number that isn't 1, 2 or 3!"
+		),
+	}),
+	-- `match` also accepts a function in place of the condition, which in
+	-- turn accepts the usual functionNode-args.
+	-- The condition is considered true if the function returns any
+	-- non-nil/false-value.
+	-- If that value is a string, it is used as the `if`-text if no if is explicitly given.
+	s("mat4", {
+		i(1, { "sample_text" }),
+		t(": "),
+		m(1, function(args)
+			-- args is a table of multiline-strings (as usual).
+			return (#args[1][1] % 2 == 0 and args[1]) or nil
+		end),
+	}),
+	-- The nonempty-node inserts text depending on whether the arg-node is
+	-- empty.
+	s("nempty", {
+		i(1, "sample_text"),
+		n(1, "i(1) is not empty!"),
+	}),
+	-- dynamic lambdas work exactly like regular lambdas, except that they
+	-- don't return a textNode, but a dynamicNode containing one insertNode.
+	-- This makes it easier to dynamically set preset-text for insertNodes.
+	s("dl1", {
+		i(1, "sample_text"),
+		t({ ":", "" }),
+		dl(2, l._1, 1),
+	}),
+	-- Obviously, it's also possible to apply transformations, just like lambdas.
+	s("dl2", {
+		i(1, "sample_text"),
+		i(2, "sample_text_2"),
+		t({ "", "" }),
+		dl(3, l._1:gsub("\n", " linebreak ") .. l._2, { 1, 2 }),
+	}),
+})
 
--- autotriggered snippets have to be defined in a separate table, luasnip.autosnippets.
-ls.autosnippets = {
-	all = {
-		s("autotrigger", {
-			t("autosnippet"),
+ls.add_snippets("java", {
+	-- Very long example for a java class.
+	s("fn", {
+		d(6, jdocsnip, { 2, 4, 5 }),
+		t({ "", "" }),
+		c(1, {
+			t("public "),
+			t("private "),
 		}),
-	},
-}
+		c(2, {
+			t("void"),
+			t("String"),
+			t("char"),
+			t("int"),
+			t("double"),
+			t("boolean"),
+			i(nil, ""),
+		}),
+		t(" "),
+		i(3, "myFunc"),
+		t("("),
+		i(4),
+		t(")"),
+		c(5, {
+			t(""),
+			sn(nil, {
+				t({ "", " throws " }),
+				i(1),
+			}),
+		}),
+		t({ " {", "\t" }),
+		i(0),
+		t({ "", "}" }),
+	}),
+})
+
+ls.add_snippets("tex", {
+	-- rec_ls is self-referencing. That makes this snippet 'infinite' eg. have as many
+	-- \item as necessary by utilizing a choiceNode.
+	s("ls", {
+		t({ "\\begin{itemize}", "\t\\item " }),
+		i(1),
+		d(2, rec_ls, {}),
+		t({ "", "\\end{itemize}" }),
+	}),
+})
+
+-- set type to "autosnippets" for adding autotriggered snippets.
+ls.add_snippets("all", {
+	s("autotrigger", {
+		t("autosnippet"),
+	}),
+}, {
+	type = "autosnippets",
+})
 
 -- in a lua file: search lua-, then c-, then all-snippets.
 ls.filetype_extend("lua", { "c" })
@@ -519,8 +512,6 @@ ls.filetype_set("cpp", { "c" })
 
 -- Beside defining your own snippets you can also load snippets from "vscode-like" packages
 -- that expose snippets in json files, for example <https://github.com/rafamadriz/friendly-snippets>.
--- Mind that this will extend  `ls.snippets` so you need to do it after your own snippets or you
--- will need to extend the table yourself instead of setting a new one.
 
 require("luasnip.loaders.from_vscode").load({ include = { "python" } }) -- Load only python snippets
 
@@ -534,9 +525,9 @@ require("luasnip.loaders.from_vscode").lazy_load() -- You can pass { paths = "./
 -- You can also use snippets in snipmate format, for example <https://github.com/honza/vim-snippets>.
 -- The usage is similar to vscode.
 
--- One peculiarity of honza/vim-snippets is that the file with the global snippets is _.snippets, so global snippets
--- are stored in `ls.snippets._`.
--- We need to tell luasnip that "_" contains global snippets:
+-- One peculiarity of honza/vim-snippets is that the file containing global
+-- snippets is _.snippets, so we need to tell luasnip that the filetype "_"
+-- contains global snippets:
 ls.filetype_extend("all", { "_" })
 
 require("luasnip.loaders.from_snipmate").load({ include = { "c" } }) -- Load only python snippets

--- a/Examples/snippets.lua
+++ b/Examples/snippets.lua
@@ -530,10 +530,14 @@ require("luasnip.loaders.from_vscode").lazy_load() -- You can pass { paths = "./
 -- contains global snippets:
 ls.filetype_extend("all", { "_" })
 
-require("luasnip.loaders.from_snipmate").load({ include = { "c" } }) -- Load only python snippets
+require("luasnip.loaders.from_snipmate").load({ include = { "c" } }) -- Load only snippets for c.
 
 require("luasnip.loaders.from_snipmate").load({ path = { "./my-snippets" } }) -- Load snippets from my-snippets folder
 -- If path is not specified, luasnip will look for the `snippets` directory in rtp (for custom-snippet probably
 -- `~/.config/nvim/snippets`).
 
 require("luasnip.loaders.from_snipmate").lazy_load() -- Lazy loading
+
+-- see DOC.md/LUA SNIPPETS LOADER for some details.
+require("luasnip.loaders.from_lua").load({ include = { "c" } })
+require("luasnip.loaders.from_lua").lazy_load({ include = { "all", "cpp" } })

--- a/README.md
+++ b/README.md
@@ -195,11 +195,11 @@ For nvim-cmp, it is also possible to follow the [example recommendation](https:/
         ```
     Again, there are some [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L517) and an entry in the [docs](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#snipmate-snippets-loader)
 - **Lua**: Add the snippets by calling `require("luasnip").add_snippets(filetype, snippets)`. An example for this can be found [here](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L167).  
-This can also be done much better (one snippet-file per filetype+command for editing the current filetype) than in the example, see [this entry in the wiki](https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#split-up-snippets-by-filetype-load-on-demand-and-reload-after-change-first-iteration).  
+This can also be done much better (one snippet-file per filetype+command for editing the current filetype+reload on edit) than in the example by using the [loader for lua](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader)
 There's also a repository collecting snippets for various languages, [molleweide/LuaSnip-snippets.nvim](https://github.com/molleweide/LuaSnip-snippets.nvim)
 
 ## Docs and Examples
-Check [`DOC.md`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md) (or `:help luasnip`) for a short overview and in-depth explanations of the different nodes.
+Check [`DOC.md`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md) (or `:help luasnip`) for a short overview and in-depth explanations of the different nodes and available API.
 I highly recommend looking into (or better yet, `:luafile`ing) [`Examples/snippets.lua`](https://github.com/L3MON4D3/LuaSnip/blob/master/Examples/snippets.lua) before writing snippets in lua.  
 The [Wiki](https://github.com/L3MON4D3/LuaSnip/wiki) contains some pretty useful extensions to Luasnip.
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ For nvim-cmp, it is also possible to follow the [example recommendation](https:/
         	$0
         ```
     Again, there are some [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L517) and an entry in the [docs](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#snipmate-snippets-loader)
-- **Lua**: Add the snippets directly to `require("luasnip").snippets.<filetype>`. An example for this can be found [here](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L167).  
+- **Lua**: Add the snippets by calling `require("luasnip").add_snippets(filetype, snippets)`. An example for this can be found [here](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L167).  
 This can also be done much better (one snippet-file per filetype+command for editing the current filetype) than in the example, see [this entry in the wiki](https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#split-up-snippets-by-filetype-load-on-demand-and-reload-after-change-first-iteration).  
 There's also a repository collecting snippets for various languages, [molleweide/LuaSnip-snippets.nvim](https://github.com/molleweide/LuaSnip-snippets.nvim)
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1436,15 +1436,18 @@ empty the snippets table and the caches of the lazy_load.
     table containing lists of snippets, the keys are corresponding filetypes.
     `opts` may contain the following keys:
     - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
-- `clean_invalidated(opts: table or nil)`: clean invalidated snippets from
-    internal snippet storage. Invalidated snippets are still stored, it might be
-    useful to actually remove them, as they still have to be iterated during
+- `clean_invalidated(opts: table or nil) -> bool`: clean invalidated snippets
+    from internal snippet storage. Invalidated snippets are still stored, it might
+    be useful to actually remove them, as they still have to be iterated during
     expansion.
+    It will be necessary to call `ls.refresh_notify()` after invalidating snippets.
     `opts` may contain:
     - `inv_limit`: how many invalidated snippets are allowed. If the number of
         invalid snippets doesn’t exceed this threshold, they are not yet cleaned up.
         A small number of invalidated snippets (<100) probably doesn’t affect runtime
         at all, whereas recreating the internal snippet storage might.
+    The function returns whether snippets were removed, which may be used to only
+    conditionally `refresh_notify`.
 - `in_snippet()`: returns true if the cursor is inside the current snippet.
 - `jumpable(direction)`: returns true if the current node has a next(`direction`
     = 1) or previous(`direction` = -1), eg. whether it’s possible to jump forward

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -23,13 +23,14 @@ Table of Contents                                  *luasnip-table-of-contents*
 15. VARIABLES                                              |luasnip-variables|
 16. VSCODE SNIPPETS LOADER                    |luasnip-vscode-snippets-loader|
 17. SNIPMATE SNIPPETS LOADER                |luasnip-snipmate-snippets-loader|
-18. SNIPPETPROXY                                        |luasnip-snippetproxy|
-19. EXT_OPTS                                                |luasnip-ext_opts|
-20. DOCSTRING                                              |luasnip-docstring|
-21. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
-22. EVENTS                                                    |luasnip-events|
-23. CLEANUP                                                  |luasnip-cleanup|
-24. API-REFERENCE                                      |luasnip-api-reference|
+18. LUA SNIPPETS LOADER                          |luasnip-lua-snippets-loader|
+19. SNIPPETPROXY                                        |luasnip-snippetproxy|
+20. EXT_OPTS                                                |luasnip-ext_opts|
+21. DOCSTRING                                              |luasnip-docstring|
+22. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
+23. EVENTS                                                    |luasnip-events|
+24. CLEANUP                                                  |luasnip-cleanup|
+25. API-REFERENCE                                      |luasnip-api-reference|
 
 >
                 __                       ____
@@ -974,7 +975,7 @@ As luasnip is capable of loading the same format of plugins as vscode, it also
 includes an easy way for loading those automatically. You just have to call:
 
 >
-        require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
 <
 
 
@@ -996,7 +997,7 @@ your snippets or you will have to extend the table as well.
 Another way of using the loader is making it lazily
 
 >
-        require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
 <
 
 
@@ -1024,7 +1025,7 @@ As the snipmate snippet format is fundamentally the same as vscode, it can also
 be loaded.
 
 >
-        require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
 <
 
 
@@ -1054,7 +1055,7 @@ snippets.
 Lazy loading is also available with the snipmate-loader.
 
 >
-        require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
 <
 
 
@@ -1070,7 +1071,48 @@ Here is a summary of the differences from the original snipmate format.
 
 
 ==============================================================================
-18. SNIPPETPROXY                                        *luasnip-snippetproxy*
+18. LUA SNIPPETS LOADER                          *luasnip-lua-snippets-loader*
+
+Instead of adding all snippets via `add_snippets`, it’s possible to store
+them in separate files (each for one filetype) and load all of those.
+
+For this, the files need to be
+
+
+- in a single directory. The directory may be passed directly to `load()`, or it
+    can be named `luasnippets` and in the `runtimepath`, in which case it will be
+    automatically detected.
+- named `<filetype>.lua`.
+- return two lists of snippets (either may be `nil`). The snippets in the first
+    are regular snippets for `<filetype>`, the ones in the second are autosnippets
+    (make sure they are enabled if this table is used).
+
+
+As defining all of the snippet-constructors (`s`, `c`, `t`, …) in every file
+is rather cumbersome, luasnip will bring some globals into scope for executing
+these files. By default the names from `Examples/snippets.lua` will be used,
+but it’s possible to customize them by setting `snip_env` in `setup`.
+
+These collections can be loaded directly
+(`require("luasnip.loaders.from_lua").load(opts)`) or lazily
+(`require("luasnip.loaders.from_lua.lazy_load(opts)")`).
+
+lua-`opts` may contain the same keys as vscode-`opts`, but here `include` and
+`exclude` can be used in `lazy_load`.
+
+Apart from loading, `from_lua` also exposes functions to edit files associated
+with the currently active filetypes, which could be called via an command, for
+example:
+
+>
+    command! LuaSnipEdit :lua require("luasnip.loaders.from_lua").edit_snippet_files()
+<
+
+
+Once loaded, files will be reloaded on save (`BufWritePost`).
+
+==============================================================================
+19. SNIPPETPROXY                                        *luasnip-snippetproxy*
 
 `SnippetProxy` is used internally to alleviate the upfront-cost of loading
 snippets from eg. a snipmate-library or a vscode-package. This is achieved by
@@ -1094,7 +1136,7 @@ This will parse the snippet on startup…
 
 
 ==============================================================================
-19. EXT_OPTS                                                *luasnip-ext_opts*
+20. EXT_OPTS                                                *luasnip-ext_opts*
 
 `ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
 extmarks used for marking node-positions, either globally, per-snippet or
@@ -1293,7 +1335,7 @@ Here the highlight of an insertNode nested directly inside a choiceNode is
 always visible on top of it.
 
 ==============================================================================
-20. DOCSTRING                                              *luasnip-docstring*
+21. DOCSTRING                                              *luasnip-docstring*
 
 Snippet-docstrings can be queried using `snippet:get_docstring()`. The function
 evaluates the snippet as if it was expanded regularly, which can be problematic
@@ -1343,7 +1385,7 @@ Other issues will have to be handled manually by checking the contents of eg.
 
 
 ==============================================================================
-21. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
+22. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
 
 Although generation of docstrings is pretty fast, it’s preferable to not redo
 it as long as the snippets haven’t changed. Using
@@ -1360,7 +1402,7 @@ The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 `~/.cache/nvim/luasnip/docstrings.json`).
 
 ==============================================================================
-22. EVENTS                                                    *luasnip-events*
+23. EVENTS                                                    *luasnip-events*
 
 Upon leaving/entering nodes or changing a choice an event is triggered: `User
 Luasnip<Node>{Enter,Leave}`, where `<Node>` is the name of a node in
@@ -1377,14 +1419,14 @@ be printing eg. the nodes’ text after entering:
 
 
 ==============================================================================
-23. CLEANUP                                                  *luasnip-cleanup*
+24. CLEANUP                                                  *luasnip-cleanup*
 
 The function ls.cleanup() triggers the `LuasnipCleanup` user-event, that you
 can listen to do some kind of cleaning in your own snippets, by default it will
 empty the snippets table and the caches of the lazy_load.
 
 ==============================================================================
-24. API-REFERENCE                                      *luasnip-api-reference*
+25. API-REFERENCE                                      *luasnip-api-reference*
 
 `require("luasnip")`:
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1431,6 +1431,11 @@ empty the snippets table and the caches of the lazy_load.
 `require("luasnip")`:
 
 
+- `add_snippets(ft:string or nil, snippets:list or table, opts:table or nil)`:
+    Makes `snippets` available in `ft`. If `ft` is `nil`, `snippets` should be a
+    table containing lists of snippets, the keys are corresponding filetypes.
+    `opts` may contain the following keys:
+    - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
 - `in_snippet()`: returns true if the cursor is inside the current snippet.
 - `jumpable(direction)`: returns true if the current node has a next(`direction`
     = 1) or previous(`direction` = -1), eg. whether it’s possible to jump forward

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.5.0            Last change: 2022 March 19
+*luasnip.txt*            For NVIM v0.5.0            Last change: 2022 March 20
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -1436,6 +1436,15 @@ empty the snippets table and the caches of the lazy_load.
     table containing lists of snippets, the keys are corresponding filetypes.
     `opts` may contain the following keys:
     - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
+- `clean_invalidated(opts: table or nil)`: clean invalidated snippets from
+    internal snippet storage. Invalidated snippets are still stored, it might be
+    useful to actually remove them, as they still have to be iterated during
+    expansion.
+    `opts` may contain:
+    - `inv_limit`: how many invalidated snippets are allowed. If the number of
+        invalid snippets doesn’t exceed this threshold, they are not yet cleaned up.
+        A small number of invalidated snippets (<100) probably doesn’t affect runtime
+        at all, whereas recreating the internal snippet storage might.
 - `in_snippet()`: returns true if the cursor is inside the current snippet.
 - `jumpable(direction)`: returns true if the current node has a next(`direction`
     = 1) or previous(`direction` = -1), eg. whether it’s possible to jump forward

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.5.0            Last change: 2022 March 18
+*luasnip.txt*            For NVIM v0.5.0            Last change: 2022 March 19
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -338,7 +338,7 @@ The first parameter of `f` is the function. Its parameters are:
 1. A table of the text of currently contained in the argnodes. (eg. `{{line1},
 {line1, line2}}`). The snippet-indent will be removed from all lines following
 the first.
-1. The immediate parent of the `functionNode`. It is included here as it allows
+2. The immediate parent of the `functionNode`. It is included here as it allows
 easy access to anything that could be useful in functionNodes (ie.
 `parent.snippet.env` or `parent.snippet.captures`, which contains capture
 groups of regex-triggered snippets). In most cases `parent.env` works, but if a
@@ -551,7 +551,7 @@ argnodes:table of nodes, opts: table)`:
 
 
 1. `position`: just like all jumpable nodes, when this node will be jumped into.
-1. `function`: `fn(args, parent, old_state, user_args1, ..., user_argsn) -> snippetNode`
+2. `function`: `fn(args, parent, old_state, user_args1, ..., user_argsn) -> snippetNode`
 This function is called when the argnodes’ text changes. It generates and
 returns (wrapped inside a `snippetNode`) the nodes that should be inserted
 at the dynamicNodes place.
@@ -572,11 +572,11 @@ at the dynamicNodes place.
     The second example below illustrates the usage of `old_state`.
 - `user_args1, ..., user_argsn`: passed through from `dynamicNode`-opts.
 
-1. `argnodes`: Indices of nodes the dynamicNode depends on: if any of these trigger an
+3. `argnodes`: Indices of nodes the dynamicNode depends on: if any of these trigger an
 update, the `dynamicNode`s’ function will be executed and the result inserted at
 the `dynamicNodes` place.
 Can be a single index or a table of indices.
-1. `opts`: Just like `functionNode`, `dynamicNode` also accepts `user_args` in
+4. `opts`: Just like `functionNode`, `dynamicNode` also accepts `user_args` in
 addition to options common to all nodes.
 
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -6,6 +6,7 @@ Table of Contents                                  *luasnip-table-of-contents*
 1. BASICS                                                     |luasnip-basics|
 2. NODE                                                         |luasnip-node|
 3. SNIPPETS                                                 |luasnip-snippets|
+  - Api:                                                        |luasnip-api:|
 4. TEXTNODE                                                 |luasnip-textnode|
 5. INSERTNODE                                             |luasnip-insertnode|
 6. FUNCTIONNODE                                         |luasnip-functionnode|
@@ -195,6 +196,16 @@ Additionally, the string that was used to trigger the snippet is stored in
 `snippet.trigger`. These variables/tables are primarily useful in
 dynamic/functionNodes, where the snippet can be accessed through the immediate
 parent (`parent.snippet`), which is passed to the function.
+
+API:                                                            *luasnip-api:*
+
+
+- `invalidate()`: call this method to effectively remove the snippet. The
+    snippet will no longer be able to expand via `expand` or `expand_auto`. It
+    will also be hidden from lists (at least if the plugin creating the list
+    respects the `hidden`-key), but it might be necessary to call
+    `ls.refresh_notify(ft)` after invalidating snippets.
+
 
 ==============================================================================
 4. TEXTNODE                                                 *luasnip-textnode*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -82,19 +82,17 @@ nodes:table)`-function. It is explained in more detail in |luasnip-snippets|,
 but the gist is that it creates a snippet that contains the nodes specified in
 `nodes`, which will be inserted into a buffer if the text before the cursor
 matches `trigger` when `expand` is called. The snippets for a given filetype
-have to be appended to the `ls.snippets.<filetype>`-table. Snippets that should
-be accessible globally (in all filetypes) will be read from the
-`ls.snippets.all`-table:
+have to be added to luasnip via `ls.add_snippets(filetype, snippets)`. Snippets
+that should be accessible globally (in all filetypes) have to be added to the
+special filetype `all`.
 
 >
-    ls.snippets = {
-        all = {
-            s("ternary", {
-                -- equivalent to "${1:cond} ? ${2:then} : ${3:else}"
-                i(1, "cond"), t(" ? "), i(2, "then"), t(" : "), i(3, "else")
-            })
-        }
-    }
+    ls.add_snippets("all", {
+        s("ternary", {
+            -- equivalent to "${1:cond} ? ${2:then} : ${3:else}"
+            i(1, "cond"), t(" ? "), i(2, "then"), t(" : "), i(3, "else")
+        })
+    })
 <
 
 
@@ -1338,13 +1336,14 @@ Other issues will have to be handled manually by checking the contents of eg.
 
 Although generation of docstrings is pretty fast, it’s preferable to not redo
 it as long as the snippets haven’t changed. Using
-`ls.store_snippet_docstrings(ls.snippets)` and its counterpart
-`ls.load_snippet_docstrings(ls.snippets)`, they may be serialized from or
-deserialized into the snippets. Both functions accept a table structured like
-`ls.snippets`, ie. `{ft1={snippets}, ft2={snippets}}`. `load` should be called
-before any of the `loader`-functions as snippets loaded from vscode-style
-packages already have their `docstring` set (`docstrings` wouldn’t be
-overwritten, but there’d be unnecessary calls).
+`ls.store_snippet_docstrings(snippets)` and its counterpart
+`ls.load_snippet_docstrings(snippets)`, they may be serialized from or
+deserialized into the snippets. Both functions accept a table structsured like
+this: `{ft1={snippets}, ft2={snippets}}`. Such a table containing all snippets
+can be obtained via `ls.get_snippets()`. `load` should be called before any of
+the `loader`-functions as snippets loaded from vscode-style packages already
+have their `docstring` set (`docstrings` wouldn’t be overwritten, but
+there’d be unnecessary calls).
 
 The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 `~/.cache/nvim/luasnip/docstrings.json`).

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1436,6 +1436,12 @@ empty the snippets table and the caches of the lazy_load.
     table containing lists of snippets, the keys are corresponding filetypes.
     `opts` may contain the following keys:
     - `type`: type of `snippets`, `"snippets"` or `"autosnippets"`.
+    - `key`: Key that identifies snippets added via this call.
+        If `add_snippets` is called with a key that was already used, the snippets
+        from that previous call will be removed.
+        This can be used to reload snippets: pass an unique key to each
+        `add_snippets` and just re-do the `add_snippets`-call when the snippets have
+        changed.
 - `clean_invalidated(opts: table or nil) -> bool`: clean invalidated snippets
     from internal snippet storage. Invalidated snippets are still stored, it might
     be useful to actually remove them, as they still have to be iterated during

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -1,7 +1,7 @@
 local types = require("luasnip.util.types")
-local util = require("luasnip.util.util")
 local ext_util = require("luasnip.util.ext_opts")
 local ft_functions = require("luasnip.extras.filetype_functions")
+local session = require("luasnip.session")
 
 local defaults = {
 	history = false,
@@ -82,9 +82,9 @@ local defaults = {
 
 -- declare here to use in set_config.
 local c
+session.config = vim.deepcopy(defaults)
 
 c = {
-	config = vim.deepcopy(defaults),
 	set_config = function(user_config)
 		local conf = vim.deepcopy(defaults)
 
@@ -100,7 +100,7 @@ c = {
 			conf[k] = v
 		end
 
-		c.config = conf
+		session.config = conf
 		c._setup()
 	end,
 
@@ -117,23 +117,23 @@ c = {
 			"Remove buffers' nodes on deletion+wipeout.
 			autocmd BufDelete,BufWipeout * lua current_nodes = require("luasnip").session.current_nodes if current_nodes then current_nodes[tonumber(vim.fn.expand("<abuf>"))] = nil end
 		]]
-					.. (c.config.enable_autosnippets and [[
+					.. (session.config.enable_autosnippets and [[
 			autocmd InsertCharPre * lua Luasnip_just_inserted = true
 			autocmd TextChangedI,TextChangedP * lua if Luasnip_just_inserted then require("luasnip").expand_auto() Luasnip_just_inserted=nil end
 		]] or "")
 					.. [[
 		augroup END
 		]],
-				c.config.delete_check_events,
-				c.config.updateevents,
-				c.config.region_check_events
+				session.config.delete_check_events,
+				session.config.updateevents,
+				session.config.region_check_events
 			)
 		)
-		if c.config.store_selection_keys then
+		if session.config.store_selection_keys then
 			vim.cmd(
 				string.format(
 					[[xnoremap <silent>  %s  :lua require('luasnip.util.util').store_selection()<cr>gv"_s]],
-					c.config.store_selection_keys
+					session.config.store_selection_keys
 				)
 			)
 		end

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -78,6 +78,30 @@ local defaults = {
 	parser_nested_assembler = nil,
 	-- Function expected to return a list of filetypes (or empty list)
 	ft_func = ft_functions.from_filetype,
+	-- globals injected into luasnippet-files.
+	snip_env = {
+		s = require("luasnip.nodes.snippet").S,
+		sn = require("luasnip.nodes.snippet").SN,
+		t = require("luasnip.nodes.textNode").T,
+		f = require("luasnip.nodes.functionNode").F,
+		i = require("luasnip.nodes.insertNode").I,
+		c = require("luasnip.nodes.choiceNode").C,
+		d = require("luasnip.nodes.dynamicNode").D,
+		r = require("luasnip.nodes.restoreNode").R,
+		l = require("luasnip.extras").lambda,
+		rep = require("luasnip.extras").rep,
+		p = require("luasnip.extras").partial,
+		m = require("luasnip.extras").match,
+		n = require("luasnip.extras").nonempty,
+		dl = require("luasnip.extras").dynamic_lambda,
+		fmt = require("luasnip.extras.fmt").fmt,
+		fmta = require("luasnip.extras.fmt").fmta,
+		conds = require("luasnip.extras.expand_conditions"),
+		types = require("luasnip.util.types"),
+		events = require("luasnip.util.events"),
+		parse = require("luasnip.util.parser").parse_snippet,
+		ai = require("luasnip.nodes.absolute_indexer"),
+	},
 }
 
 -- declare here to use in set_config.

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -522,6 +522,37 @@ local function refresh_notify(ft)
 	vim.cmd([[doautocmd User LuasnipSnippetsAdded]])
 end
 
+-- opts.type can be "snippets" or "autosnippets".
+local function add_snippets(ft, snippets, opts)
+	opts = opts or {}
+	local snippet_type = opts.type or "snippets"
+	if not ls[snippet_type][ft] then
+		ls[snippet_type][ft] = {}
+	end
+	local indx = #ls[snippet_type][ft]
+	for _, snip in ipairs(snippets) do
+		ls[snippet_type][ft][indx + 1] = snip
+		indx = indx + 1
+	end
+end
+
+-- ft:
+-- * string: interpreted as filetype, return corresponding snippets.
+-- * nil: return snippets for all filetypes:
+-- {
+-- 	lua = {...},
+-- 	cpp = {...},
+-- 	...
+-- }
+-- opts: optional args, can contain `type`, either "snippets" or "autosnippets".
+local function get_snippets(ft, opts)
+	local snippet_type = opts.type or "snippets"
+	if not ft then
+		return ls[snippet_type]
+	end
+	return ls[snippet_type][ft]
+end
+
 ls = {
 	expand_or_jumpable = expand_or_jumpable,
 	expand_or_locally_jumpable = expand_or_locally_jumpable,
@@ -547,6 +578,8 @@ ls = {
 	unlink_current_if_deleted = unlink_current_if_deleted,
 	filetype_extend = filetype_extend,
 	filetype_set = filetype_set,
+	add_snippets = add_snippets,
+	get_snippets = get_snippets,
 	s = snip_mod.S,
 	sn = snip_mod.SN,
 	t = require("luasnip.nodes.textNode").T,

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -38,6 +38,26 @@ local function match_snippet(line, snippet_table)
 	return nil
 end
 
+-- ft:
+-- * string: interpreted as filetype, return corresponding snippets.
+-- * nil: return snippets for all filetypes:
+-- {
+-- 	lua = {...},
+-- 	cpp = {...},
+-- 	...
+-- }
+-- opts: optional args, can contain `type`, either "snippets" or "autosnippets".
+--
+-- return table, may be empty.
+local function get_snippets(ft, opts)
+	opts = opts or {}
+	local snippet_type = opts.type or "snippets"
+	if not ft then
+		return ls[snippet_type] or {}
+	end
+	return ls[snippet_type][ft] or {}
+end
+
 local function get_context(snip)
 	return {
 		name = snip.name,
@@ -53,12 +73,11 @@ local function available()
 	local res = {}
 	for _, ft in ipairs(fts) do
 		res[ft] = {}
-		for _, snippet_table in pairs({ ls.snippets, ls.autosnippets }) do
-			if snippet_table[ft] then
-				for _, snip in ipairs(snippet_table[ft]) do
-					table.insert(res[ft], get_context(snip))
-				end
-			end
+		for _, snip in ipairs(get_snippets(ft)) do
+			table.insert(res[ft], get_context(snip))
+		end
+		for _, snip in ipairs(get_snippets(ft, { type = "autosnippets" })) do
+			table.insert(res[ft], get_context(snip))
 		end
 	end
 	return res
@@ -534,23 +553,6 @@ local function add_snippets(ft, snippets, opts)
 		ls[snippet_type][ft][indx + 1] = snip
 		indx = indx + 1
 	end
-end
-
--- ft:
--- * string: interpreted as filetype, return corresponding snippets.
--- * nil: return snippets for all filetypes:
--- {
--- 	lua = {...},
--- 	cpp = {...},
--- 	...
--- }
--- opts: optional args, can contain `type`, either "snippets" or "autosnippets".
-local function get_snippets(ft, opts)
-	local snippet_type = opts.type or "snippets"
-	if not ft then
-		return ls[snippet_type]
-	end
-	return ls[snippet_type][ft]
 end
 
 ls = {

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -74,10 +74,14 @@ local function available()
 	for _, ft in ipairs(fts) do
 		res[ft] = {}
 		for _, snip in ipairs(get_snippets(ft)) do
-			table.insert(res[ft], get_context(snip))
+			if not snip.invalidated then
+				table.insert(res[ft], get_context(snip))
+			end
 		end
 		for _, snip in ipairs(get_snippets(ft, { type = "autosnippets" })) do
-			table.insert(res[ft], get_context(snip))
+			if not snip.invalidated then
+				table.insert(res[ft], get_context(snip))
+			end
 		end
 	end
 	return res

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -544,14 +544,22 @@ end
 -- opts.type can be "snippets" or "autosnippets".
 local function add_snippets(ft, snippets, opts)
 	opts = opts or {}
+
 	local snippet_type = opts.type or "snippets"
-	if not ls[snippet_type][ft] then
-		ls[snippet_type][ft] = {}
-	end
-	local indx = #ls[snippet_type][ft]
-	for _, snip in ipairs(snippets) do
-		ls[snippet_type][ft][indx + 1] = snip
-		indx = indx + 1
+
+	if not ft then
+		for ft_, ft_snippets in pairs(snippets) do
+			add_snippets(ft_, ft_snippets, opts)
+		end
+	else
+		if not ls[snippet_type][ft] then
+			ls[snippet_type][ft] = {}
+		end
+		local indx = #ls[snippet_type][ft]
+		for _, snip in ipairs(snippets) do
+			ls[snippet_type][ft][indx + 1] = snip
+			indx = indx + 1
+		end
 	end
 end
 

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -567,6 +567,32 @@ local function setup_snip_env()
 	setfenv(2, vim.tbl_extend("force", _G, session.config.snip_env))
 end
 
+local function clean_invalidated(opts)
+	opts = opts or {}
+
+	if opts.inv_limit then
+		if session.invalidated_count <= opts.inv_limit then
+			return
+		end
+	end
+
+	local new_snippets = {}
+	for ft, snippets in pairs(ls.snippets) do
+		new_snippets[ft] = {}
+		local indx = 1
+		for _, snippet in ipairs(snippets) do
+			if not snippet.invalidated then
+				new_snippets[ft][indx] = snippet
+				indx = indx + 1
+			end
+		end
+	end
+
+	ls.snippets = new_snippets
+
+	session.invalidated_count = 0
+end
+
 ls = {
 	expand_or_jumpable = expand_or_jumpable,
 	expand_or_locally_jumpable = expand_or_locally_jumpable,
@@ -595,6 +621,7 @@ ls = {
 	add_snippets = add_snippets,
 	get_snippets = get_snippets,
 	setup_snip_env = setup_snip_env,
+	clean_invalidated = clean_invalidated,
 	s = snip_mod.S,
 	sn = snip_mod.SN,
 	t = require("luasnip.nodes.textNode").T,

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -605,12 +605,19 @@ local function add_snippets(ft, snippets, opts)
 	end
 
 	if not ft then
+		-- not the cleanest implementation.
 		if opts.key then
 			ls.session.by_key[opts.key] = {}
-		end
-		for ft_, ft_snippets in pairs(snippets) do
-			vim.list_extend(ls[snippet_type][ft_], ft_snippets)
-			vim.list_extend(ls.session.by_key[opts.key], ft_snippets)
+			for ft_, ft_snippets in pairs(snippets) do
+				ls[snippet_type][ft_] = ls[snippet_type][ft_] or {}
+				vim.list_extend(ls[snippet_type][ft_], ft_snippets)
+				vim.list_extend(ls.session.by_key[opts.key], ft_snippets)
+			end
+		else
+			for ft_, ft_snippets in pairs(snippets) do
+				ls[snippet_type][ft_] = ls[snippet_type][ft_] or {}
+				vim.list_extend(ls[snippet_type][ft_], ft_snippets)
+			end
 		end
 	else
 		ls[snippet_type][ft] = ls[snippet_type][ft] or {}

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -555,6 +555,10 @@ local function add_snippets(ft, snippets, opts)
 	end
 end
 
+local function setup_snip_env()
+	setfenv(2, vim.tbl_extend("force", _G, session.config.snip_env))
+end
+
 ls = {
 	expand_or_jumpable = expand_or_jumpable,
 	expand_or_locally_jumpable = expand_or_locally_jumpable,
@@ -582,6 +586,7 @@ ls = {
 	filetype_set = filetype_set,
 	add_snippets = add_snippets,
 	get_snippets = get_snippets,
+	setup_snip_env = setup_snip_env,
 	s = snip_mod.S,
 	sn = snip_mod.SN,
 	t = require("luasnip.nodes.textNode").T,

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -20,4 +20,5 @@ end
 return {
 	vscode = new_cache(),
 	snipmate = new_cache(),
+	lua = new_cache(),
 }

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -12,9 +12,6 @@ local ls = require("luasnip")
 local M = {}
 
 local function load_files(ft, files)
-	local ft_snippets = {}
-	local ft_autosnippets = {}
-
 	for _, file in ipairs(files) do
 		-- 0444 = 292, eg. open with rrr.
 		local fd = vim.loop.fs_open(file, "r", 292)
@@ -39,9 +36,6 @@ local function load_files(ft, files)
 			autosnippets = file_autosnippets,
 		}
 
-		vim.list_extend(ft_snippets, file_snippets)
-		vim.list_extend(ft_autosnippets, file_autosnippets)
-
 		-- use lua autocommands here as soon as they're stable.
 		-- stylua: ignore
 		vim.cmd(string.format(
@@ -56,10 +50,20 @@ local function load_files(ft, files)
 			file:gsub(" ", "\\ "),
 			file
 		))
+
+		ls.add_snippets(
+			ft,
+			file_snippets,
+			{ type = "snippets", key = "__snippets_" .. file }
+		)
+		ls.add_snippets(
+			ft,
+			file_autosnippets,
+			{ type = "autosnippets", key = "__autosnippets_" .. file }
+		)
 	end
 
-	ls.add_snippets(ft, ft_snippets, { type = "snippets" })
-	ls.add_snippets(ft, ft_autosnippets, { type = "autosnippets" })
+	ls.refresh_notify(ft)
 end
 
 -- extend table like {lua = {path1}, c = {path1, path2}, ...}.

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -66,15 +66,13 @@ local function load_files(ft, files)
 	ls.refresh_notify(ft)
 end
 
--- extend table like {lua = {path1}, c = {path1, path2}, ...}.
--- TODO: prevent duplicates here? should only occur if one collection is loaded
--- twice.
+-- extend table like {lua = {path1}, c = {path1, path2}, ...}, new_paths has the same layout.
 local function extend_ft_paths(paths, new_paths)
 	for ft, path in pairs(new_paths) do
 		if paths[ft] then
-			table.insert(paths[ft], path)
+			vim.list_extend(paths[ft], path)
 		else
-			paths[ft] = { path }
+			paths[ft] = path
 		end
 	end
 end
@@ -87,7 +85,7 @@ local function get_ft_paths(root)
 	for _, file in ipairs(files) do
 		-- true: separate filename from extension.
 		local ft = path_mod.basename(file, true)
-		ft_paths[ft] = file
+		ft_paths[ft] = { file }
 	end
 
 	return ft_paths
@@ -113,10 +111,6 @@ local function get_load_paths(opts)
 		local collection_ft_paths = get_ft_paths(collection_root)
 
 		extend_ft_paths(load_paths, collection_ft_paths)
-
-		-- also add files from collection to cache (collection of all loaded
-		-- files by filetype, useful for editing files for some filetype).
-		extend_ft_paths(cache.ft_paths, collection_ft_paths)
 	end
 
 	-- remove files for excluded/non-included filetypes here.
@@ -127,6 +121,9 @@ local function get_load_paths(opts)
 		end
 	end
 
+	-- also add files from collection to cache (collection of all loaded
+	-- files by filetype, useful for editing files for some filetype).
+	extend_ft_paths(cache.ft_paths, load_paths)
 	return load_paths
 end
 

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -165,10 +165,14 @@ function M.reload_file(filename)
 			snip:invalidate()
 		end
 
-		ls.clean_invalidated({ inv_limit = 100 })
-
 		local ft = path_mod.basename(filename, true)
-		ls.refresh_notify(ft)
+
+		-- only refresh all filetypes if invalidated snippets were actually cleaned.
+		if ls.clean_invalidated({ inv_limit = 100 }) then
+			ls.refresh_notify()
+		else
+			ls.refresh_notify(ft)
+		end
 
 		load_files(ft, { filename })
 	end

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -7,6 +7,7 @@ local cache = require("luasnip.loaders._caches").lua
 local path_mod = require("luasnip.util.path")
 local loader_util = require("luasnip.loaders.util")
 local util = require("luasnip.util.util")
+local ls = require("luasnip")
 
 local M = {}
 

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -24,8 +24,7 @@ local function load_files(ft, files)
 		local size = vim.loop.fs_fstat(fd).size
 		local func_string = vim.loop.fs_read(fd, size)
 		-- bring snippet-constructors into global scope for that function.
-		func_string = 'dofile("/home/simon/.config/nvim/lua/plugins/luasnip/helpers.lua").setup_snip_env() '
-			.. func_string
+		func_string = 'require("luasnip").setup_snip_env() ' .. func_string
 		local file_res = loadstring(func_string)()
 
 		-- make sure these aren't nil.

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -25,17 +25,20 @@ local function load_files(ft, files)
 		local func_string = vim.loop.fs_read(fd, size)
 		-- bring snippet-constructors into global scope for that function.
 		func_string = 'require("luasnip").setup_snip_env() ' .. func_string
-		local file_res = loadstring(func_string)()
+		local file_snippets, file_autosnippets = loadstring(func_string)()
 
 		-- make sure these aren't nil.
-		file_res.snippets = file_res.snippets or {}
-		file_res.autosnippets = file_res.autosnippets or {}
+		file_snippets = file_snippets or {}
+		file_autosnippets = file_autosnippets or {}
 
 		-- keep track of snippet-source.
-		cache.path_snippets[file] = file_res
+		cache.path_snippets[file] = {
+			snippets = file_snippets,
+			autosnippets = file_autosnippets,
+		}
 
-		vim.list_extend(ft_snippets, file_res.snippets)
-		vim.list_extend(ft_autosnippets, file_res.autosnippets)
+		vim.list_extend(ft_snippets, file_snippets)
+		vim.list_extend(ft_autosnippets, file_autosnippets)
 
 		-- use lua autocommands here as soon as they're stable.
 		-- stylua: ignore

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -1,0 +1,144 @@
+local cache = require("luasnip.loaders._caches").lua
+local path_mod = require("luasnip.util.path")
+local loader_util = require("luasnip.loaders.util")
+local util = require("luasnip.util.util")
+
+local M = {}
+
+local function load_files(ft, files)
+	local ft_snippets = {}
+	local ft_autosnippets = {}
+
+	for _, file in ipairs(files) do
+		local fd = vim.loop.fs_open(file, "r", 420)
+
+		if not fd then
+			error("Couldn't find file " .. file)
+		end
+
+		local size = vim.loop.fs_fstat(fd).size
+		local func_string = vim.loop.fs_read(fd, size)
+		-- bring snippet-constructors into global scope for that function.
+		func_string = 'dofile("/home/simon/.config/nvim/lua/plugins/luasnip/helpers.lua").setup_snip_env() '
+			.. func_string
+		local file_res = loadstring(func_string)()
+
+		-- make sure these aren't nil.
+		file_res.snippets = file_res.snippets or {}
+		file_res.autosnippets = file_res.autosnippets or {}
+
+		-- keep track of snippet-source.
+		cache.path_snippets[file] = file_res
+
+		vim.list_extend(ft_snippets, file_res.snippets)
+		vim.list_extend(ft_autosnippets, file_res.autosnippets)
+	end
+
+	ls.add_snippets(ft, ft_snippets, { type = "snippets" })
+	ls.add_snippets(ft, ft_autosnippets, { type = "autosnippets" })
+end
+
+-- extend table like {lua = {path1}, c = {path1, path2}, ...}.
+-- TODO: prevent duplicates here? should only occur if one collection is loaded
+-- twice.
+local function extend_ft_paths(paths, new_paths)
+	for ft, path in pairs(new_paths) do
+		if paths[ft] then
+			table.insert(paths[ft], path)
+		else
+			paths[ft] = { path }
+		end
+	end
+end
+
+-- return table like {lua = path, c = path}.
+local function get_ft_paths(root)
+	local ft_paths = {}
+
+	local files = path_mod.scandir(root)
+	for _, file in ipairs(files) do
+		-- true: separate filename from extension.
+		local ft = path_mod.basename(file, true)
+		ft_paths[ft] = file
+	end
+
+	return ft_paths
+end
+
+function M._load_lazy_loaded()
+	local fts = util.get_snippet_filetypes()
+	for _, ft in ipairs(fts) do
+		if not cache.lazy_loaded_ft[ft] then
+			cache.lazy_loaded_ft[ft] = true
+			load_files(ft, cache.lazy_load_paths[ft] or {})
+		end
+	end
+end
+
+local function get_load_paths(opts)
+	opts = opts or {}
+
+	local load_paths = {}
+	for _, collection_root in
+		ipairs(loader_util.normalize_paths(opts.paths, "luasnippets"))
+	do
+		local collection_ft_paths = get_ft_paths(collection_root)
+
+		extend_ft_paths(load_paths, collection_ft_paths)
+
+		-- also add files from collection to cache (collection of all loaded
+		-- files by filetype, useful for editing files for some filetype).
+		extend_ft_paths(cache.ft_paths, collection_ft_paths)
+	end
+
+	-- remove files for excluded/non-included filetypes here.
+	local ft_filter = loader_util.ft_filter(opts.exclude, opts.include)
+	for ft, _ in pairs(load_paths) do
+		if not ft_filter(ft) then
+			load_paths[ft] = nil
+		end
+	end
+
+	return load_paths
+end
+
+function M.load(opts)
+	local load_paths = get_load_paths(opts)
+
+	for ft, files in pairs(load_paths) do
+		load_files(ft, files)
+	end
+end
+
+function M.lazy_load(opts)
+	local load_paths = get_load_paths(opts)
+
+	for ft, files in pairs(load_paths) do
+		if cache.lazy_loaded_ft[ft] then
+			-- instantly load snippets if they were already loaded...
+			load_files(ft, files)
+		else
+			-- and append them to the files to load for some filetype,
+			-- otherwise.
+			cache.lazy_load_paths[ft] = cache.lazy_load_paths[ft] or {}
+			vim.list_extend(cache.lazy_load_paths[ft], files)
+		end
+	end
+
+	-- call once for current filetype. Useful for lazy_loading snippets in
+	-- empty, initial buffer, and will not cause issues like duplicate
+	-- snippets.
+	M._load_lazy_loaded()
+end
+
+-- register during startup so it'll work even if lazy_load is only called after
+-- the events for some buffers already fired.
+vim.cmd([[
+augroup _luasnip_vscode_lazy_load
+	autocmd!
+	au BufWinEnter,FileType * lua require('luasnip.loaders.from_lua')._load_lazy_loaded()
+	au User LuasnipCleanup lua require('luasnip.loaders._caches').lua:clean()
+augroup END
+]])
+
+return M

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -37,6 +37,21 @@ local function load_files(ft, files)
 
 		vim.list_extend(ft_snippets, file_res.snippets)
 		vim.list_extend(ft_autosnippets, file_res.autosnippets)
+
+		-- use lua autocommands here as soon as they're stable.
+		-- stylua: ignore
+		vim.cmd(string.format(
+			[[
+				augroup luasnip_watch_%s
+				autocmd!
+				autocmd BufWritePost %s lua require("luasnip.loaders.from_lua").reload_file("%s")
+			]],
+			-- augroup name may not contain spaces.
+			file:gsub(" ", "_"),
+			-- escape for autocmd-pattern.
+			file:gsub(" ", "\\ "),
+			file
+		))
 	end
 
 	ls.add_snippets(ft, ft_snippets, { type = "snippets" })

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -164,6 +164,9 @@ function M.reload_file(filename)
 		for _, snip in ipairs(cache.path_snippets[filename].autosnippets) do
 			snip:invalidate()
 		end
+
+		ls.clean_invalidated({ inv_limit = 100 })
+
 		local ft = path_mod.basename(filename, true)
 		ls.refresh_notify(ft)
 

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -202,7 +202,7 @@ end
 -- register during startup so it'll work even if lazy_load is only called after
 -- the events for some buffers already fired.
 vim.cmd([[
-augroup _luasnip_vscode_lazy_load
+augroup _luasnip_lua_lazy_load
 	autocmd!
 	au BufWinEnter,FileType * lua require('luasnip.loaders.from_lua')._load_lazy_loaded()
 	au User LuasnipCleanup lua require('luasnip.loaders._caches').lua:clean()

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -15,7 +15,8 @@ local function load_files(ft, files)
 	local ft_autosnippets = {}
 
 	for _, file in ipairs(files) do
-		local fd = vim.loop.fs_open(file, "r", 420)
+		-- 0444 = 292, eg. open with rrr.
+		local fd = vim.loop.fs_open(file, "r", 292)
 
 		if not fd then
 			error("Couldn't find file " .. file)

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -174,10 +174,7 @@ function M.load(opts)
 	for ft, _ in pairs(cache.ft_paths) do
 		if ft_filter(ft) then
 			local snippets = M._load(ft)
-			local lang_snips = ls.snippets[ft] or {}
-			ls.snippets[ft] = vim.list_extend(lang_snips, snippets)
-			session.latest_load_ft = ft
-			vim.cmd("do User LuasnipSnippetsAdded")
+			ls.add_snippets(ft, snippets)
 		end
 	end
 end

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -118,34 +118,7 @@ local function get_ft_paths(roots)
 	return ft_path
 end
 
-local function filter(exclude, include)
-	exclude = loader_util.filetypelist_to_set(exclude)
-	include = loader_util.filetypelist_to_set(include)
-
-	return function(lang)
-		if exclude and exclude[lang] then
-			return false
-		end
-		if include == nil or include[lang] then
-			return true
-		end
-	end
-end
-
 local M = {}
-
-local function normarize_paths(paths)
-	if not paths then
-		paths = vim.api.nvim_get_runtime_file("snippets", true)
-	elseif type(paths) == "string" then
-		paths = vim.split(paths, ",")
-	end
-
-	paths = vim.tbl_map(Path.expand, paths)
-	paths = util.deduplicate(paths)
-
-	cache.ft_paths = get_ft_paths(paths)
-end
 
 function M._load(ft)
 	local snippets = {}
@@ -166,10 +139,12 @@ function M.load(opts)
 	opts = opts or {}
 
 	if not opts.is_lazy then
-		normarize_paths(opts.paths)
+		cache.ft_paths = get_ft_paths(
+			loader_util.normalize_paths(opts.paths, "snippets")
+		)
 	end
 
-	local ft_filter = filter(opts.exclude, opts.include)
+	local ft_filter = loader_util.ft_filter(opts.exclude, opts.include)
 
 	for ft, _ in pairs(cache.ft_paths) do
 		if ft_filter(ft) then
@@ -192,7 +167,9 @@ end
 function M.lazy_load(opts)
 	opts = opts or {}
 
-	normarize_paths(opts.paths)
+	cache.ft_paths = get_ft_paths(
+		loader_util.normalize_paths(opts.paths, "snippets")
+	)
 
 	vim.cmd([[
     augroup _luasnip_snipmate_lazy_load

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -25,8 +25,8 @@ local function load_snippet_file(langs, snippet_set_path)
 	end
 
 	for _, lang in pairs(langs) do
-		local lang_snips = ls.snippets[lang] or {}
-		local auto_lang_snips = ls.autosnippets[lang] or {}
+		local lang_snips = {}
+		local auto_lang_snips = {}
 		for name, parts in pairs(snippet_set_data) do
 			local body = type(parts.body) == "string" and parts.body
 				or table.concat(parts.body, "\n")
@@ -54,9 +54,8 @@ local function load_snippet_file(langs, snippet_set_path)
 				end
 			end)
 		end
-		ls.snippets[lang] = lang_snips
-		ls.autosnippets[lang] = auto_lang_snips
-		ls.refresh_notify(lang)
+		ls.add_snippets(lang, lang_snips, { type = "snippets" })
+		ls.add_snippets(lang, auto_lang_snips, { type = "autosnippets" })
 	end
 end
 

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -1,3 +1,6 @@
+local Path = require("luasnip.util.path")
+local util = require("luasnip.util.util")
+
 local function filetypelist_to_set(list)
 	vim.validate({ list = { list, "table", true } })
 	if not list then
@@ -33,7 +36,36 @@ local function split_lines(filestring)
 	)
 end
 
+local function normalize_paths(paths, rtp_dirname)
+	if not paths then
+		paths = vim.api.nvim_get_runtime_file(rtp_dirname, true)
+	elseif type(paths) == "string" then
+		paths = vim.split(paths, ",")
+	end
+
+	paths = vim.tbl_map(Path.expand, paths)
+	paths = util.deduplicate(paths)
+
+	return paths
+end
+
+local function ft_filter(exclude, include)
+	exclude = filetypelist_to_set(exclude)
+	include = filetypelist_to_set(include)
+
+	return function(lang)
+		if exclude and exclude[lang] then
+			return false
+		end
+		if include == nil or include[lang] then
+			return true
+		end
+	end
+end
+
 return {
 	filetypelist_to_set = filetypelist_to_set,
 	split_lines = split_lines,
+	normalize_paths = normalize_paths,
+	ft_filter = ft_filter,
 }

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -1,11 +1,9 @@
 local DynamicNode = require("luasnip.nodes.node").Node:new()
 local util = require("luasnip.util.util")
-local ext_util = require("luasnip.util.ext_opts")
 local node_util = require("luasnip.nodes.util")
 local Node = require("luasnip.nodes.node").Node
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
-local conf = require("luasnip.config")
 local FunctionNode = require("luasnip.nodes.functionNode").FunctionNode
 local SnippetNode = require("luasnip.nodes.snippet").SN
 

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -1,9 +1,9 @@
 local InsertNode = require("luasnip.nodes.node").Node:new()
 local ExitNode = InsertNode:new()
 local util = require("luasnip.util.util")
-local config = require("luasnip.config")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
+local session = require("luasnip.session")
 
 local function I(pos, static_text, opts)
 	static_text = util.wrap_value(static_text)
@@ -64,7 +64,7 @@ function ExitNode:input_leave()
 end
 
 function ExitNode:jump_into(dir, no_move)
-	if not config.config.history then
+	if not session.config.history then
 		self:input_enter(no_move)
 		if (dir == 1 and not self.next) or (dir == -1 and not self.prev) then
 			if self.pos == 0 then
@@ -124,7 +124,7 @@ function InsertNode:jump_into(dir, no_move)
 		if dir == 1 then
 			if self.next then
 				self.inner_active = false
-				if not config.config.history then
+				if not session.config.history then
 					self.inner_first = nil
 					self.inner_last = nil
 				end
@@ -136,7 +136,7 @@ function InsertNode:jump_into(dir, no_move)
 		else
 			if self.prev then
 				self.inner_active = false
-				if not config.config.history then
+				if not session.config.history then
 					self.inner_first = nil
 					self.inner_last = nil
 				end

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -4,7 +4,6 @@ local types = require("luasnip.util.types")
 local node_util = require("luasnip.nodes.util")
 local ext_util = require("luasnip.util.ext_opts")
 local events = require("luasnip.util.events")
-local conf = require("luasnip.config")
 
 local Node = {}
 
@@ -332,7 +331,7 @@ function Node:resolve_node_ext_opts(base_prio, parent_ext_opts)
 	ext_util.set_abs_prio(
 		self.ext_opts,
 		(base_prio or self.parent.ext_opts.base_prio)
-			+ conf.config.ext_prio_increase
+			+ session.config.ext_prio_increase
 	)
 end
 

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -7,8 +7,6 @@ local RestoreNode = Node:new()
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local util = require("luasnip.util.util")
-local ext_util = require("luasnip.util.ext_opts")
-local conf = require("luasnip.config")
 local mark = require("luasnip.util.mark").mark
 
 local function R(pos, key, nodes, opts)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -1117,6 +1117,14 @@ function Snippet:resolve_child_ext_opts()
 	end
 end
 
+function Snippet:invalidate()
+	self.hidden = true
+
+	function self:matches()
+		return nil
+	end
+end
+
 return {
 	Snippet = Snippet,
 	S = S,

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -8,7 +8,6 @@ local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local mark = require("luasnip.util.mark").mark
 local Environ = require("luasnip.util.environ")
-local conf = require("luasnip.config")
 local session = require("luasnip.session")
 local pattern_tokenizer = require("luasnip.util.pattern_tokenizer")
 local dict = require("luasnip.util.dict")
@@ -382,7 +381,7 @@ function Snippet:trigger_expand(current_node, pos)
 	if self.merge_child_ext_opts then
 		self.effective_child_ext_opts = ext_util.child_extend(
 			vim.deepcopy(self.child_ext_opts),
-			conf.config.ext_opts
+			session.config.ext_opts
 		)
 	else
 		self.effective_child_ext_opts = vim.deepcopy(self.child_ext_opts)
@@ -394,7 +393,7 @@ function Snippet:trigger_expand(current_node, pos)
 	if current_node and (current_node.indx and current_node.indx > 1) then
 		parent_ext_base_prio = current_node.parent.ext_opts.base_prio
 	else
-		parent_ext_base_prio = conf.config.ext_base_prio
+		parent_ext_base_prio = session.config.ext_base_prio
 	end
 
 	-- own highlight comes from self.child_ext_opts.snippet.
@@ -663,7 +662,7 @@ function Snippet:fake_expand(opts)
 	else
 		self.trigger = "$TRIGGER"
 	end
-	self.ext_opts = vim.deepcopy(conf.config.ext_opts)
+	self.ext_opts = vim.deepcopy(session.config.ext_opts)
 
 	self:indent("")
 

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -221,6 +221,7 @@ local function _S(snip, nodes, opts)
 			active = false,
 			type = types.snippet,
 			dependents_dict = dict.new(),
+			invalidated = false,
 		}),
 		opts
 	)
@@ -1116,12 +1117,16 @@ function Snippet:resolve_child_ext_opts()
 	end
 end
 
+local function no_match()
+	return nil
+end
+
 function Snippet:invalidate()
 	self.hidden = true
-
-	function self:matches()
-		return nil
-	end
+	-- override matching-function.
+	self.matches = no_match
+	self.invalidated = true
+	session.invalidated_count = session.invalidated_count + 1
 end
 
 return {

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -1,7 +1,6 @@
 local util = require("luasnip.util.util")
 local ext_util = require("luasnip.util.ext_opts")
 local types = require("luasnip.util.types")
-local conf = require("luasnip.config")
 
 local function subsnip_init_children(parent, children)
 	for _, child in ipairs(children) do

--- a/lua/luasnip/session.lua
+++ b/lua/luasnip/session.lua
@@ -31,4 +31,7 @@ M.config = nil
 
 M.invalidated_count = 0
 
+-- store snippets by some key.
+M.by_key = {}
+
 return M

--- a/lua/luasnip/session.lua
+++ b/lua/luasnip/session.lua
@@ -29,4 +29,6 @@ M.jump_active = false
 
 M.config = nil
 
+M.invalidated_count = 0
+
 return M

--- a/lua/luasnip/session.lua
+++ b/lua/luasnip/session.lua
@@ -27,4 +27,6 @@ M.last_expand_opts = nil
 -- init with false, it will be set by (eg.) ls.jump().
 M.jump_active = false
 
+M.config = nil
+
 return M

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -7,7 +7,7 @@ local snipNode = require("luasnip.nodes.snippet")
 local Environ = require("luasnip.util.environ")
 local functions = require("luasnip.util.functions")
 local util = require("luasnip.util.util")
-local config = require("luasnip.config")
+local session = require("luasnip.session")
 
 local function is_escaped(text, indx)
 	local count = 0
@@ -179,8 +179,8 @@ local function parse_placeholder(text, tab_stops, brackets)
 						return snipNode.SN(nil, iNode.I(1, iText))
 					end, {})
 				else
-					if config.config.parser_nested_assembler then
-						tab_stops[pos] = config.config.parser_nested_assembler(
+					if session.config.parser_nested_assembler then
+						tab_stops[pos] = session.config.parser_nested_assembler(
 							pos,
 							snip
 						)

--- a/lua/luasnip/util/path.lua
+++ b/lua/luasnip/util/path.lua
@@ -134,7 +134,7 @@ function Path.basename(filepath, ext)
 		base = base:match(("%s([^%s]+)$"):format(sep, sep))
 	end
 	if ext then
-		return base:match("(.+)%.(.+)")
+		return base:match("(.*)%.(.+)")
 	else
 		return base
 	end

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -437,7 +437,7 @@ end
 
 -- filetype: string formatted like `'filetype'`.
 local function get_snippet_filetypes()
-	local config = require("luasnip.config").config
+	local config = require("luasnip.session").config
 	local fts = config.ft_func()
 	-- add all last.
 	table.insert(fts, "all")

--- a/tests/data/lua-snippets/luasnippets/all.lua
+++ b/tests/data/lua-snippets/luasnippets/all.lua
@@ -1,0 +1,3 @@
+return {
+	s("all1", fmt("expands? jumps? {} {} !", { i(1), i(2) })),
+}

--- a/tests/data/lua-snippets/luasnippets/lua.lua
+++ b/tests/data/lua-snippets/luasnippets/lua.lua
@@ -1,0 +1,3 @@
+return {
+	s("trig2", fmt("this {} also works :))", { i(1) })),
+}

--- a/tests/integration/add_snippets_spec.lua
+++ b/tests/integration/add_snippets_spec.lua
@@ -1,0 +1,113 @@
+local helpers = require("test.functional.helpers")(after_each)
+local exec_lua, feed, exec = helpers.exec_lua, helpers.feed, helpers.exec
+local ls_helpers = require("helpers")
+local Screen = require("test.functional.ui.screen")
+
+describe("add_snippets", function()
+	local screen
+
+	before_each(function()
+		helpers.clear()
+		ls_helpers.session_setup_luasnip()
+
+		screen = Screen.new(50, 3)
+		screen:attach()
+		screen:set_default_attr_ids({
+			[0] = { bold = true, foreground = Screen.colors.Blue },
+			[1] = { bold = true, foreground = Screen.colors.Brown },
+			[2] = { bold = true },
+			[3] = { background = Screen.colors.LightGray },
+		})
+	end)
+
+	after_each(function()
+		screen:detach()
+	end)
+
+	it("overrides previously loaded snippets with the same key", function()
+		exec_lua([[
+			ls.add_snippets("all", {
+				ls.parser.parse_snippet("trigger1", "aaaaa")
+			}, {
+				key = "a"
+			} )
+		]])
+		exec_lua([[
+			ls.add_snippets("all", {
+				ls.parser.parse_snippet("trigger2", "eeeee")
+			}, {
+				key = "a"
+			} )
+		]])
+
+		feed("itrigger2")
+		exec_lua("ls.expand()")
+		-- snippets from second call expands.
+		screen:expect({
+			grid = [[
+			eeeee^                                             |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+		feed("<space>trigger1")
+		exec_lua("ls.expand()")
+
+		-- snippet from first call was removed.
+		screen:expect({
+			grid = [[
+			eeeee trigger1^                                    |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
+
+	it("correctly loads autosnippets", function()
+		exec_lua("ls.config.setup({ enable_autosnippets = true })")
+		exec_lua([[
+			ls.add_snippets("all", {
+				ls.parser.parse_snippet("trigger1", "aaaaa")
+			}, {
+				type = "autosnippets"
+			} )
+		]])
+
+		feed("itrigger1")
+		screen:expect({
+			grid = [[
+			aaaaa^                                             |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
+
+	it("can handle snippet-table", function()
+		exec_lua([[
+			ls.add_snippets(nil, {
+				all = {
+					ls.parser.parse_snippet("trigger1", "aaaaa")
+				},
+				c = {
+					ls.parser.parse_snippet("trigger2", "eeeee")
+				}
+			})
+		]])
+
+		feed("itrigger1")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
+			aaaaa^                                             |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+		exec("set ft=c")
+		feed("<space>trigger2")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
+			aaaaa eeeee^                                       |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
+end)

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -56,6 +56,33 @@ local loaders = {
 			)
 		)
 	end,
+
+	["lua(rtp)"] = function()
+		exec(
+			"set rtp+="
+				.. os.getenv("LUASNIP_SOURCE")
+				.. "/tests/data/lua-snippets"
+		)
+		exec_lua('require("luasnip.loaders.from_lua").load()')
+	end,
+	["lua(path)"] = function()
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_lua").load({paths="%s"})]],
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/lua-snippets/luasnippets"
+			)
+		)
+	end,
+	["lua(lazy)"] = function()
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_lua").lazy_load({paths="%s"})]],
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/lua-snippets/luasnippets"
+			)
+		)
+	end,
 }
 
 local function for_all_loaders(message, fn)
@@ -110,6 +137,7 @@ describe("loaders:", function()
 	it("Can lazy-load from multiple sources", function()
 		loaders["snipmate(lazy)"]()
 		loaders["vscode(lazy)"]()
+		loaders["lua(lazy)"]()
 		-- triggers actual load for `lazy_load()`s'
 		exec("set ft=lua")
 		-- wait a bit for async-operations to finish

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -143,7 +143,7 @@ describe("loaders:", function()
 		-- wait a bit for async-operations to finish
 		exec('call wait(200, "0")')
 		-- one snippet from snipmate, one from vscode.
-		assert.are.same(2, exec_lua("return #require('luasnip').snippets.lua"))
+		assert.are.same(3, exec_lua("return #require('luasnip').snippets.lua"))
 	end)
 
 	it("Can load with extends (snipmate)", function()

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -48,13 +48,12 @@ describe("snippets_basic", function()
 
 	it("Can expand Snippets from `all` via <Plug>", function()
 		exec_lua([[
-			ls.snippets = {
-				all = {
+			ls.add_snippets("all", {
 					s("snip", {
 						t"the snippet expands"
 					})
 				}
-			}
+			)
 		]])
 		feed("isnip<Plug>luasnip-expand-or-jump")
 		screen:expect({

--- a/tests/unit/snippetProxy_spec.lua
+++ b/tests/unit/snippetProxy_spec.lua
@@ -82,12 +82,14 @@ describe("snippetProxy", function()
 			[3] = { background = Screen.colors.LightGray },
 		})
 
-		exec_lua([[ls.snippets[""] = { sp("trig", "$1 triggered! $2")}]])
+		exec_lua([[ls.add_snippets("", { sp("trig", "$1 triggered! $2")})]])
 
 		exec_lua("ls.expand()")
 		-- make sure the snippet wasn't instantiated.
 		assert.is_true(
-			exec_lua([[return rawget(ls.snippets[""][1], "_snippet") == nil]])
+			exec_lua(
+				[[return rawget(ls.get_snippets("")[1], "_snippet") == nil]]
+			)
 		)
 
 		feed("itrig")


### PR DESCRIPTION
The goal of this PR is to switch from directly setting/getting snippets via `ls.snippets` to doing so via some function.

```lua
ls.snippets = {
	all = {
		...
	},
	lua = {
		...
	}
}

-- becomes

-- `type` is optional, may be "snippets" or "autosnippets".
ls.add_snippets("all", {...}, {type = "snippets"})
ls.add_snippets("lua", {...})
...
-- returns snippets, will be useful for eg. `cmp_luasnip`.
ls.get_snippets("all")
```
This is necessary to decouple the user-api from the internal structure of the snippet-storage (and should've been done a long time ago!), thereby enabling us to improve the internals (eg. in #334) without breaking changes in the future.
Adding snippets works fine using the functions, the on-demand-loading of snippets described in  [the wiki](https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#split-up-snippets-by-filetype-load-on-demand-and-reload-after-change-first-iteration) will not work any longer, and should be replaced by an (imo) autocommand-based implementation, similar to `lazy_load` in `loaders`.

After this is merged there will be a short deprecation-period (I'm thinking of two weeks, but feel free to suggest otherwise) during which existing direct access to the `ls.snippet` or `ls.autosnippet`-tables should be replaced by calls to `add_snippets(ft, snippets, opts)` or `get_snippets(ft, opts)`.

As always, feel free to discuss these proposed changes.
If you have any workflows that rely on the current layout of the snippet-tables, please mention them here so we can find a solution.