### PR TITLE
Autotrigger as snippet option

### DIFF
--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -154,6 +154,8 @@ local function init_snippet_opts(opts)
 	-- return sn(t("")) for so-far-undefined keys.
 	in_node.stored = setmetatable(opts.stored or {}, stored_mt)
 
+	in_node.autotriggered = opts.autotriggered or false
+
 	-- wrap non-snippetNode in snippetNode.
 	for key, nodes in pairs(in_node.stored) do
 		in_node.stored[key] = wrap_nodes_in_snippetNode(nodes)


### PR DESCRIPTION
Allows to specify `autotriggered` in the snippet options, and the snippet is added to the corresponding autosnippet tables. No need anymore to add snippets and autosnippets separately.

TODO:
- [ ] run/modify tests
- [ ] check if [autotable](https://github.com/atticus-sullivan/LuaSnip/tree/autotable_testing) functionality (c.f. [lua-users](https://lua-users.org/wiki/AutomagicTables)) is worth a try (see [this PR](https://github.com/atticus-sullivan/LuaSnip/pull/1) for work on this)
- [ ] add documentation of the new feature