### PR TITLE
fixing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ For nvim-cmp, it is also possible to follow the [example recommendation](https:/
         	$0
         ```
     Again, there are some [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L517) and an entry in the [docs](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#snipmate-snippets-loader)
-- **Lua**: Add the snippets by calling `require("luasnip").add_snippets(filetype, snippets)`. An example for this can be found [here](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L167).  
+- **Lua**: Add the snippets by calling `require("luasnip").add_snippets(filetype, snippets)`. An example for this can be found [here](https://github.com/L3MON4D3/LuaSnip/blob/master/Examples/snippets.lua#L190).  
 This can also be done much better (one snippet-file per filetype+command for editing the current filetype+reload on edit) than in the example by using the [loader for lua](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader)
 There's also a repository collecting snippets for various languages, [molleweide/LuaSnip-snippets.nvim](https://github.com/molleweide/LuaSnip-snippets.nvim)
 


### PR DESCRIPTION
The first link to the example still shows to the old example which sets the snippets by accessing `ls.snippets` directly which is deprecated now.