### PR TITLE
Loader for lua-native snippets.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -891,7 +891,7 @@ snippet and then clear them.
 As luasnip is capable of loading the same format of plugins as vscode, it also
 includes an easy way for loading those automatically. You just have to call:
 ```lua
- 	require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
+require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
 ```
 
 Where `opts` is a table containing the keys:
@@ -914,7 +914,7 @@ your snippets or you will have to extend the table as well.
 Another way of using the loader is making it lazily
 
 ```lua
- 	require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
+require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
 ```
 
 In this case `opts` only accepts paths (`runtimepath` if any). That will load
@@ -938,7 +938,7 @@ As the snipmate snippet format is fundamentally the same as vscode, it can also
 be loaded.
 
 ```lua
- 	require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
+require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
 ```
 
 See `from_vscode` for an explanation of opts.
@@ -964,7 +964,7 @@ Using both `extends OtherFileType` in `FileType.snippets` and
 Lazy loading is also available with the snipmate-loader.
 
 ```lua
- 	require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
+require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
 ```
 
 
@@ -976,6 +976,44 @@ Here is a summary of the differences from the original snipmate format.
 - `${VISUAL}` will be replaced by `$TM_SELECTED_TEXT` to make the snippets
 compatible with luasnip
 - We do not implement eval using \` (backtick). This may be implemented in the future.
+
+
+# LUA SNIPPETS LOADER
+
+Instead of adding all snippets via `add_snippets`, it's possible to store them
+in separate files (each for one filetype) and load all of those.
+
+For this, the files need to be
+
+- in a single directory. The directory may be passed directly to `load()`, or it
+  can be named `luasnippets` and in the `runtimepath`, in which case it will be
+  automatically detected.
+- named `<filetype>.lua`.
+- return two lists of snippets (either may be `nil`). The snippets in the first
+  are regular snippets for `<filetype>`, the ones in the second are autosnippets
+  (make sure they are enabled if this table is used).
+
+As defining all of the snippet-constructors (`s`, `c`, `t`, ...) in every file
+is rather cumbersome, luasnip will bring some globals into scope for executing
+these files.  
+By default the names from `Examples/snippets.lua` will be used, but it's
+possible to customize them by setting `snip_env` in `setup`.  
+
+These collections can be loaded directly
+(`require("luasnip.loaders.from_lua").load(opts)`) or lazily
+(`require("luasnip.loaders.from_lua.lazy_load(opts)")`).
+
+lua-`opts` may contain the same keys as vscode-`opts`, but here `include` and
+`exclude` can be used in `lazy_load`.
+
+Apart from loading, `from_lua` also exposes functions to edit files associated
+with the currently active filetypes, which could be called via an command, for
+example:
+
+```vim
+command! LuaSnipEdit :lua require("luasnip.loaders.from_lua").edit_snippet_files()
+```
+Once loaded, files will be reloaded on save (`BufWritePost`).
 
 
 # SNIPPETPROXY

--- a/Examples/snippets.lua
+++ b/Examples/snippets.lua
@@ -530,10 +530,14 @@ require("luasnip.loaders.from_vscode").lazy_load() -- You can pass { paths = "./
 -- contains global snippets:
 ls.filetype_extend("all", { "_" })
 
-require("luasnip.loaders.from_snipmate").load({ include = { "c" } }) -- Load only python snippets
+require("luasnip.loaders.from_snipmate").load({ include = { "c" } }) -- Load only snippets for c.
 
 require("luasnip.loaders.from_snipmate").load({ path = { "./my-snippets" } }) -- Load snippets from my-snippets folder
 -- If path is not specified, luasnip will look for the `snippets` directory in rtp (for custom-snippet probably
 -- `~/.config/nvim/snippets`).
 
 require("luasnip.loaders.from_snipmate").lazy_load() -- Lazy loading
+
+-- see DOC.md/LUA SNIPPETS LOADER for some details.
+require("luasnip.loaders.from_lua").load({ include = { "c" } })
+require("luasnip.loaders.from_lua").lazy_load({ include = { "all", "cpp" } })

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -23,13 +23,14 @@ Table of Contents                                  *luasnip-table-of-contents*
 15. VARIABLES                                              |luasnip-variables|
 16. VSCODE SNIPPETS LOADER                    |luasnip-vscode-snippets-loader|
 17. SNIPMATE SNIPPETS LOADER                |luasnip-snipmate-snippets-loader|
-18. SNIPPETPROXY                                        |luasnip-snippetproxy|
-19. EXT_OPTS                                                |luasnip-ext_opts|
-20. DOCSTRING                                              |luasnip-docstring|
-21. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
-22. EVENTS                                                    |luasnip-events|
-23. CLEANUP                                                  |luasnip-cleanup|
-24. API-REFERENCE                                      |luasnip-api-reference|
+18. LUA SNIPPETS LOADER                          |luasnip-lua-snippets-loader|
+19. SNIPPETPROXY                                        |luasnip-snippetproxy|
+20. EXT_OPTS                                                |luasnip-ext_opts|
+21. DOCSTRING                                              |luasnip-docstring|
+22. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
+23. EVENTS                                                    |luasnip-events|
+24. CLEANUP                                                  |luasnip-cleanup|
+25. API-REFERENCE                                      |luasnip-api-reference|
 
 >
                 __                       ____
@@ -974,7 +975,7 @@ As luasnip is capable of loading the same format of plugins as vscode, it also
 includes an easy way for loading those automatically. You just have to call:
 
 >
-        require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
 <
 
 
@@ -996,7 +997,7 @@ your snippets or you will have to extend the table as well.
 Another way of using the loader is making it lazily
 
 >
-        require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
 <
 
 
@@ -1024,7 +1025,7 @@ As the snipmate snippet format is fundamentally the same as vscode, it can also
 be loaded.
 
 >
-        require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
 <
 
 
@@ -1054,7 +1055,7 @@ snippets.
 Lazy loading is also available with the snipmate-loader.
 
 >
-        require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
 <
 
 
@@ -1070,7 +1071,48 @@ Here is a summary of the differences from the original snipmate format.
 
 
 ==============================================================================
-18. SNIPPETPROXY                                        *luasnip-snippetproxy*
+18. LUA SNIPPETS LOADER                          *luasnip-lua-snippets-loader*
+
+Instead of adding all snippets via `add_snippets`, it’s possible to store
+them in separate files (each for one filetype) and load all of those.
+
+For this, the files need to be
+
+
+- in a single directory. The directory may be passed directly to `load()`, or it
+    can be named `luasnippets` and in the `runtimepath`, in which case it will be
+    automatically detected.
+- named `<filetype>.lua`.
+- return two lists of snippets (either may be `nil`). The snippets in the first
+    are regular snippets for `<filetype>`, the ones in the second are autosnippets
+    (make sure they are enabled if this table is used).
+
+
+As defining all of the snippet-constructors (`s`, `c`, `t`, …) in every file
+is rather cumbersome, luasnip will bring some globals into scope for executing
+these files. By default the names from `Examples/snippets.lua` will be used,
+but it’s possible to customize them by setting `snip_env` in `setup`.
+
+These collections can be loaded directly
+(`require("luasnip.loaders.from_lua").load(opts)`) or lazily
+(`require("luasnip.loaders.from_lua.lazy_load(opts)")`).
+
+lua-`opts` may contain the same keys as vscode-`opts`, but here `include` and
+`exclude` can be used in `lazy_load`.
+
+Apart from loading, `from_lua` also exposes functions to edit files associated
+with the currently active filetypes, which could be called via an command, for
+example:
+
+>
+    command! LuaSnipEdit :lua require("luasnip.loaders.from_lua").edit_snippet_files()
+<
+
+
+Once loaded, files will be reloaded on save (`BufWritePost`).
+
+==============================================================================
+19. SNIPPETPROXY                                        *luasnip-snippetproxy*
 
 `SnippetProxy` is used internally to alleviate the upfront-cost of loading
 snippets from eg. a snipmate-library or a vscode-package. This is achieved by
@@ -1094,7 +1136,7 @@ This will parse the snippet on startup…
 
 
 ==============================================================================
-19. EXT_OPTS                                                *luasnip-ext_opts*
+20. EXT_OPTS                                                *luasnip-ext_opts*
 
 `ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
 extmarks used for marking node-positions, either globally, per-snippet or
