### PR TITLE
gitignore: ignore doc tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /deps/
+/doc/tags


### PR DESCRIPTION
This is auto-generated using :helptags.