### PR TITLE
Enhance snipmate loader.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -983,6 +983,8 @@ Here is a summary of the differences from the original snipmate format.
 - `${VISUAL}` will be replaced by `$TM_SELECTED_TEXT` to make the snippets
 compatible with luasnip
 - We do not implement eval using \` (backtick). This may be implemented in the future.
+- `snippet ...` defines a regular snippet wheras `autosnippet ...` may be used
+  to add autotriggered snippets.
 
 
 # LUA SNIPPETS LOADER

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -8,9 +8,23 @@ end
 local function new_cache()
 	-- returns the table the metatable was set on.
 	return setmetatable({
+		-- maps ft to list of files. Each file provides snippets for the given
+		-- filetype.
+		-- In snipmate:
+		-- {
+		--	lua = {"~/snippets/lua.snippets"},
+		--	c = {"~/snippets/c.snippets", "/othersnippets/c.snippets"}
+		-- }
 		lazy_load_paths = {},
+
+		-- ft -> {true, nil}.
+		-- Keep track of which filetypes were already lazy_loaded to prevent
+		-- duplicates.
 		lazy_loaded_ft = {},
-		ft_paths = {}, -- key is file type, value are paths of .snippets files.
+
+		-- key is file type, value are paths of .snippets files.
+		ft_paths = {},
+
 		path_snippets = {}, -- key is file path, value are parsed snippets in it.
 	}, {
 		__index = Cache,

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -97,10 +97,46 @@ local function get_ft_paths(roots, extension)
 	return ft_path
 end
 
+-- extend table like {lua = {path1}, c = {path1, path2}, ...}, new_paths has the same layout.
+local function extend_ft_paths(paths, new_paths)
+	for ft, path in pairs(new_paths) do
+		if paths[ft] then
+			vim.list_extend(paths[ft], path)
+		else
+			paths[ft] = path
+		end
+	end
+end
+
+local function get_load_paths_snipmate_like(opts, rtp_dirname, extension)
+	opts = opts or {}
+
+	local load_paths = {}
+
+	local collection_ft_paths = get_ft_paths(
+		normalize_paths(opts.paths, rtp_dirname),
+		extension
+	)
+
+	extend_ft_paths(load_paths, collection_ft_paths)
+
+	-- remove files for excluded/non-included filetypes here.
+	local collection_filter = ft_filter(opts.exclude, opts.include)
+	for ft, _ in pairs(load_paths) do
+		if not collection_filter(ft) then
+			load_paths[ft] = nil
+		end
+	end
+
+	return load_paths, collection_ft_paths
+end
+
 return {
 	filetypelist_to_set = filetypelist_to_set,
 	split_lines = split_lines,
 	normalize_paths = normalize_paths,
 	ft_filter = ft_filter,
 	get_ft_paths = get_ft_paths,
+	get_load_paths_snipmate_like = get_load_paths_snipmate_like,
+	extend_ft_paths = extend_ft_paths,
 }

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -103,7 +103,7 @@ local function extend_ft_paths(paths, new_paths)
 		if paths[ft] then
 			vim.list_extend(paths[ft], path)
 		else
-			paths[ft] = path
+			paths[ft] = vim.deepcopy(path)
 		end
 	end
 end

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -108,6 +108,17 @@ local function extend_ft_paths(paths, new_paths)
 	end
 end
 
+--- Find
+---   1. all files that belong to a collection and
+---   2. the files from that
+---      collection that should actually be loaded.
+---@param opts table: straight from `load`/`lazy_load`.
+---@param rtp_dirname string: if no path is given in opts, we look for a
+--- directory named `rtp_dirname` in the runtimepath.
+---@param extension string: extension of valid snippet-files for the given
+--- collection (eg `.lua` or `.snippets`)
+---@return table: two tables like `{ft1={files}, ft2={files}}`: The files that
+--- should actually be loaded, and all files in the collection.
 local function get_load_paths_snipmate_like(opts, rtp_dirname, extension)
 	opts = opts or {}
 

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -125,7 +125,8 @@ local function cursor_set_keys(pos, before)
 			pos[1] = pos[1] - 1
 			-- pos2 is set to last columnt of previous line.
 			-- # counts bytes, but win_set_cursor expects bytes, so all's good.
-			pos[2] = #vim.api.nvim_buf_get_lines(
+			pos[2] =
+				#vim.api.nvim_buf_get_lines(
 					0,
 					pos[1],
 					pos[1] + 1,

--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -6,11 +6,12 @@ syn match tabStop '\$\d\+'
 syn match snipEscape '\\\\\|\\`'
 syn match snipCommand '\%(\\\@<!\%(\\\\\)*\)\@<=`.\{-}\%(\\\@<!\%(\\\\\)*\)\@<=`'
 syn match snippet '^snippet.*' contains=multiSnipText,snipKeyword
+syn match snippet '^autosnippet.*' contains=multiSnipText,snipKeyword
 syn match snippet '^extends.*' contains=snipKeyword
 syn match snippet '^version.*' contains=snipKeyword
 syn match multiSnipText '\S\+ \zs.*' contained
-syn match snipKeyword '^(snippet|extends|version)'me=s+8 contained
-syn match snipError "^[^#vse\t].*$"
+syn match snipKeyword '^(snippet|extends|version|autosnippet)'me=s+8 contained
+syn match snipError "^[^#vsae\t].*$"
 
 hi link snippet       Identifier
 hi link snipComment   Comment

--- a/tests/data/lua-snippets/luasnippets/all.lua
+++ b/tests/data/lua-snippets/luasnippets/all.lua
@@ -1,3 +1,5 @@
 return {
 	s("all1", fmt("expands? jumps? {} {} !", { i(1), i(2) })),
+}, {
+	parse("auto???", "autotriggered????????"),
 }

--- a/tests/data/snipmate-snippets/snippets1/all.snippets
+++ b/tests/data/snipmate-snippets/snippets1/all.snippets
@@ -6,5 +6,3 @@ snippet all2 Another snippet
 	# not removed??
 	line$2
 	snippet$0
-autosnippet snipmatesnipmatesnipmate An autotriggered snippet
-	snipmate$1autoautoauto

--- a/tests/data/snipmate-snippets/snippets1/lua.snippets
+++ b/tests/data/snipmate-snippets/snippets1/lua.snippets
@@ -1,0 +1,2 @@
+snippet snipmate_lua1 A lua snippet
+	snipmate$1lualualua

--- a/tests/data/snipmate-snippets/snippets1/vim.snippets
+++ b/tests/data/snipmate-snippets/snippets1/vim.snippets
@@ -1,0 +1,3 @@
+extends lua
+snippet snipmate_vim1 A vim snippet
+	snipmate$1vimvimvim

--- a/tests/data/vscode-snippets/snippets/all.json
+++ b/tests/data/vscode-snippets/snippets/all.json
@@ -13,5 +13,14 @@
 			"#not removed??",
 			"snippet$0"
 		]
+	},
+	"snip2": {
+		"prefix": "vscode_lua2",
+		"body": [
+			"vscode$1lualualua"
+		],
+		"luasnip": {
+			"autotrigger": true
+		}
 	}
 }


### PR DESCRIPTION
Includes small improvements:
* correctly handle multiple `lazy_load`-calls (previously only the last is stored)
* adding autosnippets is now possible via `autosnippet`-keyword instead of `snippet` (as proposed in #372)

Should be functional, still needs docs+tests.