### PR TITLE
docs: Correct command name for selecting previous choice

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -440,8 +440,8 @@ The active choice for a choiceNode can be changed by calling `ls.change_choice(1
 -- set keybinds for both INSERT and VISUAL.
 vim.api.nvim_set_keymap("i", "<C-n>", "<Plug>luasnip-next-choice", {})
 vim.api.nvim_set_keymap("s", "<C-n>", "<Plug>luasnip-next-choice", {})
-vim.api.nvim_set_keymap("i", "<C-p>", "<Plug>luasnip-previous-choice", {})
-vim.api.nvim_set_keymap("s", "<C-p>", "<Plug>luasnip-previous-choice", {})
+vim.api.nvim_set_keymap("i", "<C-p>", "<Plug>luasnip-prev-choice", {})
+vim.api.nvim_set_keymap("s", "<C-p>", "<Plug>luasnip-prev-choice", {})
 ```
 
 Apart from this, there is also a [picker](#select_choice) where no cycling is necessary and any

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -519,8 +519,8 @@ example via
     -- set keybinds for both INSERT and VISUAL.
     vim.api.nvim_set_keymap("i", "<C-n>", "<Plug>luasnip-next-choice", {})
     vim.api.nvim_set_keymap("s", "<C-n>", "<Plug>luasnip-next-choice", {})
-    vim.api.nvim_set_keymap("i", "<C-p>", "<Plug>luasnip-previous-choice", {})
-    vim.api.nvim_set_keymap("s", "<C-p>", "<Plug>luasnip-previous-choice", {})
+    vim.api.nvim_set_keymap("i", "<C-p>", "<Plug>luasnip-prev-choice", {})
+    vim.api.nvim_set_keymap("s", "<C-p>", "<Plug>luasnip-prev-choice", {})
 <
 
 


### PR DESCRIPTION
The documentation currently refers to `luasnip-previous-choice`, which doesn't exist/work. This change updates the docs to use the proper command name, as recognized by the plugin.