@@ -1293,7 +1335,7 @@ Here the highlight of an insertNode nested directly inside a choiceNode is
 always visible on top of it.
 
 ==============================================================================
-20. DOCSTRING                                              *luasnip-docstring*
+21. DOCSTRING                                              *luasnip-docstring*
 
 Snippet-docstrings can be queried using `snippet:get_docstring()`. The function
 evaluates the snippet as if it was expanded regularly, which can be problematic
@@ -1343,7 +1385,7 @@ Other issues will have to be handled manually by checking the contents of eg.
 
 
 ==============================================================================
-21. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
+22. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
 
 Although generation of docstrings is pretty fast, it’s preferable to not redo
 it as long as the snippets haven’t changed. Using
@@ -1360,7 +1402,7 @@ The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 `~/.cache/nvim/luasnip/docstrings.json`).
 
 ==============================================================================
-22. EVENTS                                                    *luasnip-events*
+23. EVENTS                                                    *luasnip-events*
 
 Upon leaving/entering nodes or changing a choice an event is triggered: `User
 Luasnip<Node>{Enter,Leave}`, where `<Node>` is the name of a node in
@@ -1377,14 +1419,14 @@ be printing eg. the nodes’ text after entering:
 
 
 ==============================================================================
-23. CLEANUP                                                  *luasnip-cleanup*
+24. CLEANUP                                                  *luasnip-cleanup*
 
 The function ls.cleanup() triggers the `LuasnipCleanup` user-event, that you
 can listen to do some kind of cleaning in your own snippets, by default it will
 empty the snippets table and the caches of the lazy_load.
 
 ==============================================================================
