### PR TITLE
Fix bug just seen with util.lua

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 13
+*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 15
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -239,7 +239,7 @@ local function to_string_table(value)
 	if not value then
 		return { "" }
 	end
-	if type(value) == "string" then
+	if type(value) == "string" or type(value) == "number" or type(value) == "bool" or type(value) == "function" then
 		return { value }
 	end
 	-- at this point it's a table

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -239,7 +239,12 @@ local function to_string_table(value)
 	if not value then
 		return { "" }
 	end
-	if type(value) == "string" or type(value) == "number" or type(value) == "bool" or type(value) == "function" then
+	if
+		type(value) == "string"
+		or type(value) == "number"
+		or type(value) == "bool"
+		or type(value) == "function"
+	then
 		return { value }
 	end
 	-- at this point it's a table


### PR DESCRIPTION
Hi there! I love this project and am fully hooked! Thanks for creating this!!!

Add type checking fix in util.lua

Just found a new bug where an error is thrown because it was not expecting a number. Accounted for over data types as well.


I just saw this today for the first time.

```
 Error detected while processing /home/derek/.config/nvim/init.lua:
E5113: Error while calling lua chunk: ...site/pack/packer/start/LuaSnip/lua/luasnip/util/util.lua:246: attempt to get length of local 'value' (a number value)
stack traceback:
        ...site/pack/packer/start/LuaSnip/lua/luasnip/util/util.lua:246: in function 'to_string_table'
        ...pack/packer/start/LuaSnip/lua/luasnip/nodes/textNode.lua:10: in function 't'
        [string "require("luasnip").setup_snip_env() ---@diagn..."]:88: in main chunk
        ...ck/packer/start/LuaSnip/lua/luasnip/loaders/from_lua.lua:38: in function 'load_files'
        ...ck/packer/start/LuaSnip/lua/luasnip/loaders/from_lua.lua:122: in function 'load'
        /home/derek/.config/nvim/lua/stimpack/luasnip-settings.lua:3: in main chunk
        [C]: in function 'require'
        /home/derek/.config/nvim/init.lua:37: in main chunk
```

It seems just like a little type checking error. I've attached a fix that should account for every case.