### PR TITLE
feat: add fallback if no paths are currently loaded

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2041,7 +2041,7 @@ and then (if there are multiple) the associated file to edit.
 
 <!-- panvimdoc-ignore-end -->
 
-`opts` currently only contains one setting:
+`opts` contains three settings:
 
 * `format`: `fn(file:string, source_name:string) -> string|nil`  
   `file` is simply the path to the file, `source_name` is one of `"lua"`,
@@ -2074,6 +2074,32 @@ and then (if there are multiple) the associated file to edit.
   editing. The default is a simple `vim.cmd("edit " .. file)` (replace the
   current buffer), but one could open the file in a split, a tab, or a floating
   window, for example.
+* `extend`: `fn(ft:string, ft_paths:string[]) -> (string,string)[]`  
+  This function can be used to create additional choices for the file-selection.
+
+  * `ft`: The filetype snippet-files are queried for.
+  * `ft_paths`: list of paths to the known snippet files. 
+
+  The function should return a list of `(string,string)`-tuples. The first of
+  each pair is the label that will appear in the selection-prompt, and the
+  second is the path that will be passed to the `edit()` function if that item
+  was selected.
+
+  This can be used to create a new snippet-file for the current filetype:
+```lua
+require("luasnip.loaders").edit_snippet_files {
+  extend = function(ft, paths)
+    if #paths == 0 then
+      return {
+        { "$CONFIG/" .. ft .. ".snippets",
+          string.format("%s/%s.snippets", <PERSONAL_SNIPPETS_FOLDER>, ft) }
+      }
+    end
+
+    return {}
+  end
+}
+```
 
 One comfortable way to call this function is registering it as a command:
 ```vim

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -33,6 +33,9 @@ function M.edit_snippet_files(opts)
 	opts = opts or {}
 	local format = opts.format or default_format
 	local edit = opts.edit or default_edit
+	local extend = opts.extend or function()
+		return {}
+	end
 
 	local fts = util.get_snippet_filetypes()
 	vim.ui.select(fts, {
@@ -51,6 +54,17 @@ function M.edit_snippet_files(opts)
 						table.insert(items, fmt_name)
 					end
 				end
+			end
+
+			-- extend filetypes with user-defined function.
+			local extended = extend(ft, ft_paths)
+			assert(
+				type(extended) == "table",
+				"You must return a table in extend function"
+			)
+			for _, pair in ipairs(extended) do
+				table.insert(items, pair[1])
+				table.insert(ft_paths, pair[2])
 			end
 
 			-- prompt user again if there are multiple files providing this filetype.


### PR DESCRIPTION
This PR adds a fallback if no files are found in the current cache. This allows configs like the following:

```lua
require("luasnip.loaders.from_snipmate").lazy_load()

vim.api.nvim_create_user_command("LuaSnipEdit",
  function()
    require("luasnip.loaders").edit_snippet_files {
      fallback = function(ft, edit)
        if #ft > 0 then
          local filename = "~/.config/nvim/snippets/" .. ft .. ".snippets"
          print("Creating new file: " .. filename)
          edit(filename)
        else
          print("Canceling")
        end
      end
    }
  end, {})
```

Pretty minor change, should be self explanatory - basically it calls the fallback function, passing in the chosen filetype and the edit function. Main use case is to add file for current filetype if it does not already exist, but could be used for other things as well.

I made this because there was no easy way to tell if a file already exists and add it if it doesn't (at least not that I could tell). If I'm mistaken about this, I'd be interested in what the current preferred method is for this.

If I need to add docs or anything, just let me know!