### PR TITLE
`ext opts` for (un)visited nodes.

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1838,6 +1838,13 @@ nodes:
             -- add virtual text on the line of the node, behind all text.
             virt_text = {{"virtual text!!", "GruvboxBlue"}}
         },
+        -- visited or unvisited are applied when a node was/was not jumped into.
+        visited = {
+            hl_group = "GruvboxBlue"
+        },
+        unvisited = {
+            hl_group = "GruvboxGreen"
+        },
         -- and these are applied when both the node and the snippet are inactive.
         snippet_passive = {}
     }
@@ -1855,17 +1862,22 @@ nodes:
 <
 
 
-In the above example the text inside the insertNodes is higlighted in red while
-inside them, and the virtual text "virtual text!!" is visible as long as the
-snippet is active.
+In the above example the text inside the insertNodes is higlighted in green if
+they were not yet visited, in blue once they were, and red while they are. The
+virtual text "virtual text!!" is visible as long as the snippet is active.
 
-It’s important to note that `snippet_passive` applies to the states
-`snippet_passive`, `passive`, and `active`, `passive` to `passive` and
-`active`, and `active` only to `active`.
+To make defining `ext_opts` less verbose, more specific states inherit from
+less specific ones:
 
-To disable a key from a "lower" state, it has to be explicitly set to its
+
+- `passive` inherits from `snippet_passive`
+- `visited` and `unvisited` from `passive`
+- `active` from `visited`
+
+
+To disable a key from a less specific state, it has to be explicitly set to its
 default, e.g. to disable highlighting inherited from `passive` when the node
-is `active`, `hl_group` could be set to `None` in `active`.
+is `active`, `hl_group` should be set to `None`.
 
 ------------------------------------------------------------------------------
 
