### PR TITLE
lazy_load-improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ The [Wiki](https://github.com/L3MON4D3/LuaSnip/wiki) contains some pretty useful
 - `enable_autosnippets`: Autosnippets are disabled by default to minimize performance penalty if unused. Set to `true` to enable.
 - `ext_opts`: Additional options passed to extmarks. Can be used to add passive/active highlight on a per-node-basis (more info in DOC.md)
 - `parser_nested_assembler`: Override the default behaviour of inserting a `choiceNode` containing the nested snippet and an empty `insertNode` for nested placeholders (`"${1: ${2: this is nested}}"`). For an example (behaviour more similar to vscode), check [here](https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#imitate-vscodes-behaviour-for-nested-placeholders)
-- `ft_func`: Source of possible filetypes for snippets. Defaults to a function, which returns `vim.split(vim.bo.filetype, ".", true)`, but check [filetype_functions](lua/luasnip/extras/filetype_functions.lua) for other options
+- `ft_func`: Source of possible filetypes for snippets. Defaults to a function, which returns `vim.split(vim.bo.filetype, ".", true)`, but check [filetype_functions](lua/luasnip/extras/filetype_functions.lua) or [the docs](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#filetype_functions) for more options.
+- `load_ft_func`: Function to determine which filetypes belong to a given buffer (used for `lazy_loading`). `fn(bufnr)
+  -> filetypes (string[])`. Again, there are some examples in [filetype_functions](lua/luasnip/extras/filetype_functions.lua).
 - `snip_env`: The global environment will be extended with this table in some places, eg. in files loaded by the [lua-loader](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader).  
 Setting `snip_env` to `{ some_global = "a value" }` will add the global variable `some_global` while evaluating these files.
 If you mind the (probably) large number of generated warnings, consider adding the keys set here to the globals

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -78,6 +78,8 @@ local defaults = {
 	parser_nested_assembler = nil,
 	-- Function expected to return a list of filetypes (or empty list)
 	ft_func = ft_functions.from_filetype,
+	-- fn(bufnr) -> string[] (filetypes).
+	load_ft_func = ft_functions.from_filetype_load,
 	-- globals injected into luasnippet-files.
 	snip_env = {
 		s = require("luasnip.nodes.snippet").S,

--- a/lua/luasnip/extras/filetype_functions.lua
+++ b/lua/luasnip/extras/filetype_functions.lua
@@ -39,8 +39,13 @@ local function from_pos_or_filetype()
 	end
 end
 
+local function from_filetype_load(bufnr)
+	return vim.split(vim.api.nvim_buf_get_option(bufnr, "filetype"), ".", true)
+end
+
 return {
 	from_filetype = from_filetype,
 	from_cursor_pos = from_cursor_pos,
 	from_pos_or_filetype = from_pos_or_filetype,
+	from_filetype_load = from_filetype_load,
 }

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -33,7 +33,10 @@ local function new_cache()
 		-- ft -> {true, nil}.
 		-- Keep track of which filetypes were already lazy_loaded to prevent
 		-- duplicates.
-		lazy_loaded_ft = {},
+		--
+		-- load "all" by default, makes no sense to include it again and again,
+		-- just once on startup seems nicer.
+		lazy_loaded_ft = { all = true },
 
 		-- key is file type, value are paths of .snippets files.
 		ft_paths = {},

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -92,8 +92,8 @@ function M._load_lazy_loaded_ft(ft)
 	end
 end
 
-function M._load_lazy_loaded()
-	local fts = util.get_snippet_filetypes()
+function M._load_lazy_loaded(bufnr)
+	local fts = loader_util.get_load_fts(bufnr)
 
 	for _, ft in ipairs(fts) do
 		if not cache.lazy_loaded_ft[ft] then

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -86,18 +86,19 @@ local function load_files(ft, files, add_opts)
 	ls.refresh_notify(ft)
 end
 
+function M._load_lazy_loaded_ft(ft)
+	for _, load_call_paths in ipairs(cache.lazy_load_paths) do
+		load_files(ft, load_call_paths[ft] or {}, load_call_paths.add_opts)
+	end
+end
+
 function M._load_lazy_loaded()
 	local fts = util.get_snippet_filetypes()
+
 	for _, ft in ipairs(fts) do
 		if not cache.lazy_loaded_ft[ft] then
-			for _, load_call_paths in ipairs(cache.lazy_load_paths) do
-				cache.lazy_loaded_ft[ft] = true
-				load_files(
-					ft,
-					load_call_paths[ft] or {},
-					load_call_paths.add_opts
-				)
-			end
+			M._load_lazy_loaded_ft(ft)
+			cache.lazy_loaded_ft[ft] = true
 		end
 	end
 end
@@ -153,10 +154,6 @@ function M.lazy_load(opts)
 		load_paths.add_opts = add_opts
 		table.insert(cache.lazy_load_paths, load_paths)
 	end
-	-- call once for current filetype. Necessary for lazy_loading snippets in
-	-- empty, initial buffer, and will not cause issues like duplicate
-	-- snippets.
-	M._load_lazy_loaded()
 end
 
 function M.reload_file(filename)

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -198,8 +198,8 @@ function M._load_lazy_loaded_ft(ft)
 	end
 end
 
-function M._load_lazy_loaded()
-	local fts = util.get_snippet_filetypes()
+function M._load_lazy_loaded(bufnr)
+	local fts = loader_util.get_load_fts(bufnr)
 
 	for _, ft in ipairs(fts) do
 		if not cache.lazy_loaded_ft[ft] then

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -184,22 +184,26 @@ function M.load(opts)
 	end
 end
 
-function M._lazyload()
+function M._load_lazy_loaded_ft(ft)
+	for _, collection_load_paths in ipairs(cache.lazy_load_paths) do
+		-- don't load if this ft wasn't included/was excluded.
+		if collection_load_paths[ft] then
+			load_snippet_files(
+				ft,
+				collection_load_paths[ft],
+				collection_load_paths.collection,
+				collection_load_paths.add_opts
+			)
+		end
+	end
+end
+
+function M._load_lazy_loaded()
 	local fts = util.get_snippet_filetypes()
+
 	for _, ft in ipairs(fts) do
 		if not cache.lazy_loaded_ft[ft] then
-			-- iterate over collections.
-			for _, collection_load_paths in ipairs(cache.lazy_load_paths) do
-				-- don't load if this ft wasn't included/was excluded.
-				if collection_load_paths[ft] then
-					load_snippet_files(
-						ft,
-						collection_load_paths[ft],
-						collection_load_paths.collection,
-						collection_load_paths.add_opts
-					)
-				end
-			end
+			M._load_lazy_loaded_ft(ft)
 			cache.lazy_loaded_ft[ft] = true
 		end
 	end

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -217,8 +217,9 @@ function M._load_lazy_loaded_ft(ft)
 	end
 end
 
-function M._load_lazy_loaded()
-	local fts = util.get_snippet_filetypes()
+function M._load_lazy_loaded(bufnr)
+	local fts = loader_util.get_load_fts(bufnr)
+
 	for _, ft in ipairs(fts) do
 		if not cache.lazy_loaded_ft[ft] then
 			M._load_lazy_loaded_ft(ft)

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -207,18 +207,22 @@ function M.load(opts)
 	end
 end
 
-function M._luasnip_vscode_lazy_load()
+function M._load_lazy_loaded_ft(ft)
+	for _, load_call_paths in ipairs(cache.lazy_load_paths) do
+		load_snippet_files(
+			ft,
+			load_call_paths[ft] or {},
+			load_call_paths.add_opts
+		)
+	end
+end
+
+function M._load_lazy_loaded()
 	local fts = util.get_snippet_filetypes()
 	for _, ft in ipairs(fts) do
 		if not cache.lazy_loaded_ft[ft] then
-			for _, load_call_paths in ipairs(cache.lazy_load_paths) do
-				cache.lazy_loaded_ft[ft] = true
-				load_snippet_files(
-					ft,
-					load_call_paths[ft] or {},
-					load_call_paths.add_opts
-				)
-			end
+			M._load_lazy_loaded_ft(ft)
+			cache.lazy_loaded_ft[ft] = true
 		end
 	end
 end

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -71,4 +71,21 @@ function M.cleanup()
 	]])
 end
 
+--- explicitly load lazy-loaded snippets for some filetypes.
+---@param fts string[]: list of filetypes.
+function M.load_lazy_loaded(fts)
+	fts = util.redirect_filetypes(fts)
+
+	for _, ft in ipairs(fts) do
+		require("luasnip.loaders.from_lua")._load_lazy_loaded_ft(ft)
+		Cache.lua.lazy_loaded_ft[ft] = true
+
+		require("luasnip.loaders.from_snipmate")._load_lazy_loaded_ft(ft)
+		Cache.snipmate.lazy_loaded_ft[ft] = true
+
+		require("luasnip.loaders.from_vscode")._load_lazy_loaded_ft(ft)
+		Cache.vscode.lazy_loaded_ft[ft] = true
+	end
+end
+
 return M

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -1,5 +1,6 @@
 local Path = require("luasnip.util.path")
 local util = require("luasnip.util.util")
+local session = require("luasnip.session")
 
 local function filetypelist_to_set(list)
 	vim.validate({ list = { list, "table", true } })
@@ -179,6 +180,12 @@ local function add_opts(opts)
 	}
 end
 
+local function get_load_fts(bufnr)
+	local fts = session.config.load_ft_func(bufnr)
+
+	return util.redirect_filetypes(fts)
+end
+
 return {
 	filetypelist_to_set = filetypelist_to_set,
 	split_lines = split_lines,
@@ -189,4 +196,5 @@ return {
 	extend_ft_paths = extend_ft_paths,
 	edit_snippet_files = edit_snippet_files,
 	add_opts = add_opts,
+	get_load_fts = get_load_fts,
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -453,18 +453,23 @@ local function find_outer_snippet(node)
 	return node
 end
 
+local function redirect_filetypes(fts)
+	local snippet_fts = {}
+
+	for _, ft in ipairs(fts) do
+		vim.list_extend(snippet_fts, session.ft_redirect[ft])
+	end
+
+	return snippet_fts
+end
+
 local function get_snippet_filetypes()
 	local config = require("luasnip.session").config
 	local fts = config.ft_func()
 	-- add all last.
 	table.insert(fts, "all")
 
-	local snippet_fts = {}
-	for _, ft in ipairs(fts) do
-		vim.list_extend(snippet_fts, session.ft_redirect[ft])
-	end
-
-	return snippet_fts
+	return redirect_filetypes(fts)
 end
 
 local function deduplicate(list)
@@ -568,6 +573,7 @@ return {
 	string_wrap = string_wrap,
 	to_line_table = to_line_table,
 	find_outer_snippet = find_outer_snippet,
+	redirect_filetypes = redirect_filetypes,
 	get_snippet_filetypes = get_snippet_filetypes,
 	json_encode = json_encode,
 	json_decode = json_decode,

--- a/plugin/luasnip.vim
+++ b/plugin/luasnip.vim
@@ -48,7 +48,7 @@ lua require('luasnip.config')._setup()
 " (BufWinEnter -> lazy_load() wouldn't load any files without these).
 augroup _luasnip_lazy_load
 	au!
-	au BufWinEnter,FileType * lua require('luasnip.loaders.from_lua')._load_lazy_loaded()
-	au BufWinEnter,FileType * lua require("luasnip.loaders.from_snipmate")._lazyload()
-	au BufWinEnter,FileType * lua require('luasnip.loaders.from_vscode')._luasnip_vscode_lazy_load()
+	au BufWinEnter,FileType * lua require('luasnip.loaders.from_lua')._load_lazy_loaded(tonumber(vim.fn.expand("<abuf>")))
+	au BufWinEnter,FileType * lua require("luasnip.loaders.from_snipmate")._load_lazy_loaded(tonumber(vim.fn.expand("<abuf>")))
+	au BufWinEnter,FileType * lua require('luasnip.loaders.from_vscode')._load_lazy_loaded(tonumber(vim.fn.expand("<abuf>")))
 augroup END

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -94,9 +94,6 @@ local function for_all_loaders(message, fn)
 			load("snippets")
 			-- triggers actual load for `lazy_load()`s'
 			exec("doautocmd Filetype")
-			-- wait a bit for async-operations to finish
-			-- Bad, load (even lazy_load) will be synchronous (soon).
-			exec('call wait(200, "0")')
 			fn()
 		end)
 	end


### PR DESCRIPTION
Further improve lazy_load-functionality:
- make lazy_load work, even when luasnip itself is lazy-loaded (by eg. packer and therefore cannot register the autocommands to keep track of loaded filetypes). #434 for details how this can be accomplished.
- add config-option `load_ft_func` for specifying the filetypes that should be loaded for a given buffer. This is useful when `ft_func` can return filetypes other than the buffers filetype (one could, for example, use `ft_func` to expand filetypes based on treesitter-injected regions, but this wasn't compatible with `lazy_load` until now. Now `load_ft_func` can be set to some function that returns all possible filetypes that could be expanded in some buffer)

All that is missing is documentation.
Feel free to give Feedback/ask Questions :D