### PR TITLE
otf: Prevent crash with $ before end of string.

### DIFF
--- a/lua/luasnip/extras/otf.lua
+++ b/lua/luasnip/extras/otf.lua
@@ -13,7 +13,7 @@ local chunk = p.any(
 	p.map(p.literal("\n"), function()
 		return { T.EOL }
 	end),
-	p.map(p.seq(p.literal("$"), p.pattern("%w+")), function(c)
+	p.map(p.seq(p.literal("$"), p.pattern("%w*")), function(c)
 		return { T.INP, c[1] }
 	end),
 	p.map(p.pattern("[^\n$]*"), function(c)

--- a/tests/unit/otf_spec.lua
+++ b/tests/unit/otf_spec.lua
@@ -39,4 +39,16 @@ describe("luasnip.extra.otf", function()
 			{ "INP", "someone" },
 		}
 	)
+
+	check(
+		"Empty placeholder",
+		"asdf $ asdf",
+		{ { "TXT", "asdf " }, { "INP", "" }, { "TXT", " asdf" } }
+	)
+
+	check(
+		"End with empty placeholder",
+		"asdf $",
+		{ { "TXT", "asdf " }, { "INP", "" } }
+	)
 end)


### PR DESCRIPTION
Reproducable with `asdf $`, but even `asdf $ asdf` leads to an unexpected `asdf ${1:asd}`.
@leiserfg I'm not completely sure where how the loop (I assume) is caused, do you have an idea (maybe the position in the string is getting messed up somewhere)?
I guess this should be `*` in any case, to allow for empty placeholders?