### PR TITLE
Implement pre-expand-callback.

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.5.0             Last change: 2022 May 21
+*luasnip.txt*             For NVIM v0.5.0             Last change: 2022 May 23
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -192,13 +192,15 @@ The third argument (`opts`) is a table with the following valid keys:
     `callbacks` should be set as follows:
     >
         {
+          -- position of the node, not the jump-position!!
+          -- s("trig", {t"first node", t"second node", i(1, "third node")}).
           [2] = {
-              [events.enter] = function(node) print("2!") end
+              [events.enter] = function(node, _event_args) print("2!") end
           }
         }
     <
     To register a callback for the snippets’ own events, the key `[-1]` may be
-    used. The callbacks are passed only one argument, the node that triggered it.
+    used. More info on events |luasnip-here|
 - `child_ext_opts`, `merge_child_ext_opts`: `ext_opts` applied to the children of
     this snippet. More info |luasnip-here|.
 
@@ -1677,17 +1679,90 @@ The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 ==============================================================================
 21. EVENTS                                                    *luasnip-events*
 
-Upon leaving/entering nodes or changing a choice an event is triggered: `User
-Luasnip<Node>{Enter,Leave}`, where `<Node>` is the name of a node in
-PascalCase, eg. `InsertNode` or `DynamicNode` or `Snippet`. The event triggered
-when changing the choice in a `choiceNode` is `User LuasnipChangeChoice`.
+Events can be used to react to some action inside snippets. These callbacks can
+be defined per-snippet (`callbacks`-key in snippet constructor) or globally
+(autocommand).
+
+`callbacks`: `fn(node[, event_args])` All callbacks get the `node` associated
+with the event and event-specific optional arguments, `event_args`.
+
+`autocommand`: Luasnip uses `User`-events. Autocommands for these can be
+registered using
+
+>
+    au User SomeUserEvent echom "SomeUserEvent was triggered"
+<
+
+
+or
+
+>
+    vim.api.nvim_create_autocommand("User", {
+        patter = "SomeUserEvent",
+        command = "echom SomeUserEvent was triggered"
+    })
+<
+
+
+The node and `event_args` can be accessed through `require("luasnip").session`:
+
+
+- `node`: `session.event_node`
+- `event_args`: `session.event_args`
+
+
+**Events**:
+
+
+- `enter/leave`: Called when a node is entered/left (for example when jumping
+    around in a snippet).
+    `User-event`: `"Luasnip<Node>{Enter,Leave}"`, with `<Node>` in
+    PascalCase, eg. `InsertNode` or `DynamicNode`.
+    `event_args`: none
+- `change_choice`: When the active choice in a choiceNode is changed.
+    `User-event`: `"LuasnipChangeChoice"`
+    `event_args`: none
+- `pre_expand`: Called before a snippet is expanded. Modifying text is allowed,
+    the expand-position will be adjusted so the snippet expands at the same
+    position relative to existing text.
+    `User-event`: `"LuasnipPreExpand"`
+    `event_args`:
+    - `expand_pos`: `{<row>, <column>}`, position at which the snippet will be
+        expanded. `<row>` and `<column>` are both 0-indexed.
+
 
 A pretty useless, beyond serving as an example here, application of these would
 be printing eg. the nodes’ text after entering:
 
 >
-    au User LuasnipInsertNodeEnter
-        \lua print(require("luasnip").session.event_node:get_text()[1])
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "LuasnipInsertNodeEnter",
+        callback = function()
+            local node = require("luasnip").session.event_node
+            print(table.concat(node:get_text(), "\n"))
+        end
+    })
+<
+
+
+or some information about expansions
+
+>
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "LuasnipPreExpand",
+        callback = function()
+            -- get event-parameters from `session`.
+            local snippet = require("luasnip").session.event_node
+            local expand_position =
+                require("luasnip").session.event_args.expand_pos
+    
+            print(string.format("expanding snippet %s at %s:%s",
+                table.concat(snippet:get_docstring(), "\n"),
+                expand_position[1],
+                expand_position[2]
+            ))
+        end
+    })
 <
 
 

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -176,7 +176,7 @@ local function snip_expand(snippet, opts)
 
 	local env = Environ:new(opts.pos)
 
-	local id = vim.api.nvim_buf_set_extmark(
+	local pos_id = vim.api.nvim_buf_set_extmark(
 		0,
 		session.ns_id,
 		opts.pos[1],
@@ -201,11 +201,9 @@ local function snip_expand(snippet, opts)
 		)
 	end
 
-	local pos = vim.api.nvim_buf_get_extmark_by_id(0, session.ns_id, id, {})
-
 	snip:trigger_expand(
 		session.current_nodes[vim.api.nvim_get_current_buf()],
-		pos,
+		pos_id,
 		env
 	)
 

--- a/lua/luasnip/util/events.lua
+++ b/lua/luasnip/util/events.lua
@@ -4,9 +4,12 @@ return {
 	enter = 1,
 	leave = 2,
 	change_choice = 3,
+	pre_expand = 4,
 	to_string = function(node_type, event_id)
 		if event_id == 3 then
 			return "ChangeChoice"
+		elseif event_id == 4 then
+			return "PreExpand"
 		else
 			return node_names[node_type]
 				.. (event_id == 1 and "Enter" or "Leave")


### PR DESCRIPTION
This adds a pre-expand-callback, which is executed before any text is inserted into the buffer.
Inside it, it's okay to remove/insert text (we keep track of the snippet's expand-position using an extmark).

One example where this is useful: a snippet that always expands without indent.
```lua
s("trig36",
	t{"", "no indent"},
	{
		callbacks = {
			-- event for snippet.
			[-1] = {
				[events.pre_expand] = function(_, opts)
					local pos = opts.expand_pos
					-- simply remove all text before the snippet's expand-position.
					vim.api.nvim_buf_set_text(0, pos[1], 0, pos[1], pos[2], {""})
				end
			}
		}
	}
)
```

Another application would be logging expansions (seems useless though)
```vim
au User LuasnipPreExpand lua print("expanding " .. table.concat(ls.session.event_node:get_docstring(), "\n") )
```

I'll have to think about whether this really is the best way to handle pre-expand-callbacks, then add some docs.