-24. API-REFERENCE                                      *luasnip-api-reference*
+25. API-REFERENCE                                      *luasnip-api-reference*
 
 `require("luasnip")`:
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.5.0            Last change: 2022 March 18
+*luasnip.txt*            For NVIM v0.5.0            Last change: 2022 March 19
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -338,7 +338,7 @@ The first parameter of `f` is the function. Its parameters are:
 1. A table of the text of currently contained in the argnodes. (eg. `{{line1},
 {line1, line2}}`). The snippet-indent will be removed from all lines following
 the first.
-1. The immediate parent of the `functionNode`. It is included here as it allows
+2. The immediate parent of the `functionNode`. It is included here as it allows
 easy access to anything that could be useful in functionNodes (ie.
 `parent.snippet.env` or `parent.snippet.captures`, which contains capture
 groups of regex-triggered snippets). In most cases `parent.env` works, but if a
@@ -551,7 +551,7 @@ argnodes:table of nodes, opts: table)`:
 
 
 1. `position`: just like all jumpable nodes, when this node will be jumped into.
-1. `function`: `fn(args, parent, old_state, user_args1, ..., user_argsn) -> snippetNode`
+2. `function`: `fn(args, parent, old_state, user_args1, ..., user_argsn) -> snippetNode`
 This function is called when the argnodes’ text changes. It generates and
 returns (wrapped inside a `snippetNode`) the nodes that should be inserted
 at the dynamicNodes place.
@@ -572,11 +572,11 @@ at the dynamicNodes place.
     The second example below illustrates the usage of `old_state`.
 - `user_args1, ..., user_argsn`: passed through from `dynamicNode`-opts.
 
-1. `argnodes`: Indices of nodes the dynamicNode depends on: if any of these trigger an
+3. `argnodes`: Indices of nodes the dynamicNode depends on: if any of these trigger an
 update, the `dynamicNode`s’ function will be executed and the result inserted at
 the `dynamicNodes` place.
 Can be a single index or a table of indices.
-1. `opts`: Just like `functionNode`, `dynamicNode` also accepts `user_args` in
+4. `opts`: Just like `functionNode`, `dynamicNode` also accepts `user_args` in
 addition to options common to all nodes.
 
 

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -1,7 +1,7 @@
 local types = require("luasnip.util.types")
-local util = require("luasnip.util.util")
 local ext_util = require("luasnip.util.ext_opts")
 local ft_functions = require("luasnip.extras.filetype_functions")
+local session = require("luasnip.session")
 
 local defaults = {
 	history = false,
@@ -82,9 +82,9 @@ local defaults = {
 
 -- declare here to use in set_config.
 local c
+session.config = vim.deepcopy(defaults)
 
 c = {
-	config = vim.deepcopy(defaults),
 	set_config = function(user_config)
 		local conf = vim.deepcopy(defaults)
 
@@ -100,7 +100,7 @@ c = {
 			conf[k] = v
 		end
 
-		c.config = conf
+		session.config = conf
 		c._setup()
 	end,
 
@@ -117,23 +117,23 @@ c = {
 			"Remove buffers' nodes on deletion+wipeout.
 			autocmd BufDelete,BufWipeout * lua current_nodes = require("luasnip").session.current_nodes if current_nodes then current_nodes[tonumber(vim.fn.expand("<abuf>"))] = nil end
 		]]
-					.. (c.config.enable_autosnippets and [[
+					.. (session.config.enable_autosnippets and [[
 			autocmd InsertCharPre * lua Luasnip_just_inserted = true
 			autocmd TextChangedI,TextChangedP * lua if Luasnip_just_inserted then require("luasnip").expand_auto() Luasnip_just_inserted=nil end
 		]] or "")
 					.. [[
 		augroup END
 		]],
-				c.config.delete_check_events,
-				c.config.updateevents,
-				c.config.region_check_events
+				session.config.delete_check_events,
+				session.config.updateevents,
+				session.config.region_check_events
 			)
 		)
-		if c.config.store_selection_keys then
+		if session.config.store_selection_keys then
 			vim.cmd(
 				string.format(
 					[[xnoremap <silent>  %s  :lua require('luasnip.util.util').store_selection()<cr>gv"_s]],
-					c.config.store_selection_keys
+					session.config.store_selection_keys
 				)
 			)
 		end

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -78,6 +78,30 @@ local defaults = {
 	parser_nested_assembler = nil,
 	-- Function expected to return a list of filetypes (or empty list)
 	ft_func = ft_functions.from_filetype,
+	-- globals injected into luasnippet-files.
+	snip_env = {
+		s = require("luasnip.nodes.snippet").S,
+		sn = require("luasnip.nodes.snippet").SN,
+		t = require("luasnip.nodes.textNode").T,
+		f = require("luasnip.nodes.functionNode").F,
+		i = require("luasnip.nodes.insertNode").I,
+		c = require("luasnip.nodes.choiceNode").C,
+		d = require("luasnip.nodes.dynamicNode").D,
+		r = require("luasnip.nodes.restoreNode").R,
+		l = require("luasnip.extras").lambda,
+		rep = require("luasnip.extras").rep,
+		p = require("luasnip.extras").partial,
+		m = require("luasnip.extras").match,
+		n = require("luasnip.extras").nonempty,
+		dl = require("luasnip.extras").dynamic_lambda,
+		fmt = require("luasnip.extras.fmt").fmt,
+		fmta = require("luasnip.extras.fmt").fmta,
+		conds = require("luasnip.extras.expand_conditions"),
+		types = require("luasnip.util.types"),
+		events = require("luasnip.util.events"),
+		parse = require("luasnip.util.parser").parse_snippet,
+		ai = require("luasnip.nodes.absolute_indexer"),
+	},
 }
 
 -- declare here to use in set_config.

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -555,6 +555,10 @@ local function add_snippets(ft, snippets, opts)
 	end
 end
 
+local function setup_snip_env()
+	setfenv(2, vim.tbl_extend("force", _G, session.config.snip_env))
+end
+
 ls = {
 	expand_or_jumpable = expand_or_jumpable,
 	expand_or_locally_jumpable = expand_or_locally_jumpable,
@@ -582,6 +586,7 @@ ls = {
 	filetype_set = filetype_set,
 	add_snippets = add_snippets,
 	get_snippets = get_snippets,
+	setup_snip_env = setup_snip_env,
 	s = snip_mod.S,
 	sn = snip_mod.SN,
 	t = require("luasnip.nodes.textNode").T,

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -20,4 +20,5 @@ end
 return {
 	vscode = new_cache(),
 	snipmate = new_cache(),
+	lua = new_cache(),
 }

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -24,8 +24,7 @@ local function load_files(ft, files)
 		local size = vim.loop.fs_fstat(fd).size
 		local func_string = vim.loop.fs_read(fd, size)
 		-- bring snippet-constructors into global scope for that function.
-		func_string = 'dofile("/home/simon/.config/nvim/lua/plugins/luasnip/helpers.lua").setup_snip_env() '
-			.. func_string
+		func_string = 'require("luasnip").setup_snip_env() ' .. func_string
 		local file_res = loadstring(func_string)()
 
 		-- make sure these aren't nil.

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -25,17 +25,20 @@ local function load_files(ft, files)
 		local func_string = vim.loop.fs_read(fd, size)
 		-- bring snippet-constructors into global scope for that function.
 		func_string = 'require("luasnip").setup_snip_env() ' .. func_string
-		local file_res = loadstring(func_string)()
+		local file_snippets, file_autosnippets = loadstring(func_string)()
 
 		-- make sure these aren't nil.
-		file_res.snippets = file_res.snippets or {}
-		file_res.autosnippets = file_res.autosnippets or {}
+		file_snippets = file_snippets or {}
+		file_autosnippets = file_autosnippets or {}
 
 		-- keep track of snippet-source.
-		cache.path_snippets[file] = file_res
+		cache.path_snippets[file] = {
+			snippets = file_snippets,
+			autosnippets = file_autosnippets,
+		}
 
-		vim.list_extend(ft_snippets, file_res.snippets)
-		vim.list_extend(ft_autosnippets, file_res.autosnippets)
+		vim.list_extend(ft_snippets, file_snippets)
+		vim.list_extend(ft_autosnippets, file_autosnippets)
 
 		-- use lua autocommands here as soon as they're stable.
 		-- stylua: ignore

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -1,0 +1,144 @@
+local cache = require("luasnip.loaders._caches").lua
+local path_mod = require("luasnip.util.path")
+local loader_util = require("luasnip.loaders.util")
+local util = require("luasnip.util.util")
+
+local M = {}
+
+local function load_files(ft, files)
+	local ft_snippets = {}
+	local ft_autosnippets = {}
+
+	for _, file in ipairs(files) do
+		local fd = vim.loop.fs_open(file, "r", 420)
+
+		if not fd then
+			error("Couldn't find file " .. file)
+		end
+
+		local size = vim.loop.fs_fstat(fd).size
+		local func_string = vim.loop.fs_read(fd, size)
+		-- bring snippet-constructors into global scope for that function.
+		func_string = 'dofile("/home/simon/.config/nvim/lua/plugins/luasnip/helpers.lua").setup_snip_env() '
+			.. func_string
+		local file_res = loadstring(func_string)()
+
+		-- make sure these aren't nil.
+		file_res.snippets = file_res.snippets or {}
+		file_res.autosnippets = file_res.autosnippets or {}
+
+		-- keep track of snippet-source.
+		cache.path_snippets[file] = file_res
+
+		vim.list_extend(ft_snippets, file_res.snippets)
+		vim.list_extend(ft_autosnippets, file_res.autosnippets)
+	end
+
+	ls.add_snippets(ft, ft_snippets, { type = "snippets" })
+	ls.add_snippets(ft, ft_autosnippets, { type = "autosnippets" })
+end
+
+-- extend table like {lua = {path1}, c = {path1, path2}, ...}.
+-- TODO: prevent duplicates here? should only occur if one collection is loaded
+-- twice.
+local function extend_ft_paths(paths, new_paths)
+	for ft, path in pairs(new_paths) do
+		if paths[ft] then
+			table.insert(paths[ft], path)
+		else
+			paths[ft] = { path }
+		end
+	end
+end
+
+-- return table like {lua = path, c = path}.
+local function get_ft_paths(root)
+	local ft_paths = {}
+
+	local files = path_mod.scandir(root)
+	for _, file in ipairs(files) do
+		-- true: separate filename from extension.
+		local ft = path_mod.basename(file, true)
+		ft_paths[ft] = file
+	end
+
+	return ft_paths
+end
+
+function M._load_lazy_loaded()
+	local fts = util.get_snippet_filetypes()
+	for _, ft in ipairs(fts) do
+		if not cache.lazy_loaded_ft[ft] then
+			cache.lazy_loaded_ft[ft] = true
+			load_files(ft, cache.lazy_load_paths[ft] or {})
+		end
+	end
+end
+
+local function get_load_paths(opts)
+	opts = opts or {}
+
+	local load_paths = {}
+	for _, collection_root in
+		ipairs(loader_util.normalize_paths(opts.paths, "luasnippets"))
+	do
+		local collection_ft_paths = get_ft_paths(collection_root)
+
+		extend_ft_paths(load_paths, collection_ft_paths)
+
+		-- also add files from collection to cache (collection of all loaded
+		-- files by filetype, useful for editing files for some filetype).
+		extend_ft_paths(cache.ft_paths, collection_ft_paths)
+	end
+
+	-- remove files for excluded/non-included filetypes here.
+	local ft_filter = loader_util.ft_filter(opts.exclude, opts.include)
+	for ft, _ in pairs(load_paths) do
+		if not ft_filter(ft) then
+			load_paths[ft] = nil
+		end
+	end
+
+	return load_paths
+end
+
+function M.load(opts)
+	local load_paths = get_load_paths(opts)
+
+	for ft, files in pairs(load_paths) do
+		load_files(ft, files)
+	end
+end
+
+function M.lazy_load(opts)
+	local load_paths = get_load_paths(opts)
+
+	for ft, files in pairs(load_paths) do
+		if cache.lazy_loaded_ft[ft] then
+			-- instantly load snippets if they were already loaded...
+			load_files(ft, files)
+		else
+			-- and append them to the files to load for some filetype,
+			-- otherwise.
+			cache.lazy_load_paths[ft] = cache.lazy_load_paths[ft] or {}
+			vim.list_extend(cache.lazy_load_paths[ft], files)
+		end
+	end
+
+	-- call once for current filetype. Useful for lazy_loading snippets in
+	-- empty, initial buffer, and will not cause issues like duplicate
+	-- snippets.
+	M._load_lazy_loaded()
+end
+
+-- register during startup so it'll work even if lazy_load is only called after
+-- the events for some buffers already fired.
+vim.cmd([[
+augroup _luasnip_vscode_lazy_load
+	autocmd!
+	au BufWinEnter,FileType * lua require('luasnip.loaders.from_lua')._load_lazy_loaded()
+	au User LuasnipCleanup lua require('luasnip.loaders._caches').lua:clean()
+augroup END
+]])
+
+return M

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -37,6 +37,21 @@ local function load_files(ft, files)
 
 		vim.list_extend(ft_snippets, file_res.snippets)
 		vim.list_extend(ft_autosnippets, file_res.autosnippets)
+
+		-- use lua autocommands here as soon as they're stable.
+		-- stylua: ignore
+		vim.cmd(string.format(
+			[[
+				augroup luasnip_watch_%s
+				autocmd!
+				autocmd BufWritePost %s lua require("luasnip.loaders.from_lua").reload_file("%s")
+			]],
+			-- augroup name may not contain spaces.
+			file:gsub(" ", "_"),
+			-- escape for autocmd-pattern.
+			file:gsub(" ", "\\ "),
+			file
+		))
 	end
 
 	ls.add_snippets(ft, ft_snippets, { type = "snippets" })

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -15,7 +15,8 @@ local function load_files(ft, files)
 	local ft_autosnippets = {}
 
 	for _, file in ipairs(files) do
-		local fd = vim.loop.fs_open(file, "r", 420)
+		-- 0444 = 292, eg. open with rrr.
+		local fd = vim.loop.fs_open(file, "r", 292)
 
 		if not fd then
 			error("Couldn't find file " .. file)

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -118,34 +118,7 @@ local function get_ft_paths(roots)
 	return ft_path
 end
 
-local function filter(exclude, include)
-	exclude = loader_util.filetypelist_to_set(exclude)
-	include = loader_util.filetypelist_to_set(include)
-
-	return function(lang)
-		if exclude and exclude[lang] then
-			return false
-		end
-		if include == nil or include[lang] then
-			return true
-		end
-	end
-end
-
 local M = {}
-
-local function normarize_paths(paths)
-	if not paths then
-		paths = vim.api.nvim_get_runtime_file("snippets", true)
-	elseif type(paths) == "string" then
-		paths = vim.split(paths, ",")
-	end
-
-	paths = vim.tbl_map(Path.expand, paths)
-	paths = util.deduplicate(paths)
-
-	cache.ft_paths = get_ft_paths(paths)
-end
 
 function M._load(ft)
 	local snippets = {}
@@ -166,10 +139,12 @@ function M.load(opts)
 	opts = opts or {}
 
 	if not opts.is_lazy then
-		normarize_paths(opts.paths)
+		cache.ft_paths = get_ft_paths(
+			loader_util.normalize_paths(opts.paths, "snippets")
+		)
 	end
 
-	local ft_filter = filter(opts.exclude, opts.include)
+	local ft_filter = loader_util.ft_filter(opts.exclude, opts.include)
 
 	for ft, _ in pairs(cache.ft_paths) do
 		if ft_filter(ft) then
@@ -192,7 +167,9 @@ end
 function M.lazy_load(opts)
 	opts = opts or {}
 
-	normarize_paths(opts.paths)
+	cache.ft_paths = get_ft_paths(
+		loader_util.normalize_paths(opts.paths, "snippets")
+	)
 
 	vim.cmd([[
     augroup _luasnip_snipmate_lazy_load

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -1,3 +1,6 @@
+local Path = require("luasnip.util.path")
+local util = require("luasnip.util.util")
+
 local function filetypelist_to_set(list)
 	vim.validate({ list = { list, "table", true } })
 	if not list then
@@ -33,7 +36,36 @@ local function split_lines(filestring)
 	)
 end
 
+local function normalize_paths(paths, rtp_dirname)
+	if not paths then
+		paths = vim.api.nvim_get_runtime_file(rtp_dirname, true)
+	elseif type(paths) == "string" then
+		paths = vim.split(paths, ",")
+	end
+
+	paths = vim.tbl_map(Path.expand, paths)
+	paths = util.deduplicate(paths)
+
+	return paths
+end
+
+local function ft_filter(exclude, include)
+	exclude = filetypelist_to_set(exclude)
+	include = filetypelist_to_set(include)
+
+	return function(lang)
+		if exclude and exclude[lang] then
+			return false
+		end
+		if include == nil or include[lang] then
+			return true
+		end
+	end
+end
+
 return {
 	filetypelist_to_set = filetypelist_to_set,
 	split_lines = split_lines,
+	normalize_paths = normalize_paths,
+	ft_filter = ft_filter,
 }

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -1,11 +1,9 @@
 local DynamicNode = require("luasnip.nodes.node").Node:new()
 local util = require("luasnip.util.util")
-local ext_util = require("luasnip.util.ext_opts")
 local node_util = require("luasnip.nodes.util")
 local Node = require("luasnip.nodes.node").Node
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
-local conf = require("luasnip.config")
 local FunctionNode = require("luasnip.nodes.functionNode").FunctionNode
 local SnippetNode = require("luasnip.nodes.snippet").SN
 

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -1,9 +1,9 @@
 local InsertNode = require("luasnip.nodes.node").Node:new()
 local ExitNode = InsertNode:new()
 local util = require("luasnip.util.util")
-local config = require("luasnip.config")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
+local session = require("luasnip.session")
 
 local function I(pos, static_text, opts)
 	static_text = util.wrap_value(static_text)
@@ -64,7 +64,7 @@ function ExitNode:input_leave()
 end
 
 function ExitNode:jump_into(dir, no_move)
-	if not config.config.history then
+	if not session.config.history then
 		self:input_enter(no_move)
 		if (dir == 1 and not self.next) or (dir == -1 and not self.prev) then
 			if self.pos == 0 then
@@ -124,7 +124,7 @@ function InsertNode:jump_into(dir, no_move)
 		if dir == 1 then
 			if self.next then
 				self.inner_active = false
-				if not config.config.history then
+				if not session.config.history then
 					self.inner_first = nil
 					self.inner_last = nil
 				end
@@ -136,7 +136,7 @@ function InsertNode:jump_into(dir, no_move)
 		else
 			if self.prev then
 				self.inner_active = false
-				if not config.config.history then
+				if not session.config.history then
 					self.inner_first = nil
 					self.inner_last = nil
 				end

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -4,7 +4,6 @@ local types = require("luasnip.util.types")
 local node_util = require("luasnip.nodes.util")
 local ext_util = require("luasnip.util.ext_opts")
 local events = require("luasnip.util.events")
-local conf = require("luasnip.config")
 
 local Node = {}
 
@@ -332,7 +331,7 @@ function Node:resolve_node_ext_opts(base_prio, parent_ext_opts)
 	ext_util.set_abs_prio(
 		self.ext_opts,
 		(base_prio or self.parent.ext_opts.base_prio)
-			+ conf.config.ext_prio_increase
+			+ session.config.ext_prio_increase
 	)
 end
 

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -7,8 +7,6 @@ local RestoreNode = Node:new()
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local util = require("luasnip.util.util")
-local ext_util = require("luasnip.util.ext_opts")
-local conf = require("luasnip.config")
 local mark = require("luasnip.util.mark").mark
 
 local function R(pos, key, nodes, opts)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -8,7 +8,6 @@ local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local mark = require("luasnip.util.mark").mark
 local Environ = require("luasnip.util.environ")
-local conf = require("luasnip.config")
 local session = require("luasnip.session")
 local pattern_tokenizer = require("luasnip.util.pattern_tokenizer")
 local dict = require("luasnip.util.dict")
@@ -382,7 +381,7 @@ function Snippet:trigger_expand(current_node, pos)
 	if self.merge_child_ext_opts then
 		self.effective_child_ext_opts = ext_util.child_extend(
 			vim.deepcopy(self.child_ext_opts),
-			conf.config.ext_opts
+			session.config.ext_opts
 		)
 	else
 		self.effective_child_ext_opts = vim.deepcopy(self.child_ext_opts)
@@ -394,7 +393,7 @@ function Snippet:trigger_expand(current_node, pos)
 	if current_node and (current_node.indx and current_node.indx > 1) then
 		parent_ext_base_prio = current_node.parent.ext_opts.base_prio
 	else
-		parent_ext_base_prio = conf.config.ext_base_prio
+		parent_ext_base_prio = session.config.ext_base_prio
 	end
 
 	-- own highlight comes from self.child_ext_opts.snippet.
@@ -663,7 +662,7 @@ function Snippet:fake_expand(opts)
 	else
 		self.trigger = "$TRIGGER"
 	end
-	self.ext_opts = vim.deepcopy(conf.config.ext_opts)
+	self.ext_opts = vim.deepcopy(session.config.ext_opts)
 
 	self:indent("")
 

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -1,7 +1,6 @@
 local util = require("luasnip.util.util")
 local ext_util = require("luasnip.util.ext_opts")
 local types = require("luasnip.util.types")
-local conf = require("luasnip.config")
 
 local function subsnip_init_children(parent, children)
 	for _, child in ipairs(children) do

--- a/lua/luasnip/session.lua
+++ b/lua/luasnip/session.lua
@@ -27,4 +27,6 @@ M.last_expand_opts = nil
 -- init with false, it will be set by (eg.) ls.jump().
 M.jump_active = false
 
+M.config = nil
+
 return M

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -7,7 +7,7 @@ local snipNode = require("luasnip.nodes.snippet")
 local Environ = require("luasnip.util.environ")
 local functions = require("luasnip.util.functions")
 local util = require("luasnip.util.util")
-local config = require("luasnip.config")
+local session = require("luasnip.session")
 
 local function is_escaped(text, indx)
 	local count = 0
@@ -179,8 +179,8 @@ local function parse_placeholder(text, tab_stops, brackets)
 						return snipNode.SN(nil, iNode.I(1, iText))
 					end, {})
 				else
-					if config.config.parser_nested_assembler then
-						tab_stops[pos] = config.config.parser_nested_assembler(
+					if session.config.parser_nested_assembler then
+						tab_stops[pos] = session.config.parser_nested_assembler(
 							pos,
 							snip
 						)

--- a/lua/luasnip/util/path.lua
+++ b/lua/luasnip/util/path.lua
@@ -134,7 +134,7 @@ function Path.basename(filepath, ext)
 		base = base:match(("%s([^%s]+)$"):format(sep, sep))
 	end
 	if ext then
-		return base:match("(.+)%.(.+)")
+		return base:match("(.*)%.(.+)")
 	else
 		return base
 	end

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -437,7 +437,7 @@ end
 
 -- filetype: string formatted like `'filetype'`.
 local function get_snippet_filetypes()
-	local config = require("luasnip.config").config
+	local config = require("luasnip.session").config
 	local fts = config.ft_func()
 	-- add all last.
 	table.insert(fts, "all")

--- a/tests/data/lua-snippets/luasnippets/all.lua
+++ b/tests/data/lua-snippets/luasnippets/all.lua
@@ -1,0 +1,3 @@
+return {
+	s("all1", fmt("expands? jumps? {} {} !", { i(1), i(2) })),
+}

--- a/tests/data/lua-snippets/luasnippets/lua.lua
+++ b/tests/data/lua-snippets/luasnippets/lua.lua
@@ -1,0 +1,3 @@
+return {
+	s("trig2", fmt("this {} also works :))", { i(1) })),
+}

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -56,6 +56,33 @@ local loaders = {
 			)
 		)
 	end,
+
+	["lua(rtp)"] = function()
+		exec(
+			"set rtp+="
+				.. os.getenv("LUASNIP_SOURCE")
+				.. "/tests/data/lua-snippets"
+		)
+		exec_lua('require("luasnip.loaders.from_lua").load()')
+	end,
+	["lua(path)"] = function()
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_lua").load({paths="%s"})]],
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/lua-snippets/luasnippets"
+			)
+		)
+	end,
+	["lua(lazy)"] = function()
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_lua").lazy_load({paths="%s"})]],
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/lua-snippets/luasnippets"
+			)
+		)
+	end,
 }
 
 local function for_all_loaders(message, fn)
@@ -110,6 +137,7 @@ describe("loaders:", function()
 	it("Can lazy-load from multiple sources", function()
 		loaders["snipmate(lazy)"]()
 		loaders["vscode(lazy)"]()
+		loaders["lua(lazy)"]()
 		-- triggers actual load for `lazy_load()`s'
 		exec("set ft=lua")
 		-- wait a bit for async-operations to finish


### PR DESCRIPTION
As discussed [here](https://github.com/L3MON4D3/LuaSnip/discussions/341), a loader for lua-snippets.
Some stuff is still custom to my setup ([global scope for snippet-files](https://github.com/L3MON4D3/Dotfiles/blob/master/.config/nvim/lua/plugins/luasnip/helpers.lua#L3-L56)), and some is missing (reload+edit).

To avoid having to define all of `local s = ls.snippet local i = ls.insert_node ...` at the beginning of each file, I propose using `setfenv` for adding these definitions to all of the loaded lua-files.
The definition would be globally configurable, and default to the names (`s`, `i`, `t`, ...) used in `Examples/snippets.lua` (see the link above for the implementation, I'll port add that in this PR too). This has the added benefit of being able to set global defaults for some snippet-options, eg. for [choiceNode](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#choicenode).