### PR TITLE
Fix name of `enable_autosnippets` parameter in documentation

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1694,7 +1694,7 @@ the lazy_load.
 - `expand_or_jump()`: returns true if jump/expand was succesful.
 
 - `expand_auto()`: expands the autosnippets before the cursor (not necessary
-  to call manually, will be called via autocmd if `enable_autosnippet` is set
+  to call manually, will be called via autocmd if `enable_autosnippets` is set
   in the config).
 
 - `snip_expand(snip, opts)`: expand `snip` at the current cursor position.

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1854,7 +1854,7 @@ empty the snippets table and the caches of the lazy_load.
     is ignored if the cursor is not inside the current snippet.
 - `expand_or_jump()`: returns true if jump/expand was succesful.
 - `expand_auto()`: expands the autosnippets before the cursor (not necessary to
-    call manually, will be called via autocmd if `enable_autosnippet` is set in the
+    call manually, will be called via autocmd if `enable_autosnippets` is set in the
     config).
 - `snip_expand(snip, opts)`: expand `snip` at the current cursor position. `opts`
     may contain the following keys:


### PR DESCRIPTION
The error in the docs tripped me up when trying to get autosnippets working. I grepped the repository and fixed all places where the `enable_autosnippets` was misspelled.

Cheers for the plugin!