@@ -1880,11 +1892,13 @@ set of `ext_opts` should be applied to:
         ext_opts = {
             [types.insertNode] = {
                 active = {...},
+                visited = {...},
                 passive = {...},
                 snippet_passive = {...}
             },
             [types.choiceNode] = {
-                active = {...}
+                active = {...},
+                unvisited = {...}
             },
             [types.snippet] = {
                 passive = {...}
@@ -1919,8 +1933,8 @@ snippet.
 
 By default, the `ext_opts` actually used for a node are created by extending
 the `node_ext_opts` with the `effective_child_ext_opts[node.type]` of the
-parent, which are in turn the `child_ext_opts` of the parent extended with the
-global `ext_opts` set in the config.
+parent, which are in turn the parent’s `child_ext_opts` extended with the
+global `ext_opts` (those set `ls.setup`).
 
 It’s possible to prevent both of these merges by passing
 `merge_node/child_ext_opts=false` to the snippet/node-opts:
@@ -1942,7 +1956,9 @@ It’s possible to prevent both of these merges by passing
                 active = {...}
             },
             merge_node_ext_opts = false
-        }), i(2, "text2") }, {
+        }),
+        i(2, "text2")
+    }, {
         child_ext_opts = {
             [types.insertNode] = {
                 passive = {...}
@@ -1962,7 +1978,7 @@ highlight-groups:
     vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
     vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
     
-    -- needs to be called for resolving the actual ext_opts.
+    -- needs to be called for resolving the effective ext_opts.
     ls.setup({})
 <
 
@@ -1974,12 +1990,13 @@ kind of node in PascalCase (or "Snippet").
 ------------------------------------------------------------------------------
 
 One problem that might arise when nested nodes are highlighted, is that the
-highlight of inner nodes should be visible above that of nodes they are nested
-inside.
+highlight of inner nodes should be visible, eg. above that of nodes they are
+nested inside.
 
-This can be controlled using the `priority`-key in `ext_opts`. Normally, that
-value is an absolute value, but here it is relative to some base-priority,
-which is increased for each nesting level of snippets.
+This can be controlled using the `priority`-key in `ext_opts`. In
+`nvim_buf_set_extmark`, that value is an absolute value, but here it is
+relative to some base-priority, which is increased for each nesting level of
+snippet(Nodes)s.
 
 Both the initial base-priority and its’ increase and can be controlled using
 `ext_base_prio` and `ext_prio_increase`:

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -28,11 +28,15 @@ local defaults = {
 		[types.textNode] = {
 			active = { hl_group = "LuasnipTextNodeActive" },
 			passive = { hl_group = "LuasnipTextNodePassive" },
+			visited = { hl_group = "LuasnipTextNodeVisited" },
+			unvisited = { hl_group = "LuasnipTextNodeUnvisited" },
 			snippet_passive = { hl_group = "LuasnipTextNodeSnippetPassive" },
 		},
 		[types.insertNode] = {
 			active = { hl_group = "LuasnipInsertNodeActive" },
 			passive = { hl_group = "LuasnipInsertNodePassive" },
+			visited = { hl_group = "LuasnipInsertNodeVisited" },
+			unvisited = { hl_group = "LuasnipInsertNodeUnvisited" },
 			snippet_passive = {
 				hl_group = "LuasnipInsertNodeSnippetPassive",
 			},
@@ -40,11 +44,15 @@ local defaults = {
 		[types.exitNode] = {
 			active = { hl_group = "LuasnipExitNodeActive" },
 			passive = { hl_group = "LuasnipExitNodePassive" },
+			visited = { hl_group = "LuasnipExitNodeVisited" },
+			unvisited = { hl_group = "LuasnipExitNodeUnvisited" },
 			snippet_passive = { hl_group = "LuasnipExitNodeSnippetPassive" },
 		},
 		[types.functionNode] = {
 			active = { hl_group = "LuasnipFunctionNodeActive" },
 			passive = { hl_group = "LuasnipFunctionNodePassive" },
+			visited = { hl_group = "LuasnipFunctionNodeVisited" },
+			unvisited = { hl_group = "LuasnipFunctionNodeUnvisited" },
 			snippet_passive = {
 				hl_group = "LuasnipFunctionNodeSnippetPassive",
 			},
@@ -52,6 +60,8 @@ local defaults = {
 		[types.snippetNode] = {
 			active = { hl_group = "LuasnipSnippetNodeActive" },
 			passive = { hl_group = "LuasnipSnippetNodePassive" },
+			visited = { hl_group = "LuasnipSnippetNodeVisited" },
+			unvisited = { hl_group = "LuasnipSnippetNodeUnvisited" },
 			snippet_passive = {
 				hl_group = "LuasnipSnippetNodeSnippetPassive",
 			},
@@ -59,6 +69,8 @@ local defaults = {
 		[types.choiceNode] = {
 			active = { hl_group = "LuasnipChoiceNodeActive" },
 			passive = { hl_group = "LuasnipChoiceNodePassive" },
+			visited = { hl_group = "LuasnipChoiceNodeVisited" },
+			unvisited = { hl_group = "LuasnipChoiceNodeUnvisited" },
 			snippet_passive = {
 				hl_group = "LuasnipChoiceNodeSnippetPassive",
 			},
@@ -66,6 +78,8 @@ local defaults = {
 		[types.dynamicNode] = {
 			active = { hl_group = "LuasnipDynamicNodeActive" },
 			passive = { hl_group = "LuasnipDynamicNodePassive" },
+			visited = { hl_group = "LuasnipDynamicNodeVisited" },
+			unvisited = { hl_group = "LuasnipDynamicNodeUnvisited" },
 			snippet_passive = {
 				hl_group = "LuasnipDynamicNodeSnippetPassive",
 			},
@@ -74,11 +88,15 @@ local defaults = {
 			active = { hl_group = "LuasnipSnippetActive" },
 			passive = { hl_group = "LuasnipSnippetPassive" },
 			-- not used!
+			visited = { hl_group = "LuasnipSnippetVisited" },
+			unvisited = { hl_group = "LuasnipSnippetUnvisited" },
 			snippet_passive = { hl_group = "LuasnipSnippetSnippetPassive" },
 		},
 		[types.restoreNode] = {
 			active = { hl_group = "LuasnipRestoreNodeActive" },
 			passive = { hl_group = "LuasnipRestoreNodePassive" },
+			visited = { hl_group = "LuasnipRestoreNodeVisited" },
+			unvisited = { hl_group = "LuasnipRestoreNodeUnvisited" },
 			snippet_passive = {
 				hl_group = "LuasnipRestoreNodeSnippetPassive",
 			},

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -114,7 +114,7 @@ function ChoiceNode:put_initial(pos)
 	local mark_opts = vim.tbl_extend("keep", {
 		right_gravity = false,
 		end_right_gravity = false,
-	}, self.active_choice.ext_opts.passive)
+	}, self.active_choice:get_passive_ext_opts())
 
 	self.active_choice.mark = mark(old_pos, pos, mark_opts)
 	self.visible = true
@@ -138,6 +138,7 @@ function ChoiceNode:input_enter()
 
 	self.prev_choice_node = session.active_choice_node
 	session.active_choice_node = self
+	self.visited = true
 	self.active = true
 
 	self:event(events.enter)
@@ -146,7 +147,7 @@ end
 function ChoiceNode:input_leave()
 	self:event(events.leave)
 
-	self.mark:update_opts(self.ext_opts.passive)
+	self.mark:update_opts(self:get_passive_ext_opts())
 	self:update_dependents()
 	session.active_choice_node = self.prev_choice_node
 	self.active = false
@@ -240,7 +241,7 @@ function ChoiceNode:set_choice(choice, current_node)
 	self.active_choice = choice
 
 	self.active_choice.mark = self.mark:copy_pos_gravs(
-		vim.deepcopy(self.active_choice.ext_opts.passive)
+		vim.deepcopy(self.active_choice:get_passive_ext_opts())
 	)
 
 	-- re-init positions for child-restoreNodes (they will update their
@@ -328,7 +329,8 @@ function ChoiceNode:set_mark_rgrav(rgrav_beg, rgrav_end)
 end
 
 function ChoiceNode:set_ext_opts(name)
-	self.mark:update_opts(self.ext_opts[name])
+	Node.set_ext_opts(self, name)
+
 	self.active_choice:set_ext_opts(name)
 end
 

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -149,9 +149,8 @@ function DynamicNode:update()
 	tmp:resolve_node_ext_opts()
 	tmp:subsnip_init()
 
-	tmp.mark = self.mark:copy_pos_gravs(
-		vim.deepcopy(tmp:get_passive_ext_opts())
-	)
+	tmp.mark =
+		self.mark:copy_pos_gravs(vim.deepcopy(tmp:get_passive_ext_opts()))
 	tmp.dynamicNode = self
 	tmp.update_dependents = function(node)
 		node:_update_dependents()
@@ -321,7 +320,8 @@ function DynamicNode:update_restore()
 		-- prevent entering the uninitialized snip in enter_node in a few lines.
 		local tmp = self.stored_snip
 
-		tmp.mark = self.mark:copy_pos_gravs(vim.deepcopy(tmp:get_passive_ext_opts()))
+		tmp.mark =
+			self.mark:copy_pos_gravs(vim.deepcopy(tmp:get_passive_ext_opts()))
 
 		-- position might (will probably!!) still have changed, so update it
 		-- here too (as opposed to only in update).

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -25,6 +25,7 @@ end
 extend_decorator.register(D, { arg_indx = 4 })
 
 function DynamicNode:input_enter()
+	self.visited = true
 	self.active = true
 	self.mark:update_opts(self.ext_opts.active)
 
@@ -36,7 +37,7 @@ function DynamicNode:input_leave()
 
 	self:update_dependents()
 	self.active = false
-	self.mark:update_opts(self.ext_opts.passive)
+	self.mark:update_opts(self:get_passive_ext_opts())
 end
 
 function DynamicNode:get_static_text()
@@ -148,7 +149,9 @@ function DynamicNode:update()
 	tmp:resolve_node_ext_opts()
 	tmp:subsnip_init()
 
-	tmp.mark = self.mark:copy_pos_gravs(vim.deepcopy(tmp.ext_opts.passive))
+	tmp.mark = self.mark:copy_pos_gravs(
+		vim.deepcopy(tmp:get_passive_ext_opts())
+	)
 	tmp.dynamicNode = self
 	tmp.update_dependents = function(node)
 		node:_update_dependents()
@@ -298,7 +301,8 @@ function DynamicNode:exit()
 end
 
 function DynamicNode:set_ext_opts(name)
-	self.mark:update_opts(self.ext_opts[name])
+	Node.set_ext_opts(self, name)
+
 	-- might not have been generated (missing nodes).
 	if self.snip then
 		self.snip:set_ext_opts(name)
@@ -317,7 +321,7 @@ function DynamicNode:update_restore()
 		-- prevent entering the uninitialized snip in enter_node in a few lines.
 		local tmp = self.stored_snip
 
-		tmp.mark = self.mark:copy_pos_gravs(vim.deepcopy(tmp.ext_opts.passive))
+		tmp.mark = self.mark:copy_pos_gravs(vim.deepcopy(tmp:get_passive_ext_opts()))
 
 		-- position might (will probably!!) still have changed, so update it
 		-- here too (as opposed to only in update).

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -96,7 +96,9 @@ function ExitNode:is_interactive()
 end
 
 function InsertNode:input_enter(no_move)
+	self.visited = true
 	self.mark:update_opts(self.ext_opts.active)
+
 	if not no_move then
 		self.parent:enter_node(self.indx)
 
@@ -192,7 +194,7 @@ function InsertNode:input_leave()
 	self:event(events.leave)
 
 	self:update_dependents()
-	self.mark:update_opts(self.ext_opts.passive)
+	self.mark:update_opts(self:get_passive_ext_opts())
 end
 
 function InsertNode:exit()

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -17,6 +17,7 @@ function Node:new(o, opts)
 	o.visible = false
 	o.static_visible = false
 	o.old_text = {}
+	o.visited = false
 	-- override existing keys, might be necessary due to double-init from
 	-- snippetProxy, but shouldn't hurt.
 	o = vim.tbl_extend("force", o, node_util.init_node_opts(opts or {}))
@@ -65,6 +66,7 @@ function Node:put_initial(pos)
 end
 
 function Node:input_enter(_)
+	self.visited = true
 	self.mark:update_opts(self.ext_opts.active)
 
 	self:event(events.enter)
@@ -138,10 +140,18 @@ function Node:exit()
 	self.mark:clear()
 end
 
+function Node:get_passive_ext_opts()
+	if self.visited then
+		return self.ext_opts.visited
+	else
+		return self.ext_opts.unvisited
+	end
+end
+
 function Node:input_leave()
 	self:event(events.leave)
 
-	self.mark:update_opts(self.ext_opts.passive)
+	self.mark:update_opts(self:get_passive_ext_opts())
 end
 
 local function find_dependents(self, position_self, dict)
@@ -286,7 +296,12 @@ function Node:get_static_args()
 end
 
 function Node:set_ext_opts(name)
-	self.mark:update_opts(self.ext_opts[name])
+	-- differentiate, either visited or unvisited needs to be set.
+	if name == "passive" then
+		self.mark:update_opts(self:get_passive_ext_opts())
+	else
+		self.mark:update_opts(self.ext_opts[name])
+	end
 end
 
 -- for insert,functionNode.

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -41,6 +41,7 @@ end
 
 function RestoreNode:input_enter()
 	self.active = true
+	self.visited = true
 	self.mark:update_opts(self.ext_opts.active)
 
 	self:event(events.enter)
@@ -51,7 +52,8 @@ function RestoreNode:input_leave()
 
 	self:update_dependents()
 	self.active = false
-	self.mark:update_opts(self.ext_opts.passive)
+
+	self.mark:update_opts(self:get_passive_ext_opts())
 end
 
 -- set snippetNode for this key here.
@@ -111,7 +113,7 @@ function RestoreNode:put_initial(pos)
 	local mark_opts = vim.tbl_extend("keep", {
 		right_gravity = false,
 		end_right_gravity = false,
-	}, tmp.ext_opts.passive)
+	}, tmp:get_passive_ext_opts())
 
 	local old_pos = vim.deepcopy(pos)
 	tmp:put_initial(pos)
@@ -139,7 +141,8 @@ function RestoreNode:jump_into(dir, no_move)
 end
 
 function RestoreNode:set_ext_opts(name)
-	self.mark:update_opts(self.ext_opts[name])
+	Node.set_ext_opts(self, name)
+
 	self.snip:set_ext_opts(name)
 end
 

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -484,7 +484,7 @@ function Snippet:trigger_expand(current_node, pos_id, env)
 	local mark_opts = vim.tbl_extend("keep", {
 		right_gravity = false,
 		end_right_gravity = true,
-	}, self.ext_opts.passive)
+	}, self:get_passive_ext_opts())
 	self.mark = mark(old_pos, pos, mark_opts)
 
 	self:update()
@@ -671,7 +671,7 @@ function Snippet:put_initial(pos)
 		local mark_opts = vim.tbl_extend("keep", {
 			right_gravity = false,
 			end_right_gravity = false,
-		}, node.ext_opts.passive)
+		}, node:get_passive_ext_opts())
 		node.mark = mark(old_pos, pos, mark_opts)
 	end
 	self.visible = true
@@ -853,10 +853,11 @@ function Snippet:make_args_absolute()
 end
 
 function Snippet:input_enter()
+	self.visited = true
 	self.active = true
 
 	if self.type == types.snippet then
-		-- set snippet-passive -> passive for all children.
+		-- set snippet-passive -> visited/unvisited for all children.
 		self:set_ext_opts("passive")
 	end
 	self.mark:update_opts(self.ext_opts.active)

--- a/lua/luasnip/nodes/textNode.lua
+++ b/lua/luasnip/nodes/textNode.lua
@@ -17,6 +17,8 @@ extend_decorator.register(T, { arg_indx = 2 })
 
 function TextNode:input_enter(no_move)
 	self.mark:update_opts(self.ext_opts.active)
+	self.visited = true
+
 	if not no_move then
 		local mark_begin_pos = self.mark:pos_begin_raw()
 		if vim.fn.mode() == "i" then

--- a/tests/integration/ext_opts_spec.lua
+++ b/tests/integration/ext_opts_spec.lua
@@ -1,0 +1,149 @@
+local helpers = require("test.functional.helpers")(after_each)
+local exec_lua, feed, exec = helpers.exec_lua, helpers.feed, helpers.exec
+local ls_helpers = require("helpers")
+local Screen = require("test.functional.ui.screen")
+
+describe("snippets_basic", function()
+	local screen
+
+	before_each(function()
+		helpers.clear()
+		ls_helpers.session_setup_luasnip()
+
+		exec([[
+			hi Blue ctermfg=Blue guifg=Blue
+			hi Green ctermfg=Green guifg=Green
+			hi Cyan ctermfg=Cyan guifg=Cyan
+			hi Red ctermfg=Red guifg=Red
+		]])
+
+		screen = Screen.new(50, 3)
+		screen:attach()
+		screen:set_default_attr_ids({
+			[0] = {bold = true, foreground = Screen.colors.Blue1},
+			[1] = {bold = true, foreground = Screen.colors.Brown},
+			[2] = {bold = true},
+			[3] = {background = Screen.colors.LightGray},
+			[4] = {foreground = Screen.colors.WebGreen},
+			[5] = {foreground = Screen.colors.Blue1},
+			[6] = {background = Screen.colors.LightGray, foreground = Screen.colors.Blue1},
+			[7] = {foreground = Screen.colors.Cyan1},
+			[8] = {background = Screen.colors.LightGray, foreground = Screen.colors.Cyan1},
+			[9] = {foreground = Screen.colors.Red}
+		})
+	end)
+
+	after_each(function()
+		screen:detach()
+	end)
+
+	it("Can apply ext_opts per-node", function()
+		local snip = [[
+			s("trig", {
+				t("Green", {
+					node_ext_opts = {
+						passive = {hl_group = "Green"}
+					}
+				}),
+				-- so the snippet is active at all.
+				i(1, "text", {
+					node_ext_opts = {
+						passive = {hl_group = "Blue"}
+					}
+				})
+			})
+		]]
+		exec_lua("ls.snip_expand(" .. snip .. ")")
+		screen:expect{grid=[[
+			{4:Green}{5:^t}{6:ext}                                         |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]}
+		exec_lua("ls.jump(1)")
+		screen:expect{grid=[[
+			Greentext^                                         |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]}
+	end)
+
+	it("Correctly applies active,visited,unvisited", function()
+		local snip = [[
+			s("trig", {
+				-- so the snippet is active at all.
+				i(1, "text", {
+					node_ext_opts = {
+						unvisited = {hl_group = "Blue"},
+						visited = {hl_group = "Green"},
+						active = {hl_group = "Cyan"}
+					}
+				}),
+				i(2, "text", {
+					node_ext_opts = {
+						unvisited = {hl_group = "Blue"},
+						visited = {hl_group = "Green"},
+						active = {hl_group = "Cyan"}
+					}
+				}),
+				i(3, "text", {
+					node_ext_opts = {
+						unvisited = {hl_group = "Blue"},
+						visited = {hl_group = "Green"},
+						active = {hl_group = "Cyan"}
+					}
+				})
+			})
+		]]
+		exec_lua("ls.snip_expand(" .. snip .. ")")
+		screen:expect{grid=[[
+			{7:^t}{8:ext}{5:texttext}                                      |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]}
+		exec_lua("ls.jump(1)")
+		screen:expect{grid=[[
+			{4:text}{7:^t}{8:ext}{5:text}                                      |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]}
+		exec_lua("ls.jump(1)")
+		screen:expect{grid=[[
+			{4:texttext}{7:^t}{8:ext}                                      |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]}
+	end)
+
+	it("Inheritance", function()
+		local snip = [[
+			s("trig", {
+				-- so the snippet is active at all.
+				i(1, "text", {
+					node_ext_opts = {
+						snippet_passive = {hl_group = "Red"},
+						passive = {hl_group = "Blue"},
+						visited = {hl_group = "Green"},
+						active = {hl_group = "Cyan"}
+					}
+				}),
+				i(2, "text", {
+					node_ext_opts = {
+						passive = {hl_group = "Blue"},
+						visited = {hl_group = "Green"},
+						active = {hl_group = "Cyan"}
+					}
+				}),
+			})
+		]]
+		exec_lua("ls.snip_expand(" .. snip .. ")")
+		screen:expect{grid=[[
+			{7:^t}{8:ext}{5:text}                                          |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]}
+		exec_lua("ls.jump(1)")
+		screen:expect{grid=[[
+			{4:text}{7:^t}{8:ext}                                          |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]}
+		exec_lua("ls.jump(1)")
+		screen:expect{grid=[[
+			{9:text}text^                                          |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]}
+	end)
+end)

--- a/tests/integration/ext_opts_spec.lua
+++ b/tests/integration/ext_opts_spec.lua
@@ -20,16 +20,22 @@ describe("snippets_basic", function()
 		screen = Screen.new(50, 3)
 		screen:attach()
 		screen:set_default_attr_ids({
-			[0] = {bold = true, foreground = Screen.colors.Blue1},
-			[1] = {bold = true, foreground = Screen.colors.Brown},
-			[2] = {bold = true},
-			[3] = {background = Screen.colors.LightGray},
-			[4] = {foreground = Screen.colors.WebGreen},
-			[5] = {foreground = Screen.colors.Blue1},
-			[6] = {background = Screen.colors.LightGray, foreground = Screen.colors.Blue1},
-			[7] = {foreground = Screen.colors.Cyan1},
-			[8] = {background = Screen.colors.LightGray, foreground = Screen.colors.Cyan1},
-			[9] = {foreground = Screen.colors.Red}
+			[0] = { bold = true, foreground = Screen.colors.Blue1 },
+			[1] = { bold = true, foreground = Screen.colors.Brown },
+			[2] = { bold = true },
+			[3] = { background = Screen.colors.LightGray },
+			[4] = { foreground = Screen.colors.WebGreen },
+			[5] = { foreground = Screen.colors.Blue1 },
+			[6] = {
+				background = Screen.colors.LightGray,
+				foreground = Screen.colors.Blue1,
+			},
+			[7] = { foreground = Screen.colors.Cyan1 },
+			[8] = {
+				background = Screen.colors.LightGray,
+				foreground = Screen.colors.Cyan1,
+			},
+			[9] = { foreground = Screen.colors.Red },
 		})
 	end)
 
@@ -54,15 +60,19 @@ describe("snippets_basic", function()
 			})
 		]]
 		exec_lua("ls.snip_expand(" .. snip .. ")")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			{4:Green}{5:^t}{6:ext}                                         |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]}
+			{2:-- SELECT --}                                      |]],
+		})
 		exec_lua("ls.jump(1)")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			Greentext^                                         |
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 	end)
 
 	it("Correctly applies active,visited,unvisited", function()
@@ -93,20 +103,26 @@ describe("snippets_basic", function()
 			})
 		]]
 		exec_lua("ls.snip_expand(" .. snip .. ")")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			{7:^t}{8:ext}{5:texttext}                                      |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]}
+			{2:-- SELECT --}                                      |]],
+		})
 		exec_lua("ls.jump(1)")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			{4:text}{7:^t}{8:ext}{5:text}                                      |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]}
+			{2:-- SELECT --}                                      |]],
+		})
 		exec_lua("ls.jump(1)")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			{4:texttext}{7:^t}{8:ext}                                      |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]}
+			{2:-- SELECT --}                                      |]],
+		})
 	end)
 
 	it("Inheritance", function()
@@ -131,19 +147,25 @@ describe("snippets_basic", function()
 			})
 		]]
 		exec_lua("ls.snip_expand(" .. snip .. ")")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			{7:^t}{8:ext}{5:text}                                          |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]}
+			{2:-- SELECT --}                                      |]],
+		})
 		exec_lua("ls.jump(1)")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			{4:text}{7:^t}{8:ext}                                          |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]}
+			{2:-- SELECT --}                                      |]],
+		})
 		exec_lua("ls.jump(1)")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			{9:text}text^                                          |
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 	end)
 end)


### PR DESCRIPTION
As proposed in #410.
For now the inheritance is (with arrows `to` _gets-and-extends-ext_opts-from_ `from`)
```mermaid
flowchart TD
	passive --> active
	passive --> visited
	passive --> unvisited
	snippet_passive --> passive
```
although that feels a bit weird, maybe it would be better to combine `ext_opts` from `visited` and `unvisited` for `active`.

One example:
```lua
ls.setup_snip_env()

local node_ext_opts = {
	visited = {
		hl_group = "GruvboxPurple"
	},
	unvisited = {
		hl_group = "GruvboxBlue"
	},
}

ls.add_snippets("all", {
	s("trig36", {
		t{"no indent"}, c(3, {
			t"a",
			t"b",
			t"c"
		}, {
			node_ext_opts = node_ext_opts
		}), i(2, "some text"), i(1, "some text")
	}, {
		child_ext_opts = {
			[types.insertNode] = {
				passive = {
					hl_group = "GruvboxRed"
				},
				visited = {
					hl_group = "GruvboxOrange"
				},
				unvisited = {
					hl_group = "GruvboxYellow"
				},
			}
		}
	})
}, {
	key = "test"
})
```

Needs docs and tests.