### PR TITLE
Improve loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ For nvim-cmp, it is also possible to follow the [example recommendation](https:/
 
 ## Add Snippets
 
+Check out [the doc](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#loaders) for a general explanation of the
+loaders and their benefits. The following list serves only as a short overview.
+
 - **Vscode-like**: To use existing vs-code style snippets from a plugin (eg. [rafamadriz/friendly-snippets](https://github.com/rafamadriz/friendly-snippets)) simply install the plugin and then add
     ```lua
     require("luasnip.loaders.from_vscode").lazy_load()
@@ -176,7 +179,7 @@ For nvim-cmp, it is also possible to follow the [example recommendation](https:/
     -- load snippets from path/of/your/nvim/config/my-cool-snippets
     require("luasnip.loaders.from_vscode").lazy_load({ paths = { "./my-cool-snippets" } })
     ```
-	For more info on the vscode-loader, check the [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L501) or [documentation](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#vscode-snippets-loader).
+	For more info on the vscode-loader, check the [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L501) or [documentation](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#loaders).
 
 - **Snipmate-like**: Very similar to Vscode-packages: install a plugin that provides snippets and call the `load`-function:
     ```lua
@@ -193,13 +196,14 @@ For nvim-cmp, it is also possible to follow the [example recommendation](https:/
         if ($1)
         	$0
         ```
-    Again, there are some [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L517) and an entry in the [docs](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#snipmate-snippets-loader)
+    Again, there are some [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L517) and [documentation](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#snipmate).  
 - **Lua**: Add the snippets by calling `require("luasnip").add_snippets(filetype, snippets)`. An example for this can be found [here](https://github.com/L3MON4D3/LuaSnip/blob/master/Examples/snippets.lua#L190).  
-This can also be done much better (one snippet-file per filetype+command for editing the current filetype+reload on edit) than in the example by using the [loader for lua](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader)
+This can also be done much cleaner, with all the benefits that come with using a loader, by using the [loader for lua](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua)
+
 There's also a repository collecting snippets for various languages, [molleweide/LuaSnip-snippets.nvim](https://github.com/molleweide/LuaSnip-snippets.nvim)
 
 ## Docs and Examples
-Check [`DOC.md`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md) (or `:help luasnip`) for a short overview and in-depth explanations of the different nodes and available API.
+Check [`DOC.md`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md) (or `:help luasnip`) for a short overview and in-depth explanations of the different nodes and available API.  
 I highly recommend looking into (or better yet, `:luafile`ing) [`Examples/snippets.lua`](https://github.com/L3MON4D3/LuaSnip/blob/master/Examples/snippets.lua) before writing snippets in lua.  
 The [Wiki](https://github.com/L3MON4D3/LuaSnip/wiki) contains some pretty useful extensions to Luasnip.
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.5.0             Last change: 2022 May 14
+*luasnip.txt*             For NVIM v0.5.0             Last change: 2022 May 15
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -21,16 +21,19 @@ Table of Contents                                  *luasnip-table-of-contents*
   - Select_choice                                      |luasnip-select_choice|
 14. LSP-SNIPPETS                                        |luasnip-lsp-snippets|
 15. VARIABLES                                              |luasnip-variables|
-16. VSCODE SNIPPETS LOADER                    |luasnip-vscode-snippets-loader|
-17. SNIPMATE SNIPPETS LOADER                |luasnip-snipmate-snippets-loader|
-18. LUA SNIPPETS LOADER                          |luasnip-lua-snippets-loader|
-19. SNIPPETPROXY                                        |luasnip-snippetproxy|
-20. EXT_OPTS                                                |luasnip-ext_opts|
-21. DOCSTRING                                              |luasnip-docstring|
-22. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
-23. EVENTS                                                    |luasnip-events|
-24. CLEANUP                                                  |luasnip-cleanup|
-25. API-REFERENCE                                      |luasnip-api-reference|
+16. LOADERS                                                  |luasnip-loaders|
+  - Troubleshooting                                  |luasnip-troubleshooting|
+  - VSCODE                                                    |luasnip-vscode|
+  - SNIPMATE                                                |luasnip-snipmate|
+  - LUA                                                          |luasnip-lua|
+  - EDIT_SNIPPETS                                      |luasnip-edit_snippets|
+17. SNIPPETPROXY                                        |luasnip-snippetproxy|
+18. EXT_OPTS                                                |luasnip-ext_opts|
+19. DOCSTRING                                              |luasnip-docstring|
+20. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
+21. EVENTS                                                    |luasnip-events|
+22. CLEANUP                                                  |luasnip-cleanup|
+23. API-REFERENCE                                      |luasnip-api-reference|
 
 >
                 __                       ____
@@ -992,127 +995,250 @@ case, hitting `<Tab>` while in Visualmode will populate the `*SELECT*`-vars for
 the next snippet and then clear them.
 
 ==============================================================================
-16. VSCODE SNIPPETS LOADER                    *luasnip-vscode-snippets-loader*
+16. LOADERS                                                  *luasnip-loaders*
 
-As luasnip is capable of loading the same format of plugins as vscode, it also
-includes an easy way for loading those automatically. You just have to call:
+Luasnip is capable of loading snippets from different formats, including both
+the well-established vscode- and snipmate-format, as well as plain lua-files
+for snippets written in lua
+
+All loaders share a similar interface:
 
 >
-    require("luasnip.loaders.from_vscode").load(opts) -- opts can be ommited
+    require("luasnip.loaders.from_{vscode,snipmate,lua}").{lazy_,}load(opts:table|nil)
 <
 
 
-Where `opts` is a table containing the keys: - `paths`: List of paths to load.
-Can be a table or a single, comma-separated string. If not set, `runtimepath`
-is used. The paths may begin with `~/` or `./` to indicate that the path is
-relative to your home or to the folder where your `$MYVIMRC` resides (useful to
-add your snippets). The directories passed this way must be structured like
-`friendly-snippets` <https://github.com/rafamadriz/friendly-snippets> eg.
-include a `package.json`. - `exclude`: List of languages to exclude, by default
-is empty. - `include`: List of languages to include, by default is not set.
+where `opts` can contain the following keys:
 
-The last two are useful mainly to avoid loading snippets from 3erd parties you
-don’t wanna include.
 
-Keep in mind that it will extend your `snippets` table, so do it after setting
-your snippets or you will have to extend the table as well.
+- `paths`: List of paths to load. Can be a table or a single,
+    comma-separated string.
+    The paths may begin with `~/` or `./` to indicate that the path is
+    relative to your `$HOME` or to the directory where your `$MYVIMRC` resides
+    (useful to add your snippets).
+    If not set, `runtimepath` is searched for
+    directories that contain snippets. This procedure differs slightly for
+    each loader:
+    - `lua`: the snippet-library has to be in a directory named
+        `"luasnippets"`.
+    - `snipmate`: similar to lua, but the directory has to be `"snippets"`.
+    - `vscode`: any directory in `runtimepath` that contains a
+        `package.json` contributing snippets.
+- `exclude`: List of languages to exclude, empty by default.
+- `include`: List of languages to include, includes everything by default.
+- `{override,default}_priority`: These keys are passed straight to the
+    |luasnip-`add_snippets`|-calls and can therefore change the priority
+    of snippets loaded from some colletion (or, in combination with
+    `{in,ex}clude`, only some of its snippets).
 
-Another way of using the loader is making it lazily
+
+While `load` will immediately load the snippets, `lazy_load` will defer loading
+until the snippets are actually needed (whenever a new buffer is created or the
+filetype is changed luasnip actually loads `lazy_load`ed snippets for the
+filetypes associated with this buffer).
+
+All of the loaders support reloading, so simply editing any file contributing
+snippets will reload its snippets (only in the session the file was edited in,
+we use `BufWritePost` for reloading, not some lower-level mechanism).
+
+For easy editing of these files, Luasnip provides a
+|luasnip-`vim.ui.select`-based-dialog| where first the filetype, and then the
+file can be selected.
+
+TROUBLESHOOTING                                      *luasnip-troubleshooting*
+
+
+- Luasnip uses `all` as the global filetype. As most snippet collections don’t
+    explicitly target luasnip, they may not provide global snippets for this
+    filetype, but another, like `_` (`honza/vim-snippets`). In these cases, it’s
+    necessary to extend luasnip’s global filetype with the collection’s global
+    filetype:
+    >
+        ls.filetype_extend("all", { "_" })
+    <
+    In general, if some snippets don’t show up when loading a collection, a good
+    first step is checking the filetype luasnip is actually looking into (print
+    them for the current buffer via `:lua
+    print(vim.inspect(require("luasnip").get_snippet_filetypes()))`), against the
+    one the missing snippet is provided for (in the collection). If there is indeed
+    a mismatch, `filetype_extend` can be used to also search the collection’s
+    filetype:
+    >
+        ls.filetype_extend("<luasnip-filetype>", { "<collection-filetype>" })
+    <
+- As we only load `lazy_load`ed snippet on some events, `lazy_load` will probably
+    not play nice when a non-default `ft_func` is used: if it depends on eg. the
+    cursor-position, only the filetypes for the cursor-position when the
+    `lazy_load`-events are triggered will be loaded. In these cases, `load` should
+    be used.
+
+
+VSCODE                                                        *luasnip-vscode*
+
+As a reference on the structure of these snippet-libraries, see
+`friendly-snippets` <https://github.com/rafamadriz/friendly-snippets>.
+
+We support a small extension: snippets can contain luasnip-specific options in
+the `luasnip`-table:
 
 >
-    require("luasnip.loaders.from_vscode").lazy_load(opts) -- opts can be ommited
+    "example1": {
+        "prefix": "options",
+        "body": [
+            "whoa! :O"
+        ],
+        "luasnip": {
+            "priority": 2000,
+            "autotrigger": true
+        }
+    }
 <
 
 
-In this case `opts` only accepts paths (`runtimepath` if any). That will load
-the general snippets (the ones of filetype 'all') and those of the filetype of
-the buffers, you open every time you open a new one (but it won’t reload
-them).
+**Example**:
 
-Apart from what is stipulated by the start each snippet in the json file can
-contain a "luasnip" field which is a table for extra parameters for the
-snippet, till now the only valid one is autotrigger.
-
-After snippets were lazy-loaded, the `User LuasnipSnippetsAdded`-event will be
-triggered.
-
-Note load vscode-style packages using
-`require("luasnip.loaders.from_vscode").load()`, if you’ve configured luasnip
-to detect the filetype based on the cursor position. Else the snippets won’t
-be available to the `from_cursor_pos` function.
-
-==============================================================================
-17. SNIPMATE SNIPPETS LOADER                *luasnip-snipmate-snippets-loader*
-
-As the snipmate snippet format is fundamentally the same as vscode, it can also
-be loaded.
+`~/.config/nvim/my_snippets/package.json`:
 
 >
-    require("luasnip.loaders.from_snipmate").load(opts) -- opts can be ommited
+    {
+        "name": "example-snippets",
+        "contributes": {
+            "snippets": [
+                {
+                    "language": [
+                        "all"
+                    ],
+                    "path": "./snippets/all.json"
+                },
+                {
+                    "language": [
+                        "lua"
+                    ],
+                    "path": "./lua.json"
+                }
+            ]
+        }
+    }
 <
 
 
-See `from_vscode` for an explanation of opts. If `opts.paths` is ommited,
-snippets are loaded from any directory named `snippets` located in the
-`runtimepath`.
-
-Luasnip is compatible with honza/vim-snippets
-<https://github.com/honza/vim-snippets>. Please use it as a reference for your
-directory structure.
-
-When using `honza/vim-snippets`, the file with the global snippets is
-`_.snippets`, So we need to tell luasnip that `_` also contains global
-snippets:
+`~/.config/nvim/my_snippets/snippets/all.json`:
 
 >
-    ls.filetype_extend("all", { "_" })
+    {
+        "snip1": {
+            "prefix": "all1",
+            "body": [
+                "expands? jumps? $1 $2 !"
+            ]
+        },
+        "snip2": {
+            "prefix": "all2",
+            "body": [
+                "multi $1",
+                "line $2",
+                "snippet$0"
+            ]
+        },
+    }
 <
 
 
-Something similar may have to be done for other snippet-repos as well.
-
-Using both `extends OtherFileType` in `FileType.snippets` and
-`ls.filetype_extend("FileType", {"OtherFileType"})` leads to duplicate
-snippets.
-
-Lazy loading is also available with the snipmate-loader.
+`~/.config/nvim/my_snippets/lua.json`:
 
 >
-    require("luasnip.loaders.from_snipmate").lazy_load(opts) -- opts can be ommited
+    {
+        "snip1": {
+            "prefix": "lua",
+            "body": [
+                "lualualua"
+            ]
+        }
+    }
 <
 
 
-Here is a summary of the differences from the original snipmate format.
+This collection can be loaded with any of
+
+>
+    -- don't pass any arguments, luasnip will find the collection because it is
+    -- (probably) in rtp.
+    require("luasnip.loaders.from_vscode").lazy_load()
+    -- specify the full path...
+    require("luasnip.loaders.from_vscode").lazy_load({paths = "~/.config/nvim/my_snippets"})
+    -- or relative to the directory of $MYVIMRC
+    require("luasnip.loaders.from_vscode").load({paths = "./my_snippets"})
+<
 
 
-- Only `./{ft}.snippets` and `./{ft}/*.snippets` will be loaded.
-- The file name or folder name will be used as file type.
-- You can use the comment and extends syntax.
+SNIPMATE                                                    *luasnip-snipmate*
+
+Luasnip does not support the full snipmate format: Only `./{ft}.snippets` and
+`./{ft}/*.snippets` will be loaded. See honza/vim-snippets
+<https://github.com/honza/vim-snippets> for lots of examples.
+
+Like vscode, the snipmate-format is also extended to make use of some of
+luasnips more advanced capabilities:
+
+>
+    priority 2000
+    autosnippet options
+        whoa :O
+<
+
+
+**Example**:
+
+`~/.config/nvim/snippets/c.snippets`:
+
+>
+    # this is a comment
+    snippet c c-snippet
+        c!
+<
+
+
+`~/.config/nvim/snippets/cpp.snippets`:
+
+>
+    extends c
+    
+    snippet cpp cpp-snippet
+        cpp!
+<
+
+
+This can, again, be loaded with any of
+
+>
+    require("luasnip.loaders.from_snipmate").load()
+    -- specify the full path...
+    require("luasnip.loaders.from_snipmate").lazy_load({paths = "~/.config/nvim/snippets"})
+    -- or relative to the directory of $MYVIMRC
+    require("luasnip.loaders.from_snipmate").lazy_load({paths = "./snippets"})
+<
+
+
+Stuff to watch out for:
+
+
+- Using both `extends <ft2>` in `<ft1>.snippets` and
+    `ls.filetype_extend("<ft1>", {"<ft2>"})` leads to duplicate snippets.
 - `${VISUAL}` will be replaced by `$TM_SELECTED_TEXT` to make the snippets
     compatible with luasnip
-- We do not implement eval using ` (backtick). This may be implemented in the future.
-- `snippet ...` defines a regular snippet wheras `autosnippet ...` may be used
-    to add autotriggered snippets.
+- We do not implement eval using ` (backtick). This may be implemented in the
+    future.
 
 
-==============================================================================
-18. LUA SNIPPETS LOADER                          *luasnip-lua-snippets-loader*
+LUA                                                              *luasnip-lua*
 
 Instead of adding all snippets via `add_snippets`, it’s possible to store
-them in separate files (each for one filetype) and load all of those.
-
-For this, the files need to be
-
-
-- in a single directory. The directory may be passed directly to `load()`, or it
-    can be named `luasnippets` and in the `runtimepath`, in which case it will be
-    automatically detected.
-- named `<filetype>.lua` or in a subdirectory `<filetype>/somename.lua`
-    (Snipmate-structure).
-- return two lists of snippets (either may be `nil`). The snippets in the first
-    are regular snippets for `<filetype>`, the ones in the second are autosnippets
-    (make sure they are enabled if this table is used).
-
+them in separate files and load all of those. The file-structure here is
+exactly the supported snipmate-structure, eg. `<ft>.lua` or `<ft>/*.lua` to add
+snippets for the filetype `<ft>`. The files need to return two lists of
+snippets (either may be `nil`). The snippets in the first are regular snippets
+for `<ft>`, the ones in the second are autosnippets (make sure they are enabled
+in `setup` or `set_config` if this table is used).
 
 As defining all of the snippet-constructors (`s`, `c`, `t`, …) in every file
 is rather cumbersome, luasnip will bring some globals into scope for executing
@@ -1121,25 +1247,7 @@ these files. By default the names from `luasnip.config.snip_env`
 will be used, but it’s possible to customize them by setting `snip_env` in
 `setup`.
 
-These collections can be loaded directly
-(`require("luasnip.loaders.from_lua").load(opts)`) or lazily
-(`require("luasnip.loaders.from_lua").lazy_load(opts)`).
-
-lua-`opts` may contain the same keys as vscode-`opts`, but here `include` and
-`exclude` can be used in `lazy_load`.
-
-Apart from loading, `from_lua` also exposes functions to edit files associated
-with the currently active filetypes, which could be called via an command, for
-example:
-
->
-    command! LuaSnipEdit :lua require("luasnip.loaders.from_lua").edit_snippet_files()
-<
-
-
-Once loaded, files will be reloaded on save (`BufWritePost`).
-
-Example:
+**Example**:
 
 `~/snippets/all.lua`:
 
@@ -1168,8 +1276,39 @@ Load via
 <
 
 
+EDIT_SNIPPETS                                          *luasnip-edit_snippets*
+
+To easily edit snippets for the current session, the files loaded by any loader
+can be quickly edited via
+`require("luasnip.loaders").edit_snippet_files(opts:table|nil)` When called, it
+will open a `vim.ui.select`-dialog to select first a filetype, and then (if
+there are multiple) the associated file to edit.
+
+`opts` currently only contains only one setting:
+
+
+- `format`: `fn(file:string, source_name:string) -> string|nil`
+    `file` is simply the path to the file, `source_name` is one of `"lua"`,
+    `"snipmate"` or `"vscode"`.
+    If a string is returned, it is used as the title of the item, `nil` on the
+    other hand will filter out this item.
+    The default simply replaces some long strings (packer-path and config-path)
+    in `file` with shorter, symbolic names (`"$PLUGINS"`, `"$CONFIG"`), but
+    this can be extended to
+    - filter files from some specific source/path
+    - more aggressively shorten paths using symbolic names, eg.
+        `"$FRIENDLY_SNIPPETS"`
+
+
+One comfortable way to call this function is registering it as a command:
+
+>
+    command! LuaSnipEdit :lua require("luasnip.loaders").edit_snippet_files()
+<
+
+
 ==============================================================================
-19. SNIPPETPROXY                                        *luasnip-snippetproxy*
+17. SNIPPETPROXY                                        *luasnip-snippetproxy*
 
 `SnippetProxy` is used internally to alleviate the upfront-cost of loading
 snippets from eg. a snipmate-library or a vscode-package. This is achieved by
@@ -1193,7 +1332,7 @@ This will parse the snippet on startup…
 
 
 ==============================================================================
-20. EXT_OPTS                                                *luasnip-ext_opts*
+18. EXT_OPTS                                                *luasnip-ext_opts*
 
 `ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
 extmarks used for marking node-positions, either globally, per-snippet or
@@ -1392,7 +1531,7 @@ Here the highlight of an insertNode nested directly inside a choiceNode is
 always visible on top of it.
 
 ==============================================================================
-21. DOCSTRING                                              *luasnip-docstring*
+19. DOCSTRING                                              *luasnip-docstring*
 
 Snippet-docstrings can be queried using `snippet:get_docstring()`. The function
 evaluates the snippet as if it was expanded regularly, which can be problematic
@@ -1442,7 +1581,7 @@ Other issues will have to be handled manually by checking the contents of eg.
 
 
 ==============================================================================
-22. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
+20. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
 
 Although generation of docstrings is pretty fast, it’s preferable to not redo
 it as long as the snippets haven’t changed. Using
@@ -1459,7 +1598,7 @@ The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 `~/.cache/nvim/luasnip/docstrings.json`).
 
 ==============================================================================
-23. EVENTS                                                    *luasnip-events*
+21. EVENTS                                                    *luasnip-events*
 
 Upon leaving/entering nodes or changing a choice an event is triggered: `User
 Luasnip<Node>{Enter,Leave}`, where `<Node>` is the name of a node in
@@ -1476,14 +1615,14 @@ be printing eg. the nodes’ text after entering:
 
 
 ==============================================================================
-24. CLEANUP                                                  *luasnip-cleanup*
+22. CLEANUP                                                  *luasnip-cleanup*
 
 The function ls.cleanup() triggers the `LuasnipCleanup` user-event, that you
 can listen to do some kind of cleaning in your own snippets, by default it will
 empty the snippets table and the caches of the lazy_load.
 
 ==============================================================================
-25. API-REFERENCE                                      *luasnip-api-reference*
+23. API-REFERENCE                                      *luasnip-api-reference*
 
 `require("luasnip")`:
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.5.0             Last change: 2022 May 05
+*luasnip.txt*             For NVIM v0.5.0             Last change: 2022 May 14
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -3,7 +3,7 @@ local util = require("luasnip.util.util")
 local session = require("luasnip.session")
 local snippet_collection = require("luasnip.session.snippet_collection")
 
-local loader_caches = require("luasnip.loaders._caches")
+local loader = require("luasnip.loaders")
 
 local next_expand = nil
 local next_expand_params = nil
@@ -555,7 +555,7 @@ local function cleanup()
 	vim.cmd([[doautocmd <nomodeline> User LuasnipCleanup]])
 	-- clear all snippets.
 	snippet_collection.clear_snippets()
-	loader_caches.cleanup()
+	loader.cleanup()
 end
 
 local function refresh_notify(ft)

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -649,6 +649,7 @@ ls = {
 	get_id_snippet = get_id_snippet,
 	setup_snip_env = setup_snip_env,
 	clean_invalidated = clean_invalidated,
+	get_snippet_filetypes = util.get_snippet_filetypes,
 	s = snip_mod.S,
 	sn = snip_mod.SN,
 	t = require("luasnip.nodes.textNode").T,

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -163,21 +163,11 @@ function M.reload_file(filename)
 	-- only clear and load(!!! snippets may not actually be loaded, lazy_load)
 	-- if the snippets were really loaded.
 	if file_cache then
-		for _, snip in ipairs(file_cache.snippets) do
-			snip:invalidate()
-		end
-		for _, snip in ipairs(file_cache.autosnippets) do
-			snip:invalidate()
-		end
-
 		local add_opts = file_cache.add_opts
 		local ft = file_cache.ft
 
-		-- only refresh all filetypes if invalidated snippets were actually cleaned.
-		ls.clean_invalidated({ inv_limit = 100 })
-		ls.refresh_notify(ft)
-
 		load_files(ft, { filename }, add_opts)
+		ls.clean_invalidated({ inv_limit = 100 })
 	end
 end
 

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -44,6 +44,7 @@ local function load_files(ft, files, add_opts)
 		cache.path_snippets[file] = {
 			snippets = file_snippets,
 			autosnippets = file_autosnippets,
+			add_opts = add_opts,
 		}
 
 		-- use lua autocommands here as soon as they're stable.
@@ -161,6 +162,7 @@ function M.reload_file(filename)
 		for _, snip in ipairs(cache.path_snippets[filename].autosnippets) do
 			snip:invalidate()
 		end
+		local add_opts = cache.path_snippets[filename].add_opts
 
 		local ft = path_mod.basename(filename, true)
 
@@ -168,7 +170,7 @@ function M.reload_file(filename)
 		ls.clean_invalidated({ inv_limit = 100 })
 		ls.refresh_notify(ft)
 
-		load_files(ft, { filename })
+		load_files(ft, { filename }, add_opts)
 	end
 end
 

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -48,16 +48,16 @@ local function load_files(ft, files, add_opts)
 			ft = ft,
 		}
 
-		-- use lua autocommands here as soon as they're stable.
+		-- Use lua autocommands here as soon as they're stable.
+		-- ++once: the autocommand will be re-registered in the reload_file-call.
+		-- All autocommands in the augroup will be cleaned on ls.cleanup.
 		-- stylua: ignore
 		vim.cmd(string.format(
 			[[
-				augroup luasnip_watch_%s
-				autocmd!
-				autocmd BufWritePost %s lua require("luasnip.loaders.from_lua").reload_file("%s")
+				augroup luasnip_watch_reload
+				autocmd BufWritePost %s ++once lua require("luasnip.loaders.from_lua").reload_file("%s")
+				augroup END
 			]],
-			-- augroup name may not contain spaces.
-			file:gsub(" ", "_"),
 			-- escape for autocmd-pattern.
 			file:gsub(" ", "\\ "),
 			file

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -105,6 +105,8 @@ end
 function M.load(opts)
 	opts = opts or {}
 
+	local add_opts = loader_util.add_opts(opts)
+
 	local collections = loader_util.get_load_paths_snipmate_like(
 		opts,
 		"luasnippets",
@@ -118,14 +120,15 @@ function M.load(opts)
 		loader_util.extend_ft_paths(cache.ft_paths, load_paths)
 
 		for ft, files in pairs(load_paths) do
-			load_files(ft, files, opts.add_opts or {})
+			load_files(ft, files, add_opts)
 		end
 	end
 end
 
 function M.lazy_load(opts)
 	opts = opts or {}
-	local add_opts = opts.add_opts or {}
+
+	local add_opts = loader_util.add_opts(opts)
 
 	local collections = loader_util.get_load_paths_snipmate_like(
 		opts,

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -177,14 +177,4 @@ function M.edit_snippet_files()
 	loader_util.edit_snippet_files(cache.ft_paths)
 end
 
--- register during startup (not really startup, as soon as this file is
--- required) so it'll work even if lazy_load is only called after the events
--- for some buffers already fired.
-vim.cmd([[
-augroup _luasnip_lua_lazy_load
-	autocmd!
-	au BufWinEnter,FileType * lua require('luasnip.loaders.from_lua')._load_lazy_loaded()
-augroup END
-]])
-
 return M

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -42,8 +42,6 @@ local function load_files(ft, files, add_opts)
 
 		-- keep track of snippet-source.
 		cache.path_snippets[file] = {
-			snippets = file_snippets,
-			autosnippets = file_autosnippets,
 			add_opts = add_opts,
 			ft = ft,
 		}

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -162,6 +162,8 @@ function M.reload_file(filename)
 	local file_cache = cache.path_snippets[filename]
 	-- only clear and load(!!! snippets may not actually be loaded, lazy_load)
 	-- if the snippets were really loaded.
+	-- normally file_cache should exist if the autocommand was registered, just
+	-- be safe here.
 	if file_cache then
 		local add_opts = file_cache.add_opts
 		local ft = file_cache.ft

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -107,18 +107,21 @@ end
 function M.load(opts)
 	opts = opts or {}
 
-	local load_paths = loader_util.get_load_paths_snipmate_like(
+	local collections = loader_util.get_load_paths_snipmate_like(
 		opts,
 		"luasnippets",
 		"lua"
 	)
+	for _, collection in ipairs(collections) do
+		local load_paths = collection.load_paths
 
-	-- also add files from collection to cache (collection of all loaded
-	-- files by filetype, useful for editing files for some filetype).
-	loader_util.extend_ft_paths(cache.ft_paths, load_paths)
+		-- also add files from collection to cache (collection of all loaded
+		-- files by filetype, useful for editing files for some filetype).
+		loader_util.extend_ft_paths(cache.ft_paths, load_paths)
 
-	for ft, files in pairs(load_paths) do
-		load_files(ft, files, opts.add_opts or {})
+		for ft, files in pairs(load_paths) do
+			load_files(ft, files, opts.add_opts or {})
+		end
 	end
 end
 
@@ -126,27 +129,29 @@ function M.lazy_load(opts)
 	opts = opts or {}
 	local add_opts = opts.add_opts or {}
 
-	local load_paths = loader_util.get_load_paths_snipmate_like(
+	local collections = loader_util.get_load_paths_snipmate_like(
 		opts,
 		"luasnippets",
 		"lua"
 	)
+	for _, collection in ipairs(collections) do
+		local load_paths = collection.load_paths
 
-	loader_util.extend_ft_paths(cache.ft_paths, load_paths)
+		loader_util.extend_ft_paths(cache.ft_paths, load_paths)
 
-	for ft, files in pairs(load_paths) do
-		if cache.lazy_loaded_ft[ft] then
-			-- instantly load snippets if they were already loaded...
-			load_files(ft, files, add_opts)
+		for ft, files in pairs(load_paths) do
+			if cache.lazy_loaded_ft[ft] then
+				-- instantly load snippets if they were already loaded...
+				load_files(ft, files, add_opts)
 
-			-- don't load these files again.
-			load_paths[ft] = nil
+				-- don't load these files again.
+				load_paths[ft] = nil
+			end
 		end
+
+		load_paths.add_opts = add_opts
+		table.insert(cache.lazy_load_paths, load_paths)
 	end
-
-	load_paths.add_opts = add_opts
-	table.insert(cache.lazy_load_paths, load_paths)
-
 	-- call once for current filetype. Necessary for lazy_loading snippets in
 	-- empty, initial buffer, and will not cause issues like duplicate
 	-- snippets.

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -172,28 +172,7 @@ function M.reload_file(filename)
 end
 
 function M.edit_snippet_files()
-	local fts = util.get_snippet_filetypes()
-	vim.ui.select(fts, {
-		prompt = "Select filetype:",
-	}, function(item, _)
-		if item then
-			local ft_paths = cache.ft_paths[item]
-			if ft_paths then
-				-- prompt user again if there are multiple files providing this filetype.
-				if #ft_paths > 1 then
-					vim.ui.select(ft_paths, {
-						prompt = "Multiple files for this filetype, choose one:",
-					}, function(multi_item)
-						vim.cmd("edit " .. multi_item)
-					end)
-				else
-					vim.cmd("edit " .. ft_paths[1])
-				end
-			else
-				print("No file for this filetype.")
-			end
-		end
-	end)
+	loader_util.edit_snippet_files(cache.ft_paths)
 end
 
 -- register during startup (not really startup, as soon as this file is

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -83,15 +83,15 @@ local function load_snippet_files(add_ft, paths, collection_files, add_opts)
 		local snippet, autosnippet, extends
 
 		if cache.path_snippets[path] then
-			snippet = cache.path_snippets[path].snippet
-			autosnippet = cache.path_snippets[path].autosnippet
+			snippet = vim.deepcopy(cache.path_snippets[path].snippet)
+			autosnippet = vim.deepcopy(cache.path_snippets[path].autosnippet)
 			extends = cache.path_snippets[path].extends
 		else
 			local buffer = Path.read_file(path)
 			snippet, autosnippet, extends = parse_snipmate(buffer, path)
 			cache.path_snippets[path] = {
-				snippet = snippet,
-				autosnippet = autosnippet,
+				snippet = vim.deepcopy(snippet),
+				autosnippet = vim.deepcopy(autosnippet),
 				extends = extends,
 				-- store for reload.
 				add_opts = add_opts,

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -74,61 +74,68 @@ local function parse_snipmate(buffer, filename)
 	return snippets.snippet, snippets.autosnippet, extends
 end
 
-local function load_snippet_file(path)
-	if not Path.exists(path) then
-		return
+local function load_snippet_files(add_ft, paths, collection_files, add_opts)
+	for _, path in ipairs(paths) do
+		if not Path.exists(path) then
+			return
+		end
+
+		local snippet, autosnippet, extends
+
+		if cache.path_snippets[path] then
+			snippet = cache.path_snippets[path].snippet
+			autosnippet = cache.path_snippets[path].autosnippet
+			extends = cache.path_snippets[path].extends
+		else
+			local buffer = Path.read_file(path)
+			snippet, autosnippet, extends = parse_snipmate(buffer, path)
+			cache.path_snippets[path] = {
+				snippet = snippet,
+				autosnippet = autosnippet,
+				extends = extends,
+			}
+		end
+
+		ls.add_snippets(
+			add_ft,
+			snippet,
+			vim.tbl_extend("keep", {
+				type = "snippets",
+				-- key has to include the filetype since one file may be loaded in
+				-- multiple filetypes (via `extends`).
+				key = string.format("__%s_snippets_%s", add_ft, path),
+			}, add_opts)
+		)
+		ls.add_snippets(
+			add_ft,
+			autosnippet,
+			vim.tbl_extend("keep", {
+				type = "autosnippets",
+				key = string.format("__%s_autosnippets_%s", add_ft, path),
+			}, add_opts)
+		)
+
+		for _, ft in ipairs(extends) do
+			-- "or {}" because the ft might (if the extended filetype is not
+			-- actually present in the collection) be nil.
+			load_snippet_files(
+				add_ft,
+				collection_files[ft] or {},
+				collection_files,
+				add_opts
+			)
+		end
 	end
-
-	local snippet, autosnippet, extends
-
-	if cache.path_snippets[path] then
-		snippet = cache.path_snippets[path].snippet
-		autosnippet = cache.path_snippets[path].autosnippet
-		extends = cache.path_snippets[path].extends
-	else
-		local buffer = Path.read_file(path)
-		snippet, autosnippet, extends = parse_snipmate(buffer)
-		cache.path_snippets[path] = {
-			snippet = snippet,
-			autosnippet = autosnippet,
-			extends = extends,
-		}
-	end
-
-	return snippet, autosnippet, extends
 end
 
 local M = {}
 
-function M._load(ft, collection_files)
-	local snippets = {}
-	local autosnippets = {}
-	-- _load might be called for non-existing filetype via `extends`-directive,
-	-- protect against that via `or {}` (we fail silently, though, maybe we
-	-- should throw an error/print some message).
-	for _, path in ipairs(collection_files[ft] or {}) do
-		local file_snippets, file_autosnippets, extends = load_snippet_file(
-			path
-		)
-		vim.list_extend(snippets, file_snippets)
-		vim.list_extend(autosnippets, file_autosnippets)
-		for _, extend in ipairs(extends) do
-			local extend_snippets, extend_autosnippets = M._load(
-				extend,
-				collection_files
-			)
-			vim.list_extend(snippets, extend_snippets)
-			vim.list_extend(autosnippets, extend_autosnippets)
-		end
-	end
-	return snippets, autosnippets
-end
-
 function M.load(opts)
 	opts = opts or {}
 	local add_opts = opts.add_opts or {}
+
 	-- we need all paths available in the collection for `extends`.
-	-- load_paths alone is influenced by in/exclude.
+	-- only load_paths is influenced by in/exclude.
 	local load_paths, collection_paths =
 		loader_util.get_load_paths_snipmate_like(
 			opts,
@@ -136,22 +143,12 @@ function M.load(opts)
 			"snippets"
 		)
 
-	-- also add files from collection to cache (collection of all loaded
+	-- also add files from load_paths to cache (collection of all loaded
 	-- files by filetype, useful for editing files for some filetype).
 	loader_util.extend_ft_paths(cache.ft_paths, load_paths)
 
-	for ft, _ in pairs(load_paths) do
-		local snippets, autosnippets = M._load(ft, collection_paths)
-		ls.add_snippets(
-			ft,
-			snippets,
-			vim.tbl_extend("keep", { type = "snippets" }, add_opts)
-		)
-		ls.add_snippets(
-			ft,
-			autosnippets,
-			vim.tbl_extend("keep", { type = "autosnippets" }, add_opts)
-		)
+	for ft, paths in pairs(load_paths) do
+		load_snippet_files(ft, paths, collection_paths, add_opts)
 	end
 end
 
@@ -163,12 +160,12 @@ function M._lazyload()
 			for _, collection_load_paths in ipairs(cache.lazy_load_paths) do
 				-- don't load if this ft wasn't included/was excluded.
 				if collection_load_paths[ft] then
-					local snippets, autosnippets = M._load(
+					load_snippet_files(
 						ft,
-						collection_load_paths.collection
+						collection_load_paths[ft],
+						collection_load_paths.collection,
+						collection_load_paths.add_opts
 					)
-					ls.add_snippets(ft, snippets, { type = "snippets" })
-					ls.add_snippets(ft, autosnippets, { type = "autosnippets" })
 				end
 			end
 			cache.lazy_loaded_ft[ft] = true
@@ -189,22 +186,10 @@ function M.lazy_load(opts)
 
 	loader_util.extend_ft_paths(cache.ft_paths, load_paths)
 
-	for ft, _ in pairs(load_paths) do
+	for ft, paths in pairs(load_paths) do
 		if cache.lazy_loaded_ft[ft] then
-			-- instantly load snippets if they were already loaded...
-			local snippets, autosnippets = M._load(ft, collection_paths)
-			Insp(vim.tbl_extend("keep", { type = "snippets" }, add_opts))
-			Insp(vim.tbl_extend("keep", { type = "autosnippets" }, add_opts))
-			ls.add_snippets(
-				ft,
-				snippets,
-				vim.tbl_extend("keep", { type = "snippets" }, add_opts)
-			)
-			ls.add_snippets(
-				ft,
-				autosnippets,
-				vim.tbl_extend("keep", { type = "autosnippets" }, add_opts)
-			)
+			-- instantly load snippets if the ft is already loaded...
+			load_snippet_files(ft, paths, collection_paths, add_opts)
 			-- clear from load_paths to prevent duplicat loads.
 			load_paths[ft] = nil
 		end

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -125,6 +125,8 @@ function M._load(ft, collection_files)
 end
 
 function M.load(opts)
+	opts = opts or {}
+	local add_opts = opts.add_opts or {}
 	-- we need all paths available in the collection for `extends`.
 	-- load_paths alone is influenced by in/exclude.
 	local load_paths, collection_paths =
@@ -140,8 +142,16 @@ function M.load(opts)
 
 	for ft, _ in pairs(load_paths) do
 		local snippets, autosnippets = M._load(ft, collection_paths)
-		ls.add_snippets(ft, snippets, { type = "snippets" })
-		ls.add_snippets(ft, autosnippets, { type = "autosnippets" })
+		ls.add_snippets(
+			ft,
+			snippets,
+			vim.tbl_extend("keep", { type = "snippets" }, add_opts)
+		)
+		ls.add_snippets(
+			ft,
+			autosnippets,
+			vim.tbl_extend("keep", { type = "autosnippets" }, add_opts)
+		)
 	end
 end
 
@@ -167,6 +177,9 @@ function M._lazyload()
 end
 
 function M.lazy_load(opts)
+	opts = opts or {}
+	local add_opts = opts.add_opts or {}
+
 	local load_paths, collection_paths =
 		loader_util.get_load_paths_snipmate_like(
 			opts,
@@ -180,13 +193,25 @@ function M.lazy_load(opts)
 		if cache.lazy_loaded_ft[ft] then
 			-- instantly load snippets if they were already loaded...
 			local snippets, autosnippets = M._load(ft, collection_paths)
-			ls.add_snippets(ft, snippets, { type = "snippets" })
-			ls.add_snippets(ft, autosnippets, { type = "autosnippets" })
+			Insp(vim.tbl_extend("keep", { type = "snippets" }, add_opts))
+			Insp(vim.tbl_extend("keep", { type = "autosnippets" }, add_opts))
+			ls.add_snippets(
+				ft,
+				snippets,
+				vim.tbl_extend("keep", { type = "snippets" }, add_opts)
+			)
+			ls.add_snippets(
+				ft,
+				autosnippets,
+				vim.tbl_extend("keep", { type = "autosnippets" }, add_opts)
+			)
 			-- clear from load_paths to prevent duplicat loads.
 			load_paths[ft] = nil
 		end
 	end
+
 	load_paths.collection = collection_paths
+	load_paths.add_opts = add_opts
 	table.insert(cache.lazy_load_paths, load_paths)
 end
 

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -243,11 +243,4 @@ function M.reload_file(ft, file)
 	end
 end
 
-vim.cmd([[
-augroup _luasnip_snipmate_lazy_load
-	au!
-	au BufWinEnter,FileType * lua require("luasnip.loaders.from_snipmate")._lazyload()
-augroup END
-]])
-
 return M

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -101,16 +101,13 @@ local function load_snippet_files(add_ft, paths, collection_files, add_opts)
 		-- ++once: the autocommand will be re-added because this file will run again.
 		vim.cmd(string.format(
 			[[
-				augroup luasnip_watch_%s_%s
-				autocmd!
-				autocmd BufWritePost %s lua require("luasnip.loaders.from_snipmate").reload_file("%s", "%s")
+				augroup luasnip_watch_reload
+				autocmd BufWritePost %s ++once lua require("luasnip.loaders.from_snipmate").reload_file("%s", "%s")
 				augroup END
 			]],
-			-- augroup name may not contain spaces.
-			path:gsub(" ", "_"),
-			add_ft,
 			-- escape for autocmd-pattern.
 			path:gsub(" ", "\\ "),
+			-- args for reload.
 			add_ft,
 			path
 		))

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -148,7 +148,8 @@ local M = {}
 
 function M.load(opts)
 	opts = opts or {}
-	local add_opts = opts.add_opts or {}
+
+	local add_opts = loader_util.add_opts(opts)
 
 	-- we need all paths available in the collection for `extends`.
 	-- only load_paths is influenced by in/exclude.
@@ -195,7 +196,8 @@ end
 
 function M.lazy_load(opts)
 	opts = opts or {}
-	local add_opts = opts.add_opts or {}
+
+	local add_opts = loader_util.add_opts(opts)
 
 	local collections_load_paths = loader_util.get_load_paths_snipmate_like(
 		opts,

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -208,6 +208,10 @@ function M.lazy_load(opts)
 	end
 end
 
+function M.edit_snippet_files()
+	loader_util.edit_snippet_files(cache.ft_paths)
+end
+
 vim.cmd([[
 augroup _luasnip_snipmate_lazy_load
 	au!

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -83,7 +83,7 @@ local function load_snippet_file(path)
 
 	if cache.path_snippets[path] then
 		snippet = cache.path_snippets[path].snippet
-		autosnippet = cache.path_snippets[path].snippet
+		autosnippet = cache.path_snippets[path].autosnippet
 		extends = cache.path_snippets[path].extends
 	else
 		local buffer = Path.read_file(path)

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -136,19 +136,23 @@ function M.load(opts)
 
 	-- we need all paths available in the collection for `extends`.
 	-- only load_paths is influenced by in/exclude.
-	local load_paths, collection_paths =
-		loader_util.get_load_paths_snipmate_like(
-			opts,
-			"snippets",
-			"snippets"
-		)
+	local collections_load_paths = loader_util.get_load_paths_snipmate_like(
+		opts,
+		"snippets",
+		"snippets"
+	)
 
-	-- also add files from load_paths to cache (collection of all loaded
-	-- files by filetype, useful for editing files for some filetype).
-	loader_util.extend_ft_paths(cache.ft_paths, load_paths)
+	for _, collection in ipairs(collections_load_paths) do
+		local load_paths = collection.load_paths
+		local collection_paths = collection.collection_paths
 
-	for ft, paths in pairs(load_paths) do
-		load_snippet_files(ft, paths, collection_paths, add_opts)
+		-- also add files from load_paths to cache (collection of all loaded
+		-- files by filetype, useful for editing files for some filetype).
+		loader_util.extend_ft_paths(cache.ft_paths, load_paths)
+
+		for ft, paths in pairs(load_paths) do
+			load_snippet_files(ft, paths, collection_paths, add_opts)
+		end
 	end
 end
 
@@ -177,27 +181,31 @@ function M.lazy_load(opts)
 	opts = opts or {}
 	local add_opts = opts.add_opts or {}
 
-	local load_paths, collection_paths =
-		loader_util.get_load_paths_snipmate_like(
-			opts,
-			"snippets",
-			"snippets"
-		)
+	local collections_load_paths = loader_util.get_load_paths_snipmate_like(
+		opts,
+		"snippets",
+		"snippets"
+	)
 
-	loader_util.extend_ft_paths(cache.ft_paths, load_paths)
+	for _, collection in ipairs(collections_load_paths) do
+		local load_paths = collection.load_paths
+		local collection_paths = collection.collection_paths
 
-	for ft, paths in pairs(load_paths) do
-		if cache.lazy_loaded_ft[ft] then
-			-- instantly load snippets if the ft is already loaded...
-			load_snippet_files(ft, paths, collection_paths, add_opts)
-			-- clear from load_paths to prevent duplicat loads.
-			load_paths[ft] = nil
+		loader_util.extend_ft_paths(cache.ft_paths, load_paths)
+
+		for ft, paths in pairs(load_paths) do
+			if cache.lazy_loaded_ft[ft] then
+				-- instantly load snippets if the ft is already loaded...
+				load_snippet_files(ft, paths, collection_paths, add_opts)
+				-- clear from load_paths to prevent duplicat loads.
+				load_paths[ft] = nil
+			end
 		end
-	end
 
-	load_paths.collection = collection_paths
-	load_paths.add_opts = add_opts
-	table.insert(cache.lazy_load_paths, load_paths)
+		load_paths.collection = collection_paths
+		load_paths.add_opts = add_opts
+		table.insert(cache.lazy_load_paths, load_paths)
+	end
 end
 
 vim.cmd([[

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -14,7 +14,7 @@ local function json_decode(data)
 	end
 end
 
-local function load_snippet_file(langs, snippet_set_path)
+local function load_snippet_file(lang, snippet_set_path)
 	if not Path.exists(snippet_set_path) then
 		return
 	end
@@ -24,57 +24,43 @@ local function load_snippet_file(langs, snippet_set_path)
 		return
 	end
 
-	for _, lang in pairs(langs) do
-		local lang_snips = {}
-		local auto_lang_snips = {}
-		for name, parts in pairs(snippet_set_data) do
-			local body = type(parts.body) == "string" and parts.body
-				or table.concat(parts.body, "\n")
+	-- TODO: make check if file was already parsed once, we can store+reuse the
+	-- snippets.
 
-			-- There are still some snippets that fail while loading
-			pcall(function()
-				-- Sometimes it's a list of prefixes instead of a single one
-				local prefixes = type(parts.prefix) == "table" and parts.prefix
-					or { parts.prefix }
-				for _, prefix in ipairs(prefixes) do
-					local ls_conf = parts.luasnip or {}
+	local lang_snips = {}
+	local auto_lang_snips = {}
+	for name, parts in pairs(snippet_set_data) do
+		local body = type(parts.body) == "string" and parts.body
+			or table.concat(parts.body, "\n")
 
-					local snip = sp({
-						trig = prefix,
-						name = name,
-						dscr = parts.description or name,
-						wordTrig = true,
-					}, body)
+		-- There are still some snippets that fail while loading
+		pcall(function()
+			-- Sometimes it's a list of prefixes instead of a single one
+			local prefixes = type(parts.prefix) == "table" and parts.prefix
+				or { parts.prefix }
+			for _, prefix in ipairs(prefixes) do
+				local ls_conf = parts.luasnip or {}
 
-					if ls_conf.autotrigger then
-						table.insert(auto_lang_snips, snip)
-					else
-						table.insert(lang_snips, snip)
-					end
+				local snip = sp({
+					trig = prefix,
+					name = name,
+					dscr = parts.description or name,
+					wordTrig = true,
+				}, body)
+
+				if ls_conf.autotrigger then
+					table.insert(auto_lang_snips, snip)
+				else
+					table.insert(lang_snips, snip)
 				end
-			end)
-		end
-		ls.add_snippets(lang, lang_snips, { type = "snippets" })
-		ls.add_snippets(lang, auto_lang_snips, { type = "autosnippets" })
+			end
+		end)
 	end
+	ls.add_snippets(lang, lang_snips, { type = "snippets" })
+	ls.add_snippets(lang, auto_lang_snips, { type = "autosnippets" })
 end
 
-local function filter_list(list, exclude, include)
-	local out = {}
-	for _, entry in ipairs(list) do
-		if exclude[entry] then
-			goto continue
-		end
-		-- If include is nil then it's true
-		if include == nil or include[entry] then
-			table.insert(out, entry)
-		end
-		::continue::
-	end
-	return out
-end
-
-local function load_snippet_folder(root, opts)
+local function package_files(root, filter)
 	local package = Path.join(root, "package.json")
 	local data = Path.read_file(package)
 	local package_data = json_decode(data)
@@ -85,21 +71,30 @@ local function load_snippet_folder(root, opts)
 			and package_data.contributes.snippets
 		)
 	then
-		return
+		-- root doesn't contain a package.json, return no snippets.
+		return {}
 	end
+
+	-- stores ft -> files(string[]).
+	local ft_files = {}
 
 	for _, snippet_entry in pairs(package_data.contributes.snippets) do
 		local langs = snippet_entry.language
 
-		if type(snippet_entry.language) ~= "table" then
+		if type(langs) ~= "table" then
 			langs = { langs }
 		end
-		langs = filter_list(langs, opts.exclude, opts.include)
-
-		if #langs ~= 0 then
-			load_snippet_file(langs, Path.join(root, snippet_entry.path))
+		for _, ft in ipairs(langs) do
+			if filter(ft) then
+				if not ft_files[ft] then
+					ft_files[ft] = {}
+				end
+				table.insert(ft_files[ft], Path.join(root, snippet_entry.path))
+			end
 		end
 	end
+
+	return ft_files
 end
 
 local function get_snippet_rtp()
@@ -108,27 +103,41 @@ local function get_snippet_rtp()
 	end, vim.api.nvim_get_runtime_file("package.json", true))
 end
 
-local M = {}
-function M.load(opts)
+-- sanitizes opts and returns ft -> files-map for `opts` (respects in/exclude).
+local function get_snippet_files(opts)
 	opts = opts or {}
-	-- nil (unset) to include all languages (default), a list for the ones you wanna include
-	opts.include = loader_util.filetypelist_to_set(opts.include)
 
-	-- A list for the ones you wanna exclude (empty by default)
-	opts.exclude = loader_util.filetypelist_to_set(opts.exclude) or {}
-
+	local paths
 	-- list of paths to crawl for loading (could be a table or a comma-separated-list)
 	if not opts.paths then
-		opts.paths = get_snippet_rtp()
+		paths = get_snippet_rtp()
 	elseif type(opts.paths) == "string" then
-		opts.paths = vim.split(opts.paths, ",")
+		paths = vim.split(opts.paths, ",")
+	else
+		paths = opts.paths
+	end
+	paths = vim.tbl_map(Path.expand, paths) -- Expand before deduping, fake paths will become nil
+	paths = util.deduplicate(paths) -- Remove doppelgänger paths and ditch nil ones
+
+	local ft_paths = {}
+
+	local ft_filter = loader_util.ft_filter(opts.exclude, opts.include)
+	for _, root_path in ipairs(paths) do
+		loader_util.extend_ft_paths(
+			ft_paths,
+			package_files(root_path, ft_filter)
+		)
 	end
 
-	opts.paths = vim.tbl_map(Path.expand, opts.paths) -- Expand before deduping, fake paths will become nil
-	opts.paths = util.deduplicate(opts.paths) -- Remove doppelgänger paths and ditch nil ones
+	return ft_paths
+end
 
-	for _, path in ipairs(opts.paths) do
-		load_snippet_folder(path, opts)
+local M = {}
+function M.load(opts)
+	for ft, files in pairs(get_snippet_files(opts)) do
+		for _, file in ipairs(files) do
+			load_snippet_file(ft, file)
+		end
 	end
 end
 

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -69,7 +69,7 @@ local function load_snippet_files(lang, files)
 			-- store snippets to prevent parsing the same file more than once.
 			cache.path_snippets[file] = {
 				snippets = lang_snips,
-				autosnippets = auto_lang_snips
+				autosnippets = auto_lang_snips,
 			}
 		end
 
@@ -170,7 +170,11 @@ end
 
 local M = {}
 function M.load(opts)
-	for ft, files in pairs(get_snippet_files(opts)) do
+	local ft_files = get_snippet_files(opts)
+
+	loader_util.extend_ft_paths(cache.ft_paths, ft_files)
+
+	for ft, files in pairs(ft_files) do
 		load_snippet_files(ft, files)
 	end
 end
@@ -188,6 +192,8 @@ end
 function M.lazy_load(opts)
 	local ft_files = get_snippet_files(opts)
 
+	loader_util.extend_ft_paths(cache.ft_paths, ft_files)
+
 	for ft, files in pairs(ft_files) do
 		if cache.lazy_loaded_ft[ft] then
 			-- instantly load snippets if they were already loaded...
@@ -199,6 +205,10 @@ function M.lazy_load(opts)
 	end
 
 	loader_util.extend_ft_paths(cache.lazy_load_paths, ft_files)
+end
+
+function M.edit_snippet_files()
+	loader_util.edit_snippet_files(cache.ft_paths)
 end
 
 vim.cmd([[

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -240,11 +240,4 @@ function M.reload_file(ft, file)
 	end
 end
 
-vim.cmd([[
-augroup _luasnip_vscode_lazy_load
-	autocmd!
-	au BufWinEnter,FileType * lua require('luasnip.loaders.from_vscode')._luasnip_vscode_lazy_load()
-augroup END
-]])
-
 return M

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -167,8 +167,6 @@ end
 
 -- sanitizes opts and returns ft -> files-map for `opts` (respects in/exclude).
 local function get_snippet_files(opts)
-	opts = opts or {}
-
 	local paths
 	-- list of paths to crawl for loading (could be a table or a comma-separated-list)
 	if not opts.paths then
@@ -197,12 +195,14 @@ end
 local M = {}
 function M.load(opts)
 	opts = opts or {}
+
 	local ft_files = get_snippet_files(opts)
+	local add_opts = loader_util.add_opts(opts)
 
 	loader_util.extend_ft_paths(cache.ft_paths, ft_files)
 
 	for ft, files in pairs(ft_files) do
-		load_snippet_files(ft, files, opts.add_opts or {})
+		load_snippet_files(ft, files, add_opts)
 	end
 end
 
@@ -224,9 +224,9 @@ end
 
 function M.lazy_load(opts)
 	opts = opts or {}
-	local add_opts = opts.add_opts or {}
 
 	local ft_files = get_snippet_files(opts)
+	local add_opts = loader_util.add_opts(opts)
 
 	loader_util.extend_ft_paths(cache.ft_paths, ft_files)
 

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -78,18 +78,18 @@ local function load_snippet_files(lang, files)
 		-- augroup.
 		vim.cmd(string.format(
 			[[
-				augroup luasnip_watch_%s_%s
-				autocmd!
-				autocmd BufWritePost %s lua require("luasnip.loaders.from_vscode").reload_file("%s", "%s")
+				augroup luasnip_watch_reload
+				autocmd BufWritePost %s ++once lua require("luasnip.loaders.from_vscode").reload_file("%s", "%s")
+				augroup END
 			]],
-			-- augroup name may not contain spaces.
-			file:gsub(" ", "_"),
-			lang,
 			-- escape for autocmd-pattern.
 			file:gsub(" ", "\\ "),
+			-- args for reload.
 			lang,
 			file
 		))
+
+		print(lang, file)
 
 		ls.add_snippets(lang, lang_snips, {
 			type = "snippets",

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -28,8 +28,8 @@ local function load_snippet_files(lang, files)
 
 		local cached_path = cache.path_snippets[file]
 		if cached_path then
-			lang_snips = cached_path.snippets
-			auto_lang_snips = cached_path.autosnippets
+			lang_snips = vim.deepcopy(cached_path.snippets)
+			auto_lang_snips = vim.deepcopy(cached_path.autosnippets)
 		else
 			local data = Path.read_file(file)
 			local snippet_set_data = json_decode(data)
@@ -68,8 +68,9 @@ local function load_snippet_files(lang, files)
 
 			-- store snippets to prevent parsing the same file more than once.
 			cache.path_snippets[file] = {
-				snippets = lang_snips,
-				autosnippets = auto_lang_snips,
+				snippets = vim.deepcopy(lang_snips),
+				autosnippets = vim.deepcopy(auto_lang_snips),
+				add_opts = add_opts,
 			}
 		end
 

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -55,6 +55,7 @@ local function load_snippet_files(lang, files, add_opts)
 							name = name,
 							dscr = parts.description or name,
 							wordTrig = true,
+							priority = ls_conf.priority,
 						}, body)
 
 						if ls_conf.autotrigger then

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -89,8 +89,6 @@ local function load_snippet_files(lang, files)
 			file
 		))
 
-		print(lang, file)
-
 		ls.add_snippets(lang, lang_snips, {
 			type = "snippets",
 			-- again, include filetype, same reasoning as with augroup.

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -9,9 +9,11 @@ end
 
 --- Quickly jump to snippet-file from any source for the active filetypes.
 ---@param opts table, options for this function:
---- - format: fn(path, source_name) -> string.
+--- - format: fn(path:string, source_name:string) -> string|nil
+---   source_name is one of "vscode", "snipmate" or "lua".
 ---   May be used to format the displayed items. For example, replace the
 ---   excessively long packer-path with something shorter.
+---   If format returns nil for some item, the item will not be displayed.
 function M.edit_snippet_files(opts)
 	opts = opts or {}
 	local format = opts.format or default_format
@@ -27,8 +29,11 @@ function M.edit_snippet_files(opts)
 			-- concat files from all loaders for the selected filetype ft.
 			for _, cache_name in ipairs({ "vscode", "snipmate", "lua" }) do
 				for _, path in ipairs(Cache[cache_name].ft_paths[ft] or {}) do
-					table.insert(ft_paths, path)
-					table.insert(items, format(path, cache_name))
+					local fmt_name = format(path, cache_name)
+					if fmt_name then
+						table.insert(ft_paths, path)
+						table.insert(items, fmt_name)
+					end
 				end
 			end
 
@@ -41,7 +46,7 @@ function M.edit_snippet_files(opts)
 						vim.cmd("edit " .. ft_paths[indx])
 					end
 				end)
-			else
+			elseif ft_paths[1] then
 				vim.cmd("edit " .. ft_paths[1])
 			end
 		end

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -1,0 +1,51 @@
+local Cache = require("luasnip.loaders._caches")
+local util = require("luasnip.util.util")
+
+local M = {}
+
+local function default_format(path, source_name)
+	return source_name .. ": " .. path
+end
+
+--- Quickly jump to snippet-file from any source for the active filetypes.
+---@param opts table, options for this function:
+--- - format: fn(path, source_name) -> string.
+---   May be used to format the displayed items. For example, replace the
+---   excessively long packer-path with something shorter.
+function M.edit_snippet_files(opts)
+	opts = opts or {}
+	local format = opts.format or default_format
+
+	local fts = util.get_snippet_filetypes()
+	vim.ui.select(fts, {
+		prompt = "Select filetype:",
+	}, function(ft, _)
+		if ft then
+			local ft_paths = {}
+			local items = {}
+
+			-- concat files from all loaders for the selected filetype ft.
+			for _, cache_name in ipairs({ "vscode", "snipmate", "lua" }) do
+				for _, path in ipairs(Cache[cache_name].ft_paths[ft] or {}) do
+					table.insert(ft_paths, path)
+					table.insert(items, format(path, cache_name))
+				end
+			end
+
+			-- prompt user again if there are multiple files providing this filetype.
+			if #ft_paths > 1 then
+				vim.ui.select(items, {
+					prompt = "Multiple files for this filetype, choose one:",
+				}, function(_, indx)
+					if indx and ft_paths[indx] then
+						vim.cmd("edit " .. ft_paths[indx])
+					end
+				end)
+			else
+				vim.cmd("edit " .. ft_paths[1])
+			end
+		end
+	end)
+end
+
+return M

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -3,8 +3,15 @@ local util = require("luasnip.util.util")
 
 local M = {}
 
-local function default_format(path, source_name)
-	return source_name .. ": " .. path
+local function default_format(path, _)
+	path = path:gsub(
+		vim.fn.stdpath("data") .. "/site/pack/packer/start",
+		"$PLUGINS"
+	)
+	if vim.env.HOME then
+		path = path:gsub(vim.env.HOME .. "/.config/nvim", "$CONFIG")
+	end
+	return path
 end
 
 --- Quickly jump to snippet-file from any source for the active filetypes.

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -53,4 +53,15 @@ function M.edit_snippet_files(opts)
 	end)
 end
 
+function M.cleanup()
+	Cache.cleanup()
+
+	-- remove reload-autocommands.
+	vim.cmd([[
+		augroup luasnip_watch_reload
+		autocmd!
+		augroup END
+	]])
+end
+
 return M

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -120,8 +120,6 @@ end
 --- - collection_paths: ft->files for the entire collection and
 --- - load_paths: ft->files for only the files that should be loaded.
 local function get_load_paths_snipmate_like(opts, rtp_dirname, extension)
-	opts = opts or {}
-
 	local collections_load_paths = {}
 
 	for _, path in ipairs(normalize_paths(opts.paths, rtp_dirname)) do
@@ -174,6 +172,13 @@ local function edit_snippet_files(ft_files)
 	end)
 end
 
+local function add_opts(opts)
+	return {
+		override_priority = opts.override_priority,
+		default_priority = opts.default_priority,
+	}
+end
+
 return {
 	filetypelist_to_set = filetypelist_to_set,
 	split_lines = split_lines,
@@ -183,4 +188,5 @@ return {
 	get_load_paths_snipmate_like = get_load_paths_snipmate_like,
 	extend_ft_paths = extend_ft_paths,
 	edit_snippet_files = edit_snippet_files,
+	add_opts = add_opts,
 }

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -71,26 +71,24 @@ local function _append(tbl, name, elem)
 end
 
 ---Get paths of .snippets files
----@param roots string[] @snippet directory paths
+---@param root string @snippet directory path
 ---@return table @keys are file types, values are paths
-local function get_ft_paths(roots, extension)
+local function get_ft_paths(root, extension)
 	local ft_path = {}
-	for _, root in ipairs(roots) do
-		local files, dirs = Path.scandir(root)
-		for _, file in ipairs(files) do
-			local ft, ext = Path.basename(file, true)
-			if ext == extension then
-				_append(ft_path, ft, file)
-			end
+	local files, dirs = Path.scandir(root)
+	for _, file in ipairs(files) do
+		local ft, ext = Path.basename(file, true)
+		if ext == extension then
+			_append(ft_path, ft, file)
 		end
-		for _, dir in ipairs(dirs) do
-			-- directory-name is ft for snippet-files.
-			local ft = vim.fn.fnamemodify(dir, ":t")
-			files, _ = Path.scandir(dir)
-			for _, file in ipairs(files) do
-				if vim.endswith(file, extension) then
-					_append(ft_path, ft, file)
-				end
+	end
+	for _, dir in ipairs(dirs) do
+		-- directory-name is ft for snippet-files.
+		local ft = vim.fn.fnamemodify(dir, ":t")
+		files, _ = Path.scandir(dir)
+		for _, file in ipairs(files) do
+			if vim.endswith(file, extension) then
+				_append(ft_path, ft, file)
 			end
 		end
 	end
@@ -117,29 +115,34 @@ end
 --- directory named `rtp_dirname` in the runtimepath.
 ---@param extension string: extension of valid snippet-files for the given
 --- collection (eg `.lua` or `.snippets`)
----@return table: two tables like `{ft1={files}, ft2={files}}`: The files that
---- should actually be loaded, and all files in the collection.
+---@return table: a list of tables, each of the inner tables contains two
+--- entries:
+--- - collection_paths: ft->files for the entire collection and
+--- - load_paths: ft->files for only the files that should be loaded.
 local function get_load_paths_snipmate_like(opts, rtp_dirname, extension)
 	opts = opts or {}
 
-	local load_paths = {}
+	local collections_load_paths = {}
 
-	local collection_ft_paths = get_ft_paths(
-		normalize_paths(opts.paths, rtp_dirname),
-		extension
-	)
+	for _, path in ipairs(normalize_paths(opts.paths, rtp_dirname)) do
+		local collection_ft_paths = get_ft_paths(path, extension)
 
-	extend_ft_paths(load_paths, collection_ft_paths)
-
-	-- remove files for excluded/non-included filetypes here.
-	local collection_filter = ft_filter(opts.exclude, opts.include)
-	for ft, _ in pairs(load_paths) do
-		if not collection_filter(ft) then
-			load_paths[ft] = nil
+		local load_paths = vim.deepcopy(collection_ft_paths)
+		-- remove files for excluded/non-included filetypes here.
+		local collection_filter = ft_filter(opts.exclude, opts.include)
+		for ft, _ in pairs(load_paths) do
+			if not collection_filter(ft) then
+				load_paths[ft] = nil
+			end
 		end
+
+		table.insert(collections_load_paths, {
+			collection_paths = collection_ft_paths,
+			load_paths = load_paths,
+		})
 	end
 
-	return load_paths, collection_ft_paths
+	return collections_load_paths
 end
 
 return {

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -145,6 +145,35 @@ local function get_load_paths_snipmate_like(opts, rtp_dirname, extension)
 	return collections_load_paths
 end
 
+--- Asks (via vim.ui.select) to edit a file that currently provides snippets
+---@param ft_files table, map filetype to a number of files.
+local function edit_snippet_files(ft_files)
+	local fts = util.get_snippet_filetypes()
+	vim.ui.select(fts, {
+		prompt = "Select filetype:",
+	}, function(item, _)
+		if item then
+			local ft_paths = ft_files[item]
+			if ft_paths then
+				-- prompt user again if there are multiple files providing this filetype.
+				if #ft_paths > 1 then
+					vim.ui.select(ft_paths, {
+						prompt = "Multiple files for this filetype, choose one:",
+					}, function(multi_item)
+						if multi_item then
+							vim.cmd("edit " .. multi_item)
+						end
+					end)
+				else
+					vim.cmd("edit " .. ft_paths[1])
+				end
+			else
+				print("No file for this filetype.")
+			end
+		end
+	end)
+end
+
 return {
 	filetypelist_to_set = filetypelist_to_set,
 	split_lines = split_lines,
@@ -153,4 +182,5 @@ return {
 	get_ft_paths = get_ft_paths,
 	get_load_paths_snipmate_like = get_load_paths_snipmate_like,
 	extend_ft_paths = extend_ft_paths,
+	edit_snippet_files = edit_snippet_files,
 }

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -160,6 +160,11 @@ local function init_snippet_opts(opts)
 		in_node.stored[key] = wrap_nodes_in_snippetNode(nodes)
 	end
 
+	-- init invalidated here.
+	-- This is because invalidated is a key that can be populated without any
+	-- information on the actual snippet (it can be used by snippetProxy!).
+	in_node.invalidated = false
+
 	return vim.tbl_extend("error", in_node, init_snippetNode_opts(opts))
 end
 
@@ -226,7 +231,6 @@ local function _S(snip, nodes, opts)
 			active = false,
 			type = types.snippet,
 			dependents_dict = dict.new(),
-			invalidated = false,
 		}),
 		opts
 	)

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -15,6 +15,8 @@ local SnippetProxy = {}
 -- add Snippet-functions SnippetProxy can perform using the available data.
 SnippetProxy.matches = snip_mod.Snippet.matches
 
+SnippetProxy.invalidate = snip_mod.Snippet.invalidate
+
 function SnippetProxy:get_docstring()
 	return self.docstring
 end

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -436,7 +436,6 @@ local function find_outer_snippet(node)
 	return node
 end
 
--- filetype: string formatted like `'filetype'`.
 local function get_snippet_filetypes()
 	local config = require("luasnip.session").config
 	local fts = config.ft_func()

--- a/plugin/luasnip.vim
+++ b/plugin/luasnip.vim
@@ -42,3 +42,13 @@ function! luasnip#choice_active()
 endfunction
 
 lua require('luasnip.config')._setup()
+
+" register these during startup so lazy_load will also load filetypes whose
+" events fired only before lazy_load is actually called.
+" (BufWinEnter -> lazy_load() wouldn't load any files without these).
+augroup _luasnip_lazy_load
+	au!
+	au BufWinEnter,FileType * lua require('luasnip.loaders.from_lua')._load_lazy_loaded()
+	au BufWinEnter,FileType * lua require("luasnip.loaders.from_snipmate")._lazyload()
+	au BufWinEnter,FileType * lua require('luasnip.loaders.from_vscode')._luasnip_vscode_lazy_load()
+augroup END

--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -9,9 +9,11 @@ syn match snippet '^snippet.*' contains=multiSnipText,snipKeyword
 syn match snippet '^autosnippet.*' contains=multiSnipText,snipKeyword
 syn match snippet '^extends.*' contains=snipKeyword
 syn match snippet '^version.*' contains=snipKeyword
+syn match snippet '^priority.*' contains=snipKeyword,priority
+syn match priority '\d\+' contained
 syn match multiSnipText '\S\+ \zs.*' contained
-syn match snipKeyword '^(snippet|extends|version|autosnippet)'me=s+8 contained
-syn match snipError "^[^#vsae\t].*$"
+syn match snipKeyword '^(snippet|extends|version|autosnippet|priority)'me=s+8 contained
+syn match snipError "^[^#vsaep\t].*$"
 
 hi link snippet       Identifier
 hi link snipComment   Comment
@@ -22,3 +24,4 @@ hi link placeHolder   Special
 hi link tabStop       Special
 hi link snipCommand   String
 hi link snipError     Error
+hi link priority      Number

--- a/tests/data/lua-snippets/luasnippets/prio.lua
+++ b/tests/data/lua-snippets/luasnippets/prio.lua
@@ -1,0 +1,3 @@
+return {
+	parse("aaaa", "lua"),
+}

--- a/tests/data/snipmate-snippets/snippets/prio.snippets
+++ b/tests/data/snipmate-snippets/snippets/prio.snippets
@@ -1,0 +1,4 @@
+# snippets for priority-tests.
+
+snippet aaaa ""
+	snipmate

--- a/tests/data/snipmate-snippets/snippets/prio.snippets
+++ b/tests/data/snipmate-snippets/snippets/prio.snippets
@@ -1,4 +1,17 @@
 # snippets for priority-tests.
 
-snippet aaaa ""
+snippet aaaa
 	snipmate
+#
+priority 2000
+snippet bbbb
+	1
+priority 2001
+snippet bbbb
+	2
+# this might be triggered when default-priority is increased.
+snippet bbbb
+	3
+priority 1999
+snippet bbbb
+	4

--- a/tests/data/snipmate-snippets/snippets1/vim.snippets
+++ b/tests/data/snipmate-snippets/snippets1/vim.snippets
@@ -1,3 +1,2 @@
-extends lua
 snippet snipmate_vim1 A vim snippet
 	snipmate$1vimvimvim

--- a/tests/data/vscode-snippets/package.json
+++ b/tests/data/vscode-snippets/package.json
@@ -10,6 +10,12 @@
 			},
 			{
 				"language": [
+					"prio"
+				],
+				"path": "./snippets/prio.json"
+			},
+			{
+				"language": [
 					"lua"
 				],
 				"path": "./lua.json"

--- a/tests/data/vscode-snippets/snippets/prio.json
+++ b/tests/data/vscode-snippets/snippets/prio.json
@@ -1,0 +1,8 @@
+{
+	"aaaa": {
+		"prefix": "aaaa",
+		"body": [
+			"vscode"
+		]
+	}
+}

--- a/tests/data/vscode-snippets/snippets/prio.json
+++ b/tests/data/vscode-snippets/snippets/prio.json
@@ -1,8 +1,41 @@
 {
-	"aaaa": {
+	"a": {
 		"prefix": "aaaa",
 		"body": [
 			"vscode"
 		]
+	},
+	"b": {
+		"prefix": "bbbb",
+		"body": [
+			"1"
+		],
+		"luasnip": {
+			"priority": 2000
+		}
+	},
+	"c": {
+		"prefix": "bbbb",
+		"body": [
+			"2"
+		],
+		"luasnip": {
+			"priority": 2001
+		}
+	},
+	"d": {
+		"prefix": "bbbb",
+		"body": [
+			"3"
+		]
+	},
+	"e": {
+		"prefix": "bbbb",
+		"body": [
+			"4"
+		],
+		"luasnip": {
+			"priority": 1999
+		}
 	}
 }

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -298,4 +298,75 @@ describe("loaders:", function()
 			{2:-- INSERT --}                                      |]],
 		})
 	end)
+
+	it("vscode-options work.", function()
+		loaders["vscode(rtp)"]()
+		exec("set ft=prio")
+
+		feed("ibbbb")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
+			2^                                                 |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+
+		exec_lua(string.format(
+			[[require("luasnip.loaders.from_vscode").load({
+					paths={"%s"},
+					default_priority = 2002
+				})]],
+			os.getenv("LUASNIP_SOURCE") .. "/tests/data/vscode-snippets"
+		))
+
+		feed("<Cr>bbbb")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
+			2                                                 |
+			3^                                                 |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
+
+	it("snipmate-options work.", function()
+		loaders["snipmate(rtp)"]()
+		exec("set ft=prio")
+
+		feed("ibbbb")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
+			2^                                                 |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+
+		exec_lua(string.format(
+			[[require("luasnip.loaders.from_snipmate").load({
+					paths={"%s"},
+					default_priority = 2002
+				})]],
+			os.getenv("LUASNIP_SOURCE")
+				.. "/tests/data/snipmate-snippets/snippets"
+		))
+
+		feed("<Cr>bbbb")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
+			2                                                 |
+			3^                                                 |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
 end)

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -177,4 +177,20 @@ describe("loaders:", function()
 		-- one snippet from vim.snippets, one from lua.snippets
 		assert.are.same(2, exec_lua('return #ls.get_snippets("vim")'))
 	end)
+
+	it("separates snippets from different collection for `extends`", function()
+		-- load from both snippets (where vim extends lua) and snippets1 (where
+		-- it doesn't).
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_snipmate").load({paths={"%s", "%s"}})]],
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/snipmate-snippets/snippets",
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/snipmate-snippets/snippets1"
+			)
+		)
+
+		assert.are.same(3, exec_lua('return #ls.get_snippets("vim")'))
+	end)
 end)


### PR DESCRIPTION
Pass any options to loaders through `(lazy_)load`-call.
Not all options are supported, `override_priority` and `default_priority` work, the others might be overriden.

Not sure if we should use this implementation, which just passes through the options to `add_opts` or if we should expose select (`override_priority` and `default_priority`) options in the `load` instead.
```lua
require("luasnip.loaders.from_snipmate").load({add_opts = {override_priority = 2000}})
-- vs
require("luasnip.loaders.from_snipmate").load({override_priority = 2000})
```
Having it named `add_opts` suggests that all opts will have an effect, which
1. depends on the loader (`from_snipmate` overrides `type`, `from_lua` overrides `type` and `key`)
2. doesn't really make sense: either the other currently options are controlled by the loader, or they might lead to detrimental behaviour (if `key` is passed to `from_snipmate`, only the last `add_snippets` with `key` will be visible)

Maybe we should just expose the valid options directly instead, we'll have to do some modifications to expose new ones should they become available in `add_snippets`, but it seems to be the better option (now, after implementing a first version :D)

- [x] snipmate override/default
- [x] lua override/default
- [x] vscode override/default
- [x] vscode priority per-snippet (pass in `snippet->luasnip`-json-object)
- [x] snipmate priority per-snippet in the line immediately before snippet-definition? Like
  ```snippets
  priority 2000
  snippet trigger a description
  	snippet body
  ```

Edit 1:
Implementing that stuff also (kind of) required doing some general improvements, which now also make adding reload-capability to all loaders much easier. I'll just add that onto this PR.

Edit 2:
The syntax is now the second version, eg `{override,default}_priority` can be passed directly in the table passed to load.
All that needs doing now is updating the docs.