### PR TITLE
Expose plugin hint for vim.ui.select

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -853,7 +853,7 @@ preferably via some keybind, eg.
 ```vim
 inoremap <c-u> <cmd>lua require("luasnip.extras.select_choice")()<cr>
 ```
-, while inside a choiceNode.
+, while inside a choiceNode. The `opts.kind` hint for `vim.ui.select` will be set to `luasnip`.
 
 
 # LSP-SNIPPETS

--- a/lua/luasnip/extras/select_choice.lua
+++ b/lua/luasnip/extras/select_choice.lua
@@ -27,7 +27,7 @@ end
 
 local function select_choice()
 	assert(session.active_choice_node, "No active choiceNode")
-	vim.ui.select(active_choice_get_choices_text(), {}, set_choice_callback)
+	vim.ui.select(active_choice_get_choices_text(), {kind="luasnip"}, set_choice_callback)
 end
 
 return select_choice


### PR DESCRIPTION
Useful for custom `vim.ui.select` handlers.