### PR TITLE
Tweak DOC.md to make panvimdoc happy

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -35,14 +35,14 @@ local ai = require("luasnip.nodes.absolute_indexer")
 
 # BASICS
 In LuaSnip, snippets are made up of `nodes`. These can contain either
-* static text (`textNode`)
-* text that can be edited (`insertNode`)
-* text that can be generated from the contents of other nodes (`functionNode`)
-* other nodes
-  * `choiceNode`: allows choosing between two nodes (which might contain more
+- static text (`textNode`)
+- text that can be edited (`insertNode`)
+- text that can be generated from the contents of other nodes (`functionNode`)
+- other nodes
+    - `choiceNode`: allows choosing between two nodes (which might contain more
     nodes)
-  * `restoreNode`: store and restore input to nodes
-* or nodes that can be generated based on input (`dynamicNode`).
+    - `restoreNode`: store and restore input to nodes
+- or nodes that can be generated based on input (`dynamicNode`).
 
 Snippets are always created using the `s(trigger:string, nodes:table)`-function.
 It is explained in more detail in [SNIPPETS](#snippets), but the gist is that


### PR DESCRIPTION
I'm guessing that panvimdoc (or pandoc?) doesn't like `*` to introduce
lists. In any case, the formatting of the list under the BASICS heading
was lost. I've switched this list to use `-` (which you use elsewhere)
and I've indented the sub-list.

There are actually a bunch of places where the translation from markdown
to vim help text is less than ideal, but this seemed like low hanging
fruit. I am happy to try to make other tweaks (e.g., lots of whitespace
changes) if you're open to it. Just let me know.

Thanks for LuaSnip. I'm just getting to know it, but I'm enjoying it so
far.