### PR TITLE
Add postfix snippet extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://user-images.githubusercontent.com/41961280/122515860-5179fa00-d00e-11eb-
 - Dynamic Snippet creation
 - Regex-Trigger
 - Autotriggered Snippets
+- Easy Postfix Snippets
 - Fast
 - Parse [LSP-Style](https://microsoft.github.io/language-server-protocol/specification#snippet_syntax) Snippets either directly in lua, as a vscode package or a snipmate snippet collection.
 - Expand LSP-Snippets with [nvim-compe](https://github.com/hrsh7th/nvim-compe) (or its' successor, [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) (requires [cmp_luasnip](https://github.com/saadparwaiz1/cmp_luasnip)))

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -10,32 +10,33 @@ Table of Contents                                  *luasnip-table-of-contents*
 4. TEXTNODE                                                 |luasnip-textnode|
 5. INSERTNODE                                             |luasnip-insertnode|
 6. FUNCTIONNODE                                         |luasnip-functionnode|
-7. CHOICENODE                                             |luasnip-choicenode|
-8. SNIPPETNODE                                           |luasnip-snippetnode|
-9. INDENTSNIPPETNODE                               |luasnip-indentsnippetnode|
-10. DYNAMICNODE                                          |luasnip-dynamicnode|
-11. RESTORENODE                                          |luasnip-restorenode|
-12. ABSOLUTE_INDEXER                                |luasnip-absolute_indexer|
-13. EXTRAS                                                    |luasnip-extras|
+7. POSTFIX SNIPPET                                   |luasnip-postfix-snippet|
+8. CHOICENODE                                             |luasnip-choicenode|
+9. SNIPPETNODE                                           |luasnip-snippetnode|
+10. INDENTSNIPPETNODE                              |luasnip-indentsnippetnode|
+11. DYNAMICNODE                                          |luasnip-dynamicnode|
+12. RESTORENODE                                          |luasnip-restorenode|
+13. ABSOLUTE_INDEXER                                |luasnip-absolute_indexer|
+14. EXTRAS                                                    |luasnip-extras|
   - FMT                                                          |luasnip-fmt|
   - On The Fly snippets                          |luasnip-on-the-fly-snippets|
   - Select_choice                                      |luasnip-select_choice|
   - filetype_functions                            |luasnip-filetype_functions|
-14. LSP-SNIPPETS                                        |luasnip-lsp-snippets|
-15. VARIABLES                                              |luasnip-variables|
-16. LOADERS                                                  |luasnip-loaders|
+15. LSP-SNIPPETS                                        |luasnip-lsp-snippets|
+16. VARIABLES                                              |luasnip-variables|
+17. LOADERS                                                  |luasnip-loaders|
   - Troubleshooting                                  |luasnip-troubleshooting|
   - VSCODE                                                    |luasnip-vscode|
   - SNIPMATE                                                |luasnip-snipmate|
   - LUA                                                          |luasnip-lua|
   - EDIT_SNIPPETS                                      |luasnip-edit_snippets|
-17. SNIPPETPROXY                                        |luasnip-snippetproxy|
-18. EXT_OPTS                                                |luasnip-ext_opts|
-19. DOCSTRING                                              |luasnip-docstring|
-20. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
-21. EVENTS                                                    |luasnip-events|
-22. CLEANUP                                                  |luasnip-cleanup|
-23. API-REFERENCE                                      |luasnip-api-reference|
+18. SNIPPETPROXY                                        |luasnip-snippetproxy|
+19. EXT_OPTS                                                |luasnip-ext_opts|
+20. DOCSTRING                                              |luasnip-docstring|
+21. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
+22. EVENTS                                                    |luasnip-events|
+23. CLEANUP                                                  |luasnip-cleanup|
+24. API-REFERENCE                                      |luasnip-api-reference|
 
 >
                 __                       ____
@@ -74,6 +75,7 @@ All code-snippets in this help assume that
     local fmt = require("luasnip.extras.fmt").fmt
     local m = require("luasnip.extras").m
     local lambda = require("luasnip.extras").l
+    local postfix = require("luasnip.extras.postfix").postfix
 <
 
 
@@ -119,8 +121,8 @@ It is possible to make snippets from one filetype available to another using
 2. NODE                                                         *luasnip-node*
 
 Every node accepts, as its’ last parameter, an optional table of arguments.
-There are some common ones (eg. |luasnip-`node_ext_opts`|), and some that only
-apply to some nodes (`user_args` for both function and dynamicNode). These
+There are some common ones (e.g. |luasnip-`node_ext_opts`|), and some that
+only apply to some nodes (`user_args` for both function and dynamicNode). These
 `opts` are only mentioned if they accept options that are not common to all
 nodes.
 
@@ -141,7 +143,7 @@ entries:
 
 
 - `trig`: string, plain text by default. The only entry that must be given.
-- `name`: string, can be used by eg. `nvim-compe` to identify the snippet.
+- `name`: string, can be used by e.g. `nvim-compe` to identify the snippet.
 - `dscr`: string, description of the snippet, -separated or table
     for multiple lines.
 - `wordTrig`: boolean, if true, the snippet is only expanded if the word
@@ -180,11 +182,11 @@ The third argument (`opts`) is a table with the following valid keys:
     captures) -> bool`. The snippet will be expanded only if it returns true
     (default is a function that just returns `true`). The function is called before
     the text is modified in any way. Some parameters are passed to the function:
-    The line up to the cursor, the matched trigger and the captures (table).
+    The line up to the cursor, the matched trigger, and the captures (table).
 - `show_condition`: Function with signature `f(line_to_cursor) -> bool`. It is a
     hint for completion-engines, indicating when the snippet should be included in
     current completion candidates. Defaults to a function returning `true`. This is
-    different than `condition` because `condition` is evaluated by LuaSnip on
+    different from `condition` because `condition` is evaluated by LuaSnip on
     snippet expansion (and thus has access to the matched trigger and captures),
     while `show_condition` is evaluated by the completion-engine when scanning for
     available snippet candidates.
@@ -206,12 +208,12 @@ The third argument (`opts`) is a table with the following valid keys:
     this snippet. More info |luasnip-here|.
 
 
-This `opts`-table can also be passed to eg. `snippetNode` or
+This `opts`-table can also be passed to e.g. `snippetNode` or
 `indentSnippetNode`, but only `callbacks` and the `ext_opts`-related options
 are used there.
 
-Snippets contain some interesting tables, eg. `snippet.env` contains variables
-used in the LSP-protocol like `TM_CURRENT_LINE` or `TM_FILENAME` or
+Snippets contain some interesting tables, e.g. `snippet.env` contains
+variables used in the LSP-protocol like `TM_CURRENT_LINE` or `TM_FILENAME` or
 `snippet.captures`, where capture-groups of regex-triggers are stored.
 Additionally, the string that was used to trigger the snippet is stored in
 `snippet.trigger`. These variables/tables are primarily useful in
@@ -258,7 +260,7 @@ lines rather than a string:
 ==============================================================================
 5. INSERTNODE                                             *luasnip-insertnode*
 
-These Nodes contain editable text and can be jumped to- and from (eg.
+These Nodes contain editable text and can be jumped to- and from (e.g.
 traditional placeholders, like `$1` in textmate-snippets).
 
 The functionality is best demonstrated with an example:
@@ -320,7 +322,7 @@ detail is that the jump-positions restart at 1 in nested snippets:
 <
 
 
-as opposed to eg. the textmate-syntax, where tabstops are snippet-global:
+as opposed to e.g. the textmate-syntax, where tabstops are snippet-global:
 
 >
     ${1:First jump} :: ${2: ${3:Third jump} : ${4:Fourth jump}}
@@ -339,7 +341,7 @@ for potentially keeping some default-value:
 <
 
 
-This initial text is defined the same way as textNodes, eg. can be multiline.
+This initial text is defined the same way as textNodes, e.g. can be multiline.
 
 `i(0)`s can have initial text, but do note that when the SELECTed text is
 replaced, its’ replacement won’t end up in the `i(0)`, but behind it (for
@@ -365,18 +367,18 @@ user-defined function:
 The first parameter of `f` is the function. Its parameters are:
 
 
-1. A table of the text of currently contained in the argnodes. (eg. `{{line1},
+1. A table of the text of currently contained in the argnodes. (e.g. `{{line1},
 {line1, line2}}`). The snippet-indent will be removed from all lines following
 the first.
 2. The immediate parent of the `functionNode`. It is included here as it allows
-easy access to anything that could be useful in functionNodes (ie.
+easy access to anything that could be useful in functionNodes (i.e.
 `parent.snippet.env` or `parent.snippet.captures`, which contains capture
 groups of regex-triggered snippets). In most cases `parent.env` works, but if a
 `functionNode` is nested within a `snippetNode`, the immediate parent (a
 `snippetNode`) will contain neither `captures` nor `env`. Those are only stored
 in the `snippet`, which can be accessed as `parent.snippet`.
 3. The `user_args` passed in `opts`. Note that there may be multiple user_args
-(eg. `user_args1, ..., user_argsn`).
+(e.g. `user_args1, ..., user_argsn`).
 
 
 The function shall return a string, which will be inserted as-is, or a table of
@@ -461,7 +463,105 @@ If the function only performs simple operations on text, consider using the
 `lambda` from |luasnip-`luasnip.extras`|
 
 ==============================================================================
-7. CHOICENODE                                             *luasnip-choicenode*
+7. POSTFIX SNIPPET                                   *luasnip-postfix-snippet*
+
+Postfix snippets, famously used in rust analyzer
+<https://rust-analyzer.github.io/> and various IDEs, are a type of snippet,
+which alters text before the snippets trigger. While these can be implemented
+using regTrig snippets, this helper makes the process easier in most cases.
+
+The simplest example, which surrounds the text preceeding the `.br` with
+brackets `[]`, looks like:
+
+>
+    
+          postfix(".br", {
+                  f(function(_, parent)
+                        return "[" .. parent.snippet.env.POSTFIX_MATCH .. "]"
+                  end, {}),
+          })
+<
+
+
+and is triggered with `xxx.br` and expands to `[xxx]`.
+
+Note the `parent.snippet.env.POSTFIX_MATCH` in the function node. This is
+additional field generated by the postfix snippet. This field is generated by
+extracting the text matched (using a configurable matching string, see below)
+from before the trigger. In the case above, the field would equal `"xxx"`. This
+is also usable within dynamic nodes.
+
+This field can also be used within lambdas and dynamic nodes.
+
+>
+          postfix(".br", {
+                  l("[" .. l.POSTFIX_MATCH .. "]"),
+          })
+<
+
+
+>
+        postfix(".brd", {
+          d(1, function (_, parent)
+            return sn(nil, {t("[" .. parent.env.POSTFIX_MATCH .. "]")})
+          end)
+        }),
+<
+
+
+The arguments to `postfix` are identical to the arguments to `s` but with a few
+extra options.
+
+The first argument can be either a string or a table. If it is a string, that
+string will act as the trigger, and if it is a table it has the same valid keys
+as the table in the same position for `s` except:
+
+
+- `wordTrig`: This key will be ignored if passed in, as it must always be
+    false for postfix snippets.
+- `match_pattern`: The pattern that the line before the trigger is matched
+    against. The default match pattern is `"[%w%.%_%-]+$"`. Note the `$`. This
+    matches since only the line _up until_ the beginning of the trigger is
+    matched against the pattern, which makes the character immediately
+    preceeding the trigger match as the end of the string.
+
+
+Some other match strings, including the default, are available from the postfix
+module. `require("luasnip.extras.postfix).matches`:
+
+
+- `default`: [%w%.%_%-%“%’]+$
+- 'line': `^.+$`
+
+
+The second argument is identical to the second argument for `s`, that is, a
+table of nodes.
+
+The optional third argument is the same as the third (`opts`) argument to the
+`s` function, but with one difference:
+
+The postfix snippet works using a callback on the pre_expand event of the
+snippet. If you pass a callback on the pre_expand event (structure example
+below) it will get run after the builtin callback. This means that your
+callback will have access to the `POSTFIX_MATCH` field as well.
+
+>
+    
+          {
+            callbacks = {
+                  [-1] = {
+                          [events.pre_expand] = function(snippet, event_args)
+                              -- function body to match before the dot
+                              -- goes here
+                           end
+                          }
+                        }
+            }
+<
+
+
+==============================================================================
+8. CHOICENODE                                             *luasnip-choicenode*
 
 ChoiceNodes allow choosing between multiple nodes.
 
@@ -481,7 +581,7 @@ will be converted into a `snippetNode`. The third parameter is a table of
 options with the following keys:
 
 
-- `restore_cursor`: `false` by default. If it is set and the node that was
+- `restore_cursor`: `false` by default. If it is set, and the node that was
     being edited also appears in the switched-to choice (can be the case if a
     `restoreNode` is present in both choice) the cursor is restored relative to
     that node.
@@ -497,7 +597,7 @@ need one inside a choiceNode; their index is the same as the choiceNodes’.
 
 As it is only possible (for now) to change choices from within the choiceNode,
 make sure that all of the choices have some place for the cursor to stop at.
-This means that in `sn(nil, {...nodes...})` `nodes` has to contain eg. an
+This means that in `sn(nil, {...nodes...})` `nodes` has to contain e.g. an
 `i(1)`, otherwise luasnip will just "jump through" the nodes, making it
 impossible to change the choice.
 
@@ -528,7 +628,7 @@ Apart from this, there is also a |luasnip-picker| where no cycling is necessary
 and any choice can be selected right away, via `vim.ui.select`.
 
 ==============================================================================
-8. SNIPPETNODE                                           *luasnip-snippetnode*
+9. SNIPPETNODE                                           *luasnip-snippetnode*
 
 SnippetNodes directly insert their contents into the surrounding snippet. This
 is useful for choiceNodes, which only accept one child, or dynamicNodes, where
@@ -549,7 +649,7 @@ number, as they too are jumpable:
 Note that snippetNodes don’t expect an `i(0)`.
 
 ==============================================================================
-9. INDENTSNIPPETNODE                               *luasnip-indentsnippetnode*
+10. INDENTSNIPPETNODE                              *luasnip-indentsnippetnode*
 
 By default, all nodes are indented at least as deep as the trigger. With these
 nodes it’s possible to override that behaviour:
@@ -571,7 +671,7 @@ indent on the line where the snippet was triggered using `ISN` (That is
 possible via regex-triggers where the entire line before the trigger is
 matched).
 
-Another nice usecase for `ISN` is inserting text, eg. `//` or some other
+Another nice usecase for `ISN` is inserting text, e.g. `//` or some other
 comment- string before the nodes of the snippet:
 
 >
@@ -586,7 +686,7 @@ applied after linebreaks. To enable such usage, `$PARENT_INDENT` in the
 indentstring is replaced by the parents’ indent (duh).
 
 ==============================================================================
-10. DYNAMICNODE                                          *luasnip-dynamicnode*
+11. DYNAMICNODE                                          *luasnip-dynamicnode*
 
 Very similar to functionNode, but returns a snippetNode instead of just text,
 which makes them very powerful as parts of the snippet can be changed based on
@@ -619,7 +719,7 @@ at the dynamicNodes place.
 - `user_args1, ..., user_argsn`: passed through from `dynamicNode`-opts.
 
 3. `argnodes`: Indices of nodes the dynamicNode depends on: if any of these trigger an
-update, the `dynamicNode`s’ function will be executed and the result inserted at
+update, the `dynamicNode`s’ function will be executed, and the result inserted at
 the `dynamicNodes` place.
 Can be a single index or a table of indices.
 4. `opts`: Just like `functionNode`, `dynamicNode` also accepts `user_args` in
@@ -696,17 +796,17 @@ first `insertNode`.
 
 
 This snippet would start out as `"1\nSample Text"` and, upon changing the 1 to
-eg. 3, it would change to `"3\nSample Text\nSample Text\nSample Text"`. Text
+e.g. 3, it would change to `"3\nSample Text\nSample Text\nSample Text"`. Text
 that was inserted into any of the dynamicNodes insertNodes is kept when
 changing to a bigger number. (`old_state` is no longer the best way to preserve
 user-input across multiple recreations: the shortly-explained `restoreNode` is
 much more user-friendly)
 
 ==============================================================================
-11. RESTORENODE                                          *luasnip-restorenode*
+12. RESTORENODE                                          *luasnip-restorenode*
 
 This node can store and restore a snippetNode that was modified (changed
-choices, inserted text) by the user. It’s usage is best demonstrated by an
+choices, inserted text) by the user. Its usage is best demonstrated by an
 example:
 
 >
@@ -729,7 +829,7 @@ Here the text entered into `user_text` is preserved upon changing choice.
 The constructor for the restoreNode, `r`, takes (at most) three parameters: -
 `pos`, when to jump to this node. - `key`, the key that identifies which
 `restoreNode`s should share their content. - `nodes`, the contents of the
-`restoreNode`. Can either be a single node or a table of nodes (both of which
+`restoreNode`. Can either be a single node, or a table of nodes (both of which
 will be wrapped inside a `snippetNode`, except if the single node already is a
 `snippetNode`). The content of a given key may be defined multiple times, but
 if the contents differ, it’s undefined which will actually be used. If a keys
@@ -783,12 +883,12 @@ Now the entered text is stored.
 that really bothers you feel free to open an issue.
 
 ==============================================================================
-12. ABSOLUTE_INDEXER                                *luasnip-absolute_indexer*
+13. ABSOLUTE_INDEXER                                *luasnip-absolute_indexer*
 
 The `absolute_indexer` can be used to pass text of nodes to a
 function/dynamicNode that it doesn’t share a parent with. Normally, accessing
-the outer `i(1)` isn’t possible from inside eg. a snippetNode (nested inside
-a choiceNode to make this example more practical):
+the outer `i(1)` isn’t possible from inside e.g. a snippetNode (nested
+inside a choiceNode to make this example more practical):
 
 >
     s("trig", {
@@ -862,7 +962,7 @@ to be accessed as `ai[restoreNodeIndx][0][1]`.
 
 
 ==============================================================================
-13. EXTRAS                                                    *luasnip-extras*
+14. EXTRAS                                                    *luasnip-extras*
 
 The module `"luasnip.extras"` contains nodes that ease writing snippets (This
 is only a short outline, their usage is shown more expansively in
@@ -891,9 +991,9 @@ is only a short outline, their usage is shown more expansively in
         specified above).
         If `then` is not given, the `then`-value depends on what was specified as the
         `condition`:
-        - pattern: Simply the return value from the `match`, eg. the entire match,
+        - pattern: Simply the return value from the `match`, e.g. the entire match,
             or, if there were capture groups, the first capture group.
-        - function: the return value of the function if it is either a string or a
+        - function: the return value of the function if it is either a string, or a
             table (if there is no `then`, the function cannot return a table containing
             something other than strings).
         - lambda: Simply the first value returned by the lambda.
@@ -913,17 +1013,18 @@ is only a short outline, their usage is shown more expansively in
         replaced with `e` if the second insertNode matches the first exactly.
 - `rep`: repeats the node with the passed index. `rep(1)` to repeat the content
     of the first insert.
-- `partial`: directly inserts the output of a function. Useful for eg.
+- `partial`: directly inserts the output of a function. Useful for e.g.
     `partial(os.date, "%Y")` (arguments passed after the function are passed to
     it).
 - `nonempty`: inserts text if the insert at the given index doesn’t contain any
     text. `nonempty(n, "empty!", "not empty!")` inserts "empty!" if insert n is
-    empty, "not empty!" it it isn’t.
+    empty, "not empty!" if it isn’t.
 - `dynamic_lambda`: Operates almost exactly like `lambda`, only that it can be
-    jumped to and it’s contents therfore be easily overridden. `dynamic_lambda(2,
-    lambda._1..lambda._1, 1)` will first contain the content of insert 1 appended
-    to itself, but the second jump will lead to it, making it easy to override the
-    generated text. The text will only be changed when a argnode updates it.
+    jumped to, and it’s contents therefore be easily overridden.
+    `dynamic_lambda(2, lambda._1..lambda._1, 1)` will first contain the content of
+    insert 1 appended to itself, but the second jump will lead to it, making it
+    easy to override the generated text. The text will only be changed when a
+    argnode updates it.
 
 
 FMT                                                              *luasnip-fmt*
@@ -977,7 +1078,7 @@ Simple example:
     subsequent occurences.
 - `nodes`: just a table of nodes.
 - `opts`: optional arguments:
-    - `delimiters`: string, two characters. Change `{,}` to some other pair, eg.
+    - `delimiters`: string, two characters. Change `{,}` to some other pair, e.g.
         `"<>"`.
     - `strict`: Warn about unused nodes (default true).
     - `trim_empty`: remove empty (`"%s*"`) first and last line in `format`. Useful
@@ -995,10 +1096,10 @@ You can create snippets that are not for being used all the time but only in a
 single session.
 
 This behaves as an "operator" takes what is in a register and transforms it
-into a snippet using words prefixed as $ as inputs or copies (depending if the
-same word appears more than once). You can escape $ by repeating it.
+into a snippet using words prefixed as $ as inputs or copies (depending on if
+the same word appears more than once). You can escape $ by repeating it.
 
-In order to use add something like this to your config:
+In order to use, add something like this to your config:
 
 >
     vnoremap <c-f>  "ec<cmd>lua require('luasnip.extras.otf').on_the_fly()<cr>
@@ -1006,7 +1107,7 @@ In order to use add something like this to your config:
 <
 
 
-Notice that you can use your own mapping instead of <c-f> and you can pick
+Notice that you can use your own mapping instead of <c-f>, and you can pick
 another register instead of `"p`. You can even use it several times, as if it
 where a macro if you add several mapppings like:
 
@@ -1026,7 +1127,7 @@ SELECT_CHOICE                                          *luasnip-select_choice*
 
 It’s possible to leverage `vim.ui.select` for selecting a choice directly,
 without cycling through choices. All that is needed for this is calling
-`require("luasnip.extras.select_choice")`, preferably via some keybind, eg.
+`require("luasnip.extras.select_choice")`, preferably via some keybind, e.g.
 
 >
     inoremap <c-u> <cmd>lua require("luasnip.extras.select_choice")()<cr>
@@ -1053,7 +1154,7 @@ Contains some utility-functions that can be passed to the `ft_func` or
 - `extend_load_ft`: `fn(extend_ft:map) -> fn` A simple solution to the problem
     described above is loading more filetypes than just that of the target-buffer
     when `lazy_load`ing. This can be done ergonomically via `extend_load_ft`:
-    calling it with a table where the keys are filetypes and the values are the
+    calling it with a table where the keys are filetypes, and the values are the
     filetypes that should be loaded additionaly returns a function that can be
     passed to `load_ft_func` and takes care of extending the filetypes properly.
     >
@@ -1071,7 +1172,7 @@ Contains some utility-functions that can be passed to the `ft_func` or
 
 
 ==============================================================================
-14. LSP-SNIPPETS                                        *luasnip-lsp-snippets*
+15. LSP-SNIPPETS                                        *luasnip-lsp-snippets*
 
 Luasnip is capable of parsing lsp-style snippets using
 `ls.parser.parse_snippet(context, snippet_string)`:
@@ -1086,7 +1187,7 @@ choiceNode’s with: - the given snippet(`"this is ${1:nested}"`) and - an
 empty insertNode
 
 ==============================================================================
-15. VARIABLES                                              *luasnip-variables*
+16. VARIABLES                                              *luasnip-variables*
 
 All `TM_something`-variables are supported with two additions: `SELECT_RAW` and
 `SELECT_DEDENT`. These were introduced because `TM_SELECTED_TEXT` is designed
@@ -1112,7 +1213,7 @@ case, hitting `<Tab>` while in Visualmode will populate the `*SELECT*`-vars for
 the next snippet and then clear them.
 
 ==============================================================================
-16. LOADERS                                                  *luasnip-loaders*
+17. LOADERS                                                  *luasnip-loaders*
 
 Luasnip is capable of loading snippets from different formats, including both
 the well-established vscode- and snipmate-format, as well as plain lua-files
@@ -1128,7 +1229,7 @@ All loaders share a similar interface:
 where `opts` can contain the following keys:
 
 
-- `paths`: List of paths to load. Can be a table or a single,
+- `paths`: List of paths to load. Can be a table, or a single
     comma-separated string.
     The paths may begin with `~/` or `./` to indicate that the path is
     relative to your `$HOME` or to the directory where your `$MYVIMRC` resides
@@ -1150,8 +1251,8 @@ where `opts` can contain the following keys:
 
 
 While `load` will immediately load the snippets, `lazy_load` will defer loading
-until the snippets are actually needed (whenever a new buffer is created or the
-filetype is changed luasnip actually loads `lazy_load`ed snippets for the
+until the snippets are actually needed (whenever a new buffer is created, or
+the filetype is changed luasnip actually loads `lazy_load`ed snippets for the
 filetypes associated with this buffer. This association can be changed by
 customizing `load_ft_func` in `setup`: the option takes a function that, passed
 a `bufnr`, returns the filetypes that should be loaded (`fn(bufnr) -> filetypes
@@ -1187,7 +1288,7 @@ TROUBLESHOOTING                                      *luasnip-troubleshooting*
         ls.filetype_extend("<luasnip-filetype>", { "<collection-filetype>" })
     <
 - As we only load `lazy_load`ed snippet on some events, `lazy_load` will probably
-    not play nice when a non-default `ft_func` is used: if it depends on eg. the
+    not play nice when a non-default `ft_func` is used: if it depends on e.g. the
     cursor-position, only the filetypes for the cursor-position when the
     `lazy_load`-events are triggered will be loaded. Check
     |luasnip-filetype_function’s-`extend_load_ft`| for a solution.
@@ -1354,15 +1455,15 @@ LUA                                                              *luasnip-lua*
 
 Instead of adding all snippets via `add_snippets`, it’s possible to store
 them in separate files and load all of those. The file-structure here is
-exactly the supported snipmate-structure, eg. `<ft>.lua` or `<ft>/*.lua` to add
-snippets for the filetype `<ft>`. The files need to return two lists of
+exactly the supported snipmate-structure, e.g. `<ft>.lua` or `<ft>/*.lua` to
+add snippets for the filetype `<ft>`. The files need to return two lists of
 snippets (either may be `nil`). The snippets in the first are regular snippets
 for `<ft>`, the ones in the second are autosnippets (make sure they are enabled
 in `setup` or `set_config` if this table is used).
 
 As defining all of the snippet-constructors (`s`, `c`, `t`, …) in every file
 is rather cumbersome, luasnip will bring some globals into scope for executing
-these files. By default the names from `luasnip.config.snip_env`
+these files. By default, the names from `luasnip.config.snip_env`
 <https://github.com/L3MON4D3/LuaSnip/blob/69cb81cf7490666890545fef905d31a414edc15b/lua/luasnip/config.lua#L82-L104>
 will be used, but it’s possible to customize them by setting `snip_env` in
 `setup`.
@@ -1404,7 +1505,7 @@ can be quickly edited via
 will open a `vim.ui.select`-dialog to select first a filetype, and then (if
 there are multiple) the associated file to edit.
 
-`opts` currently only contains only one setting:
+`opts` currently only contains one setting:
 
 
 - `format`: `fn(file:string, source_name:string) -> string|nil`
@@ -1416,7 +1517,7 @@ there are multiple) the associated file to edit.
     in `file` with shorter, symbolic names (`"$PLUGINS"`, `"$CONFIG"`), but
     this can be extended to
     - filter files from some specific source/path
-    - more aggressively shorten paths using symbolic names, eg.
+    - more aggressively shorten paths using symbolic names, e.g.
         `"$FRIENDLY_SNIPPETS"`
 
 
@@ -1428,10 +1529,10 @@ One comfortable way to call this function is registering it as a command:
 
 
 ==============================================================================
-17. SNIPPETPROXY                                        *luasnip-snippetproxy*
+18. SNIPPETPROXY                                        *luasnip-snippetproxy*
 
 `SnippetProxy` is used internally to alleviate the upfront-cost of loading
-snippets from eg. a snipmate-library or a vscode-package. This is achieved by
+snippets from e.g. a snipmate-library or a vscode-package. This is achieved by
 only parsing the snippet on expansion, not immediately after reading it from
 some file. `SnippetProxy` may also be used from lua directly, to get the same
 benefits:
@@ -1452,7 +1553,7 @@ This will parse the snippet on startup…
 
 
 ==============================================================================
-18. EXT_OPTS                                                *luasnip-ext_opts*
+19. EXT_OPTS                                                *luasnip-ext_opts*
 
 `ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
 extmarks used for marking node-positions, either globally, per-snippet or
@@ -1464,7 +1565,7 @@ nodes:
 
 >
     local ext_opts = {
-        -- these ext_opts are applied when the node is active (eg. it has been
+        -- these ext_opts are applied when the node is active (e.g. it has been
         -- jumped into, and not out yet).
         active = 
         -- this is the table actually passed to `nvim_buf_set_extmark`.
@@ -1504,8 +1605,8 @@ It’s important to note that `snippet_passive` applies to the states
 `active`, and `active` only to `active`.
 
 To disable a key from a "lower" state, it has to be explicitly set to its
-default, eg. to disable highlighting inherited from `passive` when the node is
-`active`, `hl_group` could be set to `None` in `active`.
+default, e.g. to disable highlighting inherited from `passive` when the node
+is `active`, `hl_group` could be set to `None` in `active`.
 
 ------------------------------------------------------------------------------
 
@@ -1651,16 +1752,16 @@ Here the highlight of an insertNode nested directly inside a choiceNode is
 always visible on top of it.
 
 ==============================================================================
-19. DOCSTRING                                              *luasnip-docstring*
+20. DOCSTRING                                              *luasnip-docstring*
 
 Snippet-docstrings can be queried using `snippet:get_docstring()`. The function
 evaluates the snippet as if it was expanded regularly, which can be problematic
-if eg. a dynamicNode in the snippet relies on inputs other than the
+if e.g. a dynamicNode in the snippet relies on inputs other than the
 argument-nodes. `snip.env` and `snip.captures` are populated with the names of
 the queried variable and the index of the capture respectively
 (`snip.env.TM_SELECTED_TEXT` -> `'$TM_SELECTED_TEXT'`, `snip.captures[1]` ->
 `'$CAPTURES1'`). Although this leads to more expressive docstrings, it can
-cause errors in functions that eg. rely on a capture being a number:
+cause errors in functions that e.g. rely on a capture being a number:
 
 >
     s({trig = "(%d)", regTrig = true}, {
@@ -1688,7 +1789,7 @@ can be prevented by specifying `docTrig` during snippet-definition:
 `snippet.captures` and `snippet.trigger` will be populated as if actually
 triggered with `3`.
 
-Other issues will have to be handled manually by checking the contents of eg.
+Other issues will have to be handled manually by checking the contents of e.g.
 `snip.env` or predefining the docstring for the snippet:
 
 >
@@ -1701,7 +1802,7 @@ Other issues will have to be handled manually by checking the contents of eg.
 
 
 ==============================================================================
-20. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
+21. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
 
 Although generation of docstrings is pretty fast, it’s preferable to not redo
 it as long as the snippets haven’t changed. Using
@@ -1718,7 +1819,7 @@ The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 `~/.cache/nvim/luasnip/docstrings.json`).
 
 ==============================================================================
-21. EVENTS                                                    *luasnip-events*
+22. EVENTS                                                    *luasnip-events*
 
 Events can be used to react to some action inside snippets. These callbacks can
 be defined per-snippet (`callbacks`-key in snippet constructor) or globally
@@ -1760,7 +1861,7 @@ The node and `event_args` can be accessed through `require("luasnip").session`:
 - `enter/leave`: Called when a node is entered/left (for example when jumping
     around in a snippet).
     `User-event`: `"Luasnip<Node>{Enter,Leave}"`, with `<Node>` in
-    PascalCase, eg. `InsertNode` or `DynamicNode`.
+    PascalCase, e.g. `InsertNode` or `DynamicNode`.
     `event_args`: none
 - `change_choice`: When the active choice in a choiceNode is changed.
     `User-event`: `"LuasnipChangeChoice"`
@@ -1778,7 +1879,7 @@ The node and `event_args` can be accessed through `require("luasnip").session`:
 
 
 A pretty useless, beyond serving as an example here, application of these would
-be printing eg. the nodes’ text after entering:
+be printing e.g. the nodes’ text after entering:
 
 >
     vim.api.nvim_create_autocmd("User", {
@@ -1813,14 +1914,14 @@ or some information about expansions
 
 
 ==============================================================================
-22. CLEANUP                                                  *luasnip-cleanup*
+23. CLEANUP                                                  *luasnip-cleanup*
 
 The function ls.cleanup() triggers the `LuasnipCleanup` user-event, that you
 can listen to do some kind of cleaning in your own snippets, by default it will
 empty the snippets table and the caches of the lazy_load.
 
 ==============================================================================
-23. API-REFERENCE                                      *luasnip-api-reference*
+24. API-REFERENCE                                      *luasnip-api-reference*
 
 `require("luasnip")`:
 
@@ -1850,8 +1951,8 @@ empty the snippets table and the caches of the lazy_load.
 - `get_id_snippet(id)`: returns snippet corresponding to id.
 - `in_snippet()`: returns true if the cursor is inside the current snippet.
 - `jumpable(direction)`: returns true if the current node has a next(`direction`
-    = 1) or previous(`direction` = -1), eg. whether it’s possible to jump forward
-    or backward to another node.
+    = 1) or previous(`direction` = -1), e.g. whether it’s possible to jump
+    forward or backward to another node.
 - `jump(direction)`: returns true if the jump was successful.
 - `expandable()`: true if a snippet can be expanded at the current cursor
     position.
@@ -1898,7 +1999,7 @@ empty the snippets table and the caches of the lazy_load.
 - `change_choice(direction)`: changes the choice in the innermost currently
     active choiceNode forward (`direction` = 1) or backward (`direction` = -1).
 - `unlink_current()`: removes the current snippet from the jumplist (useful if
-    luasnip fails to automatically detect eg. deletion of a snippet) and sets the
+    luasnip fails to automatically detect e.g. deletion of a snippet) and sets the
     current node behind the snippet, or, if not possible, before it.
 - `lsp_expand(snip_string, opts)`: expand the lsp-syntax-snippet defined via
     `snip_string` at the cursor. `opts` can have the same options as `opts` in
@@ -1923,9 +2024,9 @@ empty the snippets table and the caches of the lazy_load.
     `load_snippet_docstrings(snippet_table)` on startup after all snippets have
     been added to `snippet_table` is a way to avoide regenerating the (unchanged)
     docstrings on each startup. (Depending on when the docstrings are required and
-    how luasnip is loaded, it may be more sensible to let them load lazily, eg.
-    just before they are required). `snippet_table` should be laid out just like
-    `luasnip.snippets` (it will most likely always _be_ `luasnip.snippets`).
+    how luasnip is loaded, it may be more sensible to let them load lazily,
+    e.g. just before they are required). `snippet_table` should be laid out just
+    like `luasnip.snippets` (it will most likely always _be_ `luasnip.snippets`).
 - `load_snippet_docstrings(snippet_table)`: Load docstrings for all snippets in
     `snippet_table` from `stdpath("cache")/luasnip/docstrings.json`. The docstrings
     are stored and restored via trigger, meaning if two snippets for one filetype
@@ -1933,8 +2034,8 @@ empty the snippets table and the caches of the lazy_load.
     `snippet_table` should be laid out as described in `store_snippet_docstrings`.
 - `unlink_current_if_deleted()`: Checks if the current snippet was deleted, if
     so, it is removed from the jumplist. This is not 100% reliable as luasnip only
-    sees the extmarks and their begin/end may not be on the same position, even if
-    all the text between them was deleted.
+    sees the extmarks and their beginning/end may not be on the same position, even
+    if all the text between them was deleted.
 - `filetype_extend(filetype:string, extend_filetypes:table of string)`: Tells
     luasnip that for a buffer with `ft=filetype`, snippets from `extend_filetypes`
     should be searched as well. `extend_filetypes` is a lua-array (`{ft1, ft2,

--- a/lua/luasnip/extras/postfix.lua
+++ b/lua/luasnip/extras/postfix.lua
@@ -1,0 +1,87 @@
+local snip = require("luasnip").snippet
+local events = require("luasnip.util.events")
+local matches = {
+	default = [[[%w%.%_%-%"%']+$]],
+	line = "^.+$",
+}
+
+local function generate_opts(match_pattern, user_callback)
+	return {
+		callbacks = {
+			[-1] = {
+				[events.pre_expand] = function(snippet, event_args)
+					local pos = event_args.expand_pos
+					-- [1]: returns table, gets text end-exclusive.
+					local line_to_cursor = vim.api.nvim_buf_get_text(
+						0,
+						pos[1],
+						0,
+						pos[1],
+						pos[2],
+						{}
+					)[1]
+					local postfix_match = line_to_cursor:match(match_pattern)
+						or ""
+					-- clear postfix_match-text.
+					vim.api.nvim_buf_set_text(
+						0,
+						pos[1],
+						pos[2] - #postfix_match,
+						pos[1],
+						pos[2],
+						{ "" }
+					)
+					local user_env = {}
+					if user_callback then
+						user_env = user_callback(snippet, event_args) or {}
+					end
+					local postfix_env_override = {
+						env_override = {
+							POSTFIX_MATCH = postfix_match,
+						},
+					}
+
+					return vim.tbl_deep_extend(
+						"keep",
+						user_env,
+						postfix_env_override
+					)
+				end,
+			},
+		},
+	}
+end
+
+local function postfix(context, nodes, opts)
+	opts = opts or {}
+	local user_callback = vim.tbl_get(opts, "callbacks", -1, events.pre_expand)
+	vim.validate({
+		context = { context, { "string", "table" } },
+		nodes = { nodes, "table" },
+		opts = { opts, "table" },
+		user_callback = { user_callback, { "nil", "function" } },
+	})
+
+	local match_pattern
+	if type(context) == "string" then
+		context = {
+			trig = context,
+		}
+		match_pattern = matches.default
+	else
+		match_pattern = context.match_pattern or matches.default
+	end
+
+	context = vim.tbl_deep_extend("keep", context, { wordTrig = false })
+	opts = vim.tbl_deep_extend(
+		"force",
+		opts,
+		generate_opts(match_pattern, user_callback)
+	)
+	return snip(context, nodes, opts)
+end
+
+return {
+	postfix = postfix,
+	matches = matches,
+}

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -43,6 +43,7 @@ function M.session_setup_luasnip()
 	m = require("luasnip.extras").match
 	ai = require("luasnip.nodes.absolute_indexer")
 	sp = require("luasnip.nodes.snippetProxy")
+	pf = require("luasnip.extras.postfix").postfix
 	]])
 end
 

--- a/tests/integration/postfix_snippet_spec.lua
+++ b/tests/integration/postfix_snippet_spec.lua
@@ -1,0 +1,153 @@
+local helpers = require("test.functional.helpers")(after_each)
+local exec_lua, feed, exec = helpers.exec_lua, helpers.feed, helpers.exec
+local ls_helpers = require("helpers")
+local Screen = require("test.functional.ui.screen")
+
+describe("postfix snippets", function()
+	local screen
+
+	before_each(function()
+		helpers.clear()
+		ls_helpers.session_setup_luasnip()
+
+		screen = Screen.new(50, 3)
+		screen:attach()
+		screen:set_default_attr_ids({
+			[0] = { bold = true, foreground = Screen.colors.Blue },
+			[1] = { bold = true, foreground = Screen.colors.Brown },
+			[2] = { bold = true },
+			[3] = { background = Screen.colors.LightGray },
+		})
+	end)
+
+	after_each(function()
+		screen:detach()
+	end)
+
+	it(
+		"creates a postfix snippet which changes the previous text once expanded",
+		function()
+			local postfix_snip = [[
+	    pf(".parens", {
+	      f(function(_, parent)
+	        return "(" .. parent.env.POSTFIX_MATCH .. ")"
+        end, {})
+      })
+	  ]]
+
+			feed("ibar")
+			exec_lua("ls.snip_expand(" .. postfix_snip .. ")")
+			screen:expect({
+				grid = [[
+          (bar)^                                             |
+          {0:~                                                 }|
+          {2:-- INSERT --}                                      |
+        ]],
+			})
+		end
+	)
+
+	it("default pattern works with a _, -, and .", function()
+		local postfix_snip = [[
+	    pf(".parens", {
+	      f(function(_, parent)
+	        return "(" .. parent.env.POSTFIX_MATCH .. ")"
+        end, {})
+      })
+	  ]]
+
+		feed("ithis_is-a.weird_variable")
+		exec_lua("ls.snip_expand(" .. postfix_snip .. ")")
+
+		screen:expect({
+			grid = [[
+        (this_is-a.weird_variable)^                        |
+        {0:~                                                 }|
+        {2:-- INSERT --}                                      |
+      ]],
+		})
+	end)
+
+	it("can take alternate matching strings", function()
+		local postfix_snip = [[
+	    pf({trig = ".parens", match_pattern = "^.+$"}, {
+	      f(function(_, parent)
+	        return "(" .. parent.env.POSTFIX_MATCH .. ")"
+        end, {})
+      })
+	  ]]
+
+		feed([[ithis should take the whole line]])
+		exec_lua("ls.snip_expand(" .. postfix_snip .. ")")
+
+		screen:expect({
+			grid = [[
+        (this should take the whole line)^                 |
+        {0:~                                                 }|
+        {2:-- INSERT --}                                      |
+      ]],
+		})
+	end)
+
+	it("wordTrig can't accidentally be set", function()
+		local postfix_snip = [[
+	    pf({trig = ".parens", match_pattern = "^.+$", wordTrig = true}, {
+	      f(function(_, parent)
+	        return "(" .. parent.env.POSTFIX_MATCH .. ")"
+        end, {})
+      })
+	  ]]
+
+		feed([[ithis should take the whole line]])
+		exec_lua("ls.snip_expand(" .. postfix_snip .. ")")
+
+		screen:expect({
+			grid = [[
+        (this should take the whole line)^                 |
+        {0:~                                                 }|
+        {2:-- INSERT --}                                      |
+      ]],
+		})
+	end)
+
+	it("allows the user to set a callback on the same event", function()
+		local postfix_snip = [[
+      pf(
+        ".parens",
+        {
+          f(function(_, parent)
+            return "("
+              .. parent.env.POSTFIX_MATCH
+              .. " "
+              .. parent.env.another_field 
+              .. ")"
+          end),
+        },
+        {
+          callbacks = {
+            [-1] = {
+              [events.pre_expand] = function(snippet, event_args)
+                return {
+                  env_override = {
+                    another_field = "data from another env field",
+                  },
+                }
+              end,
+            },
+          },
+        }
+      )
+	  ]]
+
+		feed([[ifoo]])
+		exec_lua("ls.snip_expand(" .. postfix_snip .. ")")
+
+		screen:expect({
+			grid = [[
+      (foo data from another env field)^                 |
+      {0:~                                                 }|
+      {2:-- INSERT --}                                      |
+    ]],
+		})
+	end)
+end)


### PR DESCRIPTION
In a conversation over on issues #457, @L3MON4D3 and I discussed various ways
to best support postfix snippets. @L3MON4D3 came up with the initial callback
that supports this pr, thanks!!

This tries to handle all options intelligently, but if I missed something, please let me know!

questions:
- [x] right now, when a line doesn't match, I'm handing that by passing an empty string as `snippet.pre_dot` but I also toyed around with the idea of not letting the snippet expand. What do you think?