### PR TITLE
allow modification of env through pre_expand-callback.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1561,9 +1561,11 @@ Events can be used to react to some action inside snippets. These callbacks can
 be defined per-snippet (`callbacks`-key in snippet constructor) or globally
 (autocommand).
 
-`callbacks`: `fn(node[, event_args])`  
+`callbacks`: `fn(node[, event_args]) -> event_res`  
 All callbacks get the `node` associated with the event and event-specific
 optional arguments, `event_args`.
+`event_res` is only used in one event, `pre_expand`, where some properties of
+the snippet can be changed.
 
 `autocommand`:
 Luasnip uses `User`-events. Autocommands for these can be registered using
@@ -1600,6 +1602,9 @@ The node and `event_args` can be accessed through `require("luasnip").session`:
   `event_args`:
   * `expand_pos`: `{<row>, <column>}`, position at which the snippet will be
   	expanded. `<row>` and `<column>` are both 0-indexed.
+  `event_res`:
+  * `env_override`: `map string->(string[]|string)`, override or extend the
+    snippet's environment (`snip.env`).
 
 A pretty useless, beyond serving as an example here, application of these would
 be printing eg. the nodes' text after entering:

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -460,4 +460,32 @@ describe("snippets_basic", function()
 		})
 		--  .......|.......|
 	end)
+
+	it("env is extended", function()
+		local snip = [[
+			s("trig", {
+				l(l.EXTENDED)
+			}, {
+				callbacks = {
+					[-1] = {
+						[events.pre_expand] = function()
+							return {
+								env_override = {
+									EXTENDED = "woah :o"
+								}
+							}
+						end
+					}
+				}
+			})
+		]]
+		exec_lua("ls.snip_expand(" .. snip .. ")")
+
+		screen:expect({
+			grid = [[
+			woah :o^                                           |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
 end)


### PR DESCRIPTION
The `pre_expand`-callback may return a table used to extend the snippet's env.

I'm a tiny bit unsure about repurposing the `pre_expand`-callback for extending/modifying the snippet's state (no other event-callback does this), but introducing a different mechanism for this feels more wrong, since the pre_expand-callback is already functional and used for modifying eg. the text around the snippet.

example:
```lua
ls.setup_snip_env()

ls.add_snippets("all", {
	s("trig6", {
		l(l.P, {})
	}, {
		callbacks = {
			[-1] = {
				[events.pre_expand] = function()
					return {env_override = {
						P = "asdf"
					}}
				end
			}
		}
	})
}, {
	key ="asdff"
})
```