### PR TITLE
Improve expandtab-handling

### DIFF
--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -124,9 +124,9 @@ function ChoiceNode:indent(indentstr)
 	end
 end
 
-function ChoiceNode:expand_tabs(tabwidth)
+function ChoiceNode:expand_tabs(tabwidth, indentstringlen)
 	for _, node in ipairs(self.choices) do
-		node:expand_tabs(tabwidth)
+		node:expand_tabs(tabwidth, indentstringlen)
 	end
 end
 

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -160,7 +160,7 @@ function DynamicNode:update()
 	tmp:set_argnodes(self.parent.snippet.dependents_dict)
 
 	if vim.bo.expandtab then
-		tmp:expand_tabs(util.tab_width())
+		tmp:expand_tabs(util.tab_width(), #self.parent.indentstr)
 	end
 	tmp:indent(self.parent.indentstr)
 

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -45,7 +45,7 @@ function FunctionNode:update()
 		self.fn(args, self.parent, unpack(self.user_args))
 	)
 	if vim.bo.expandtab then
-		util.expand_tabs(text, util.tab_width())
+		util.expand_tabs(text, util.tab_width(), #self.parent.indentstr)
 	end
 	-- don't expand tabs in parent.indentstr, use it as-is.
 	self.parent:set_text(self, util.indent(text, self.parent.indentstr))

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -199,13 +199,7 @@ function Node:update() end
 function Node:update_static() end
 
 function Node:expand_tabs(tabwidth, indentstr)
-	--if self.static_text[1]:match("default") then
-	Insp(self.static_text)
-	--end
 	util.expand_tabs(self.static_text, tabwidth, indentstr)
-	--if self.static_text[1]:match("default") then
-	Insp(self.static_text)
-	--end
 end
 
 function Node:indent(indentstr)

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -198,8 +198,14 @@ Node.update_all_dependents_static = Node._update_dependents_static
 function Node:update() end
 function Node:update_static() end
 
-function Node:expand_tabs(tabwidth)
-	util.expand_tabs(self.static_text, tabwidth)
+function Node:expand_tabs(tabwidth, indentstr)
+	--if self.static_text[1]:match("default") then
+	Insp(self.static_text)
+	--end
+	util.expand_tabs(self.static_text, tabwidth, indentstr)
+	--if self.static_text[1]:match("default") then
+	Insp(self.static_text)
+	--end
 end
 
 function Node:indent(indentstr)

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -101,7 +101,7 @@ function RestoreNode:put_initial(pos)
 	tmp:set_argnodes(self.parent.snippet.dependents_dict)
 
 	if vim.bo.expandtab then
-		tmp:expand_tabs(util.tab_width())
+		tmp:expand_tabs(util.tab_width(), self.parent.indentstring)
 	end
 
 	-- correctly set extmark for node.

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -286,7 +286,7 @@ end
 local function ISN(pos, nodes, indent_text, opts)
 	local snip = SN(pos, nodes, opts)
 
-	function snip:indent(parent_indent)
+	local function get_indent(parent_indent)
 		local indentstring = ""
 		if vim.bo.expandtab then
 			-- preserve content of $PARENT_INDENT, but expand tabs before/after it
@@ -305,7 +305,22 @@ local function ISN(pos, nodes, indent_text, opts)
 			indentstring = indent_text:gsub("$PARENT_INDENT", parent_indent)
 		end
 
-		Snippet.indent(self, indentstring)
+		return indentstring
+	end
+
+	function snip:indent(parent_indent)
+		Snippet.indent(self, get_indent(parent_indent))
+	end
+
+	-- expand_tabs also needs to be modified: the children of the isn get the
+	-- indent of the isn, so we'll have to calculate it now.
+	-- This is done with a dummy-indentstring of the correct length.
+	function snip:expand_tabs(tabwidth, indentstrlen)
+		Snippet.expand_tabs(
+			self,
+			tabwidth,
+			#get_indent(string.rep(" ", indentstrlen))
+		)
 	end
 
 	return snip

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -57,8 +57,18 @@ local function indent(text, indentstring)
 	return text
 end
 
--- in-place expand tabs in leading whitespace.
-local function expand_tabs(text, tabwidth)
+--- In-place expands tabs in `text`.
+--- Difficulties:
+--- we cannot simply replace tabs with a given number of spaces, the tabs align
+--- text at multiples of `tabwidth`. This is also the reason we need the number
+--- of columns the text is already indented by (otherwise we can only start a 0).
+---@param text string[], multiline string.
+---@param tabwidth number, displaycolumns one tab should shift following text
+--- by.
+---@param parent_indent_displaycolumns number, displaycolumn this text is
+--- already at.
+---@return string[], `text` (only for simple nesting).
+local function expand_tabs(text, tabwidth, parent_indent_displaycolumns)
 	for i, line in ipairs(text) do
 		local new_line = ""
 		local start_indx = 1
@@ -69,7 +79,14 @@ local function expand_tabs(text, tabwidth)
 			if tab_indx then
 				-- #new_line is index of this tab in new_line.
 				new_line = new_line
-					.. string.rep(" ", tabwidth - #new_line % tabwidth)
+					.. string.rep(
+						" ",
+						tabwidth
+							- (
+								(parent_indent_displaycolumns + #new_line)
+								% tabwidth
+							)
+					)
 			else
 				-- reached end of string.
 				break

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -437,4 +437,27 @@ describe("snippets_basic", function()
 			{2:-- INSERT --}                                      |]],
 		})
 	end)
+
+	it("ISN also expands tabs correctly.", function()
+		local snip = [[
+			s("trig", {
+				isn(1, {
+					t{"", "\ta"}
+				}, "$PARENT_INDENT  ")
+			})
+		]]
+		exec("set expandtab | set shiftwidth=8")
+
+		feed("7i<Space><Esc>i")
+		exec_lua("ls.snip_expand(" .. snip .. ")")
+
+		-- a is indented to the 16th column, not just the 8th.
+		screen:expect({
+			grid = [[
+			                                                  |
+			                a^                                 |
+			{2:-- INSERT --}                                      |]],
+		})
+		--  .......|.......|
+	end)
 end)

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1,5 +1,5 @@
 local helpers = require("test.functional.helpers")(after_each)
-local exec_lua, feed = helpers.exec_lua, helpers.feed
+local exec_lua, feed, exec = helpers.exec_lua, helpers.feed, helpers.exec
 local ls_helpers = require("helpers")
 local Screen = require("test.functional.ui.screen")
 
@@ -419,6 +419,21 @@ describe("snippets_basic", function()
 			grid = [[
 			        the snippet expands                       |
 			        and is indeted properly.^                  |
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
+
+	it("Tabs are expanded correctly", function()
+		local snip = [[
+			parse("trig", "\ta")
+		]]
+		feed("i<Space><Space>")
+		exec("set expandtab | set shiftwidth=8")
+		exec_lua("ls.snip_expand(" .. snip .. ")")
+		screen:expect({
+			grid = [[
+			        a^                                         |
+			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
 		})
 	end)


### PR DESCRIPTION
There were some issues with tabs not expanding in `isn` or tabs expanding to an incorrect number of spaces (not-aligning with tab-column-boundary, so to speak), this should fix them.

It should work, but is missing some tests.