### PR TITLE
Add Setting: Square-Branckets is the default-delimiters

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1128,8 +1128,9 @@ ls.add_snippets("all", {
   * `dedent`: remove indent common to all lines in `format`. Again, makes
   	passing multiline-strings a bit nicer (default true).
 
-There is also `require("luasnip.extras.fmt").fmta`. This only differs from `fmt`
-by using angle-brackets (`<>`) as the default-delimiter.
+Also `require("luasnip.extras.fmt").fmta` and `require("luasnip.extras.fmt").fmts`. This is
+fmt`, using the default delimiters of the angle-brackets (`<>`) for fmta and the
+square-brackets (`[]`) for fmts, respectively.
 
 
 ## On The Fly snippets

--- a/DOC.md
+++ b/DOC.md
@@ -1128,8 +1128,8 @@ ls.add_snippets("all", {
   * `dedent`: remove indent common to all lines in `format`. Again, makes
   	passing multiline-strings a bit nicer (default true).
 
-Also `require("luasnip.extras.fmt").fmta` and `require("luasnip.extras.fmt").fmts`. This is
-fmt`, using the default-delimiters of the angle-brackets (`<>`) for fmta and the
+There are also `require("luasnip.extras.fmt").fmta` and `require("luasnip.extras.fmt").fmts`.
+This is `fmt`,　using the default-delimiters of the angle-brackets (`<>`) for fmta and the
 square-brackets (`[]`) for fmts, respectively.
 
 

--- a/DOC.md
+++ b/DOC.md
@@ -1129,7 +1129,7 @@ ls.add_snippets("all", {
   	passing multiline-strings a bit nicer (default true).
 
 Also `require("luasnip.extras.fmt").fmta` and `require("luasnip.extras.fmt").fmts`. This is
-fmt`, using the default delimiters of the angle-brackets (`<>`) for fmta and the
+fmt`, using the default-delimiters of the angle-brackets (`<>`) for fmta and the
 square-brackets (`[]`) for fmts, respectively.
 
 

--- a/Examples/snippets.lua
+++ b/Examples/snippets.lua
@@ -16,6 +16,7 @@ local n = require("luasnip.extras").nonempty
 local dl = require("luasnip.extras").dynamic_lambda
 local fmt = require("luasnip.extras.fmt").fmt
 local fmta = require("luasnip.extras.fmt").fmta
+local fmts = require("luasnip.extras.fmt").fmts
 local types = require("luasnip.util.types")
 local conds = require("luasnip.extras.expand_conditions")
 
@@ -279,12 +280,14 @@ ls.add_snippets("all", {
 		})
 	),
 	-- The delimiters can be changed from the default `{}` to something else.
-	s("fmt4", fmt("foo() { return []; }", i(1, "x"), { delimiters = "[]" })),
+	s("fmt4", fmt("foo() { return (); }", i(1, "x"), { delimiters = "()" })),
 	-- `fmta` is a convenient wrapper that uses `<>` instead of `{}`.
 	s("fmt5", fmta("foo() { return <>; }", i(1, "x"))),
+	-- `fmts` is a convenient wrapper that uses `[]` instead of `{}`.
+	s("fmt6", fmts("foo() { return []; }", i(1, "x"))),
 	-- By default all args must be used. Use strict=false to disable the check
 	s(
-		"fmt6",
+		"fmt7",
 		fmt("use {} only", { t("this"), t("not this") }, { strict = false })
 	),
 	-- Use a dynamic_node to interpolate the output of a

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -402,7 +402,7 @@ exist to more easily reuse functionNode-functions, when applicable:
     local function reused_func(_,_, user_arg1)
         return user_arg1
     end
-    
+
     s("trig", {
         f(reused_func, {}, {
             user_args = {"text"}
@@ -476,7 +476,7 @@ The simplest example, which surrounds the text preceeding the `.br` with
 brackets `[]`, looks like:
 
 >
-    
+
           postfix(".br", {
                   f(function(_, parent)
                         return "[" .. parent.snippet.env.POSTFIX_MATCH .. "]"
@@ -548,7 +548,7 @@ below) it will get run after the builtin callback. This means that your
 callback will have access to the `POSTFIX_MATCH` field as well.
 
 >
-    
+
           {
             callbacks = {
                   [-1] = {
@@ -759,19 +759,19 @@ instead of `old_state`.
         old_state = old_state or {
             updates = 0
         }
-    
+
         old_state.updates = old_state.updates + 1
-    
+
         local snip = sn(nil, {
             t(tostring(old_state.updates))
         })
-    
+
         snip.old_state = old_state
         return snip
     end
-    
+
     ...
-    
+
     ls.add_snippets("all",
         s("trig", {
             i(1, "change to update"),
@@ -835,7 +835,7 @@ The `restoreNode` is also useful for storing user-input across updates of a
     local function simple_restore(args, _)
         return sn(nil, {i(1, args[1]), i(2, "user_text")})
     end
-    
+
     s("rest", {
         i(1, "preset"), t{"",""},
         d(2, simple_restore, 1)
@@ -851,7 +851,7 @@ Every time the `i(1)` in the outer snippet is changed, the text inside the
     local function simple_restore(args, _)
         return sn(nil, {i(1, args[1]), r(2, "dyn", i(nil, "user_text"))})
     end
-    
+
     s("rest", {
         i(1, "preset"), t{"",""},
         d(2, simple_restore, 1)
@@ -1089,9 +1089,8 @@ Simple example:
         passing multiline-strings a bit nicer (default true).
 
 
-Also `require("luasnip.extras.fmt").fmta` and
-`require("luasnip.extras.fmt").fmts`. This is fmt`, using the
-default-delimiters of the angle-brackets (`<>`) for fmta and the
+There are also `require("luasnip.extras.fmt").fmta` and `require("luasnip.extras.fmt").fmts`.
+This is `fmt`,　using the default-delimiters of the angle-brackets (`<>`) for fmta and the
 square-brackets (`[]`) for fmts, respectively.
 
 ON THE FLY SNIPPETS                              *luasnip-on-the-fly-snippets*
@@ -1119,8 +1118,8 @@ where a macro if you add several mapppings like:
     " For register a
     vnoremap <c-f>a  "ac<cmd>lua require('luasnip.extras.otf').on_the_fly()<cr>
     inoremap <c-f>a  <cmd>lua require('luasnip.extras.otf').on_the_fly("a")<cr>
-    
-    
+
+
     " For register b
     vnoremap <c-f>a  "bc<cmd>:lua require('luasnip.extras.otf').on_the_fly()<cr>
     inoremap <c-f>b  <cmd>lua require('luasnip.extras.otf').on_the_fly("b")<cr>
@@ -1249,19 +1248,19 @@ A simple example to make it more clear:
     local random_lang()
         return ({"LUA", "VIML", "VIML9"})[math.floor(math.random()/2 + 1.5)]
     end
-    
+
     ls.env_namespace("MY", {vars={ NAME="LuaSnip",  LANG=random_lang }})`
-    
+
     -- then you can use  $MY_NAME and $MY_LANG in your snippets
-    
+
     ls.env_namespace("SYS", {vars=os.getenv, eager={"HOME"}})
-    
+
     -- then you can use  $SYS_HOME which was eagerly initialized but also $SYS_USER (or any other system environment var) in your snippets
-    
+
     lsp.env_namespace("POS", {init=function(pos) return {"VAL": vim.inspect(pos)}} end)
-    
+
     -- then you can use  $POS_VAL in your snippets
-    
+
     s("custom_env", d(1, function(args, parent)
       local env = parent.snippet.env
       return sn(nil, t {
@@ -1486,7 +1485,7 @@ luasnips more advanced capabilities:
 
 >
     extends c
-    
+
     snippet cpp cpp-snippet
         cpp!
 <
@@ -1648,7 +1647,7 @@ nodes:
     local ext_opts = {
         -- these ext_opts are applied when the node is active (e.g. it has been
         -- jumped into, and not out yet).
-        active = 
+        active =
         -- this is the table actually passed to `nvim_buf_set_extmark`.
         {
             -- highlight the text inside the node red.
@@ -1663,9 +1662,9 @@ nodes:
         -- and these are applied when both the node and the snippet are inactive.
         snippet_passive = {}
     }
-    
+
     ...
-    
+
     s("trig", {
         i(1, "text1", {
             node_ext_opts = ext_opts
@@ -1697,7 +1696,7 @@ set of `ext_opts` should be applied to:
 
 >
     local types = require("luasnip.util.types")
-    
+
     ls.config.setup({
         ext_opts = {
             [types.insertNode] = {
@@ -1721,7 +1720,7 @@ snippets…
 
 >
     local types = require("luasnip.util.types")
-    
+
     s("trig", { i(1, "text1"), i(2, "text2") }, {
         child_ext_opts = {
             [types.insertNode] = {
@@ -1755,9 +1754,9 @@ It’s possible to prevent both of these merges by passing
             }
         }
     })
-    
+
     ...
-    
+
     s("trig", {
         i(1, "text1", {
             node_ext_opts = {
@@ -1783,7 +1782,7 @@ highlight-groups:
 >
     vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
     vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
-    
+
     -- needs to be called for resolving the actual ext_opts.
     ls.config.setup({})
 <
@@ -1986,7 +1985,7 @@ or some information about expansions
             local snippet = require("luasnip").session.event_node
             local expand_position =
                 require("luasnip").session.event_args.expand_pos
-    
+
             print(string.format("expanding snippet %s at %s:%s",
                 table.concat(snippet:get_docstring(), "\n"),
                 expand_position[1],

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 13
+*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 15
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -402,7 +402,7 @@ exist to more easily reuse functionNode-functions, when applicable:
     local function reused_func(_,_, user_arg1)
         return user_arg1
     end
-
+    
     s("trig", {
         f(reused_func, {}, {
             user_args = {"text"}
@@ -476,7 +476,7 @@ The simplest example, which surrounds the text preceeding the `.br` with
 brackets `[]`, looks like:
 
 >
-
+    
           postfix(".br", {
                   f(function(_, parent)
                         return "[" .. parent.snippet.env.POSTFIX_MATCH .. "]"
@@ -548,7 +548,7 @@ below) it will get run after the builtin callback. This means that your
 callback will have access to the `POSTFIX_MATCH` field as well.
 
 >
-
+    
           {
             callbacks = {
                   [-1] = {
@@ -759,19 +759,19 @@ instead of `old_state`.
         old_state = old_state or {
             updates = 0
         }
-
+    
         old_state.updates = old_state.updates + 1
-
+    
         local snip = sn(nil, {
             t(tostring(old_state.updates))
         })
-
+    
         snip.old_state = old_state
         return snip
     end
-
+    
     ...
-
+    
     ls.add_snippets("all",
         s("trig", {
             i(1, "change to update"),
@@ -835,7 +835,7 @@ The `restoreNode` is also useful for storing user-input across updates of a
     local function simple_restore(args, _)
         return sn(nil, {i(1, args[1]), i(2, "user_text")})
     end
-
+    
     s("rest", {
         i(1, "preset"), t{"",""},
         d(2, simple_restore, 1)
@@ -851,7 +851,7 @@ Every time the `i(1)` in the outer snippet is changed, the text inside the
     local function simple_restore(args, _)
         return sn(nil, {i(1, args[1]), r(2, "dyn", i(nil, "user_text"))})
     end
-
+    
     s("rest", {
         i(1, "preset"), t{"",""},
         d(2, simple_restore, 1)
@@ -1089,8 +1089,9 @@ Simple example:
         passing multiline-strings a bit nicer (default true).
 
 
-Also `require("luasnip.extras.fmt").fmta` and `require("luasnip.extras.fmt").fmts`. This is
-fmt`, using the default-delimiters of the angle-brackets (`<>`) for fmta and the
+Also `require("luasnip.extras.fmt").fmta` and
+`require("luasnip.extras.fmt").fmts`. This is fmt`, using the
+default-delimiters of the angle-brackets (`<>`) for fmta and the
 square-brackets (`[]`) for fmts, respectively.
 
 ON THE FLY SNIPPETS                              *luasnip-on-the-fly-snippets*
@@ -1118,8 +1119,8 @@ where a macro if you add several mapppings like:
     " For register a
     vnoremap <c-f>a  "ac<cmd>lua require('luasnip.extras.otf').on_the_fly()<cr>
     inoremap <c-f>a  <cmd>lua require('luasnip.extras.otf').on_the_fly("a")<cr>
-
-
+    
+    
     " For register b
     vnoremap <c-f>a  "bc<cmd>:lua require('luasnip.extras.otf').on_the_fly()<cr>
     inoremap <c-f>b  <cmd>lua require('luasnip.extras.otf').on_the_fly("b")<cr>
@@ -1248,19 +1249,19 @@ A simple example to make it more clear:
     local random_lang()
         return ({"LUA", "VIML", "VIML9"})[math.floor(math.random()/2 + 1.5)]
     end
-
+    
     ls.env_namespace("MY", {vars={ NAME="LuaSnip",  LANG=random_lang }})`
-
+    
     -- then you can use  $MY_NAME and $MY_LANG in your snippets
-
+    
     ls.env_namespace("SYS", {vars=os.getenv, eager={"HOME"}})
-
+    
     -- then you can use  $SYS_HOME which was eagerly initialized but also $SYS_USER (or any other system environment var) in your snippets
-
+    
     lsp.env_namespace("POS", {init=function(pos) return {"VAL": vim.inspect(pos)}} end)
-
+    
     -- then you can use  $POS_VAL in your snippets
-
+    
     s("custom_env", d(1, function(args, parent)
       local env = parent.snippet.env
       return sn(nil, t {
@@ -1485,7 +1486,7 @@ luasnips more advanced capabilities:
 
 >
     extends c
-
+    
     snippet cpp cpp-snippet
         cpp!
 <
@@ -1647,7 +1648,7 @@ nodes:
     local ext_opts = {
         -- these ext_opts are applied when the node is active (e.g. it has been
         -- jumped into, and not out yet).
-        active =
+        active = 
         -- this is the table actually passed to `nvim_buf_set_extmark`.
         {
             -- highlight the text inside the node red.
@@ -1662,9 +1663,9 @@ nodes:
         -- and these are applied when both the node and the snippet are inactive.
         snippet_passive = {}
     }
-
+    
     ...
-
+    
     s("trig", {
         i(1, "text1", {
             node_ext_opts = ext_opts
@@ -1696,7 +1697,7 @@ set of `ext_opts` should be applied to:
 
 >
     local types = require("luasnip.util.types")
-
+    
     ls.config.setup({
         ext_opts = {
             [types.insertNode] = {
@@ -1720,7 +1721,7 @@ snippets…
 
 >
     local types = require("luasnip.util.types")
-
+    
     s("trig", { i(1, "text1"), i(2, "text2") }, {
         child_ext_opts = {
             [types.insertNode] = {
@@ -1754,9 +1755,9 @@ It’s possible to prevent both of these merges by passing
             }
         }
     })
-
+    
     ...
-
+    
     s("trig", {
         i(1, "text1", {
             node_ext_opts = {
@@ -1782,7 +1783,7 @@ highlight-groups:
 >
     vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
     vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
-
+    
     -- needs to be called for resolving the actual ext_opts.
     ls.config.setup({})
 <
@@ -1985,7 +1986,7 @@ or some information about expansions
             local snippet = require("luasnip").session.event_node
             local expand_position =
                 require("luasnip").session.event_args.expand_pos
-
+    
             print(string.format("expanding snippet %s at %s:%s",
                 table.concat(snippet:get_docstring(), "\n"),
                 expand_position[1],

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -402,7 +402,7 @@ exist to more easily reuse functionNode-functions, when applicable:
     local function reused_func(_,_, user_arg1)
         return user_arg1
     end
-    
+
     s("trig", {
         f(reused_func, {}, {
             user_args = {"text"}
@@ -476,7 +476,7 @@ The simplest example, which surrounds the text preceeding the `.br` with
 brackets `[]`, looks like:
 
 >
-    
+
           postfix(".br", {
                   f(function(_, parent)
                         return "[" .. parent.snippet.env.POSTFIX_MATCH .. "]"
@@ -548,7 +548,7 @@ below) it will get run after the builtin callback. This means that your
 callback will have access to the `POSTFIX_MATCH` field as well.
 
 >
-    
+
           {
             callbacks = {
                   [-1] = {
@@ -759,19 +759,19 @@ instead of `old_state`.
         old_state = old_state or {
             updates = 0
         }
-    
+
         old_state.updates = old_state.updates + 1
-    
+
         local snip = sn(nil, {
             t(tostring(old_state.updates))
         })
-    
+
         snip.old_state = old_state
         return snip
     end
-    
+
     ...
-    
+
     ls.add_snippets("all",
         s("trig", {
             i(1, "change to update"),
@@ -835,7 +835,7 @@ The `restoreNode` is also useful for storing user-input across updates of a
     local function simple_restore(args, _)
         return sn(nil, {i(1, args[1]), i(2, "user_text")})
     end
-    
+
     s("rest", {
         i(1, "preset"), t{"",""},
         d(2, simple_restore, 1)
@@ -851,7 +851,7 @@ Every time the `i(1)` in the outer snippet is changed, the text inside the
     local function simple_restore(args, _)
         return sn(nil, {i(1, args[1]), r(2, "dyn", i(nil, "user_text"))})
     end
-    
+
     s("rest", {
         i(1, "preset"), t{"",""},
         d(2, simple_restore, 1)
@@ -1089,8 +1089,9 @@ Simple example:
         passing multiline-strings a bit nicer (default true).
 
 
-There is also `require("luasnip.extras.fmt").fmta`. This only differs from
-`fmt` by using angle-brackets (`<>`) as the default-delimiter.
+Also `require("luasnip.extras.fmt").fmta` and `require("luasnip.extras.fmt").fmts`. This is
+fmt`, using the default delimiters of the angle-brackets (`<>`) for fmta and the
+square-brackets (`[]`) for fmts, respectively.
 
 ON THE FLY SNIPPETS                              *luasnip-on-the-fly-snippets*
 
@@ -1117,8 +1118,8 @@ where a macro if you add several mapppings like:
     " For register a
     vnoremap <c-f>a  "ac<cmd>lua require('luasnip.extras.otf').on_the_fly()<cr>
     inoremap <c-f>a  <cmd>lua require('luasnip.extras.otf').on_the_fly("a")<cr>
-    
-    
+
+
     " For register b
     vnoremap <c-f>a  "bc<cmd>:lua require('luasnip.extras.otf').on_the_fly()<cr>
     inoremap <c-f>b  <cmd>lua require('luasnip.extras.otf').on_the_fly("b")<cr>
@@ -1247,19 +1248,19 @@ A simple example to make it more clear:
     local random_lang()
         return ({"LUA", "VIML", "VIML9"})[math.floor(math.random()/2 + 1.5)]
     end
-    
+
     ls.env_namespace("MY", {vars={ NAME="LuaSnip",  LANG=random_lang }})`
-    
+
     -- then you can use  $MY_NAME and $MY_LANG in your snippets
-    
+
     ls.env_namespace("SYS", {vars=os.getenv, eager={"HOME"}})
-    
+
     -- then you can use  $SYS_HOME which was eagerly initialized but also $SYS_USER (or any other system environment var) in your snippets
-    
+
     lsp.env_namespace("POS", {init=function(pos) return {"VAL": vim.inspect(pos)}} end)
-    
+
     -- then you can use  $POS_VAL in your snippets
-    
+
     s("custom_env", d(1, function(args, parent)
       local env = parent.snippet.env
       return sn(nil, t {
@@ -1484,7 +1485,7 @@ luasnips more advanced capabilities:
 
 >
     extends c
-    
+
     snippet cpp cpp-snippet
         cpp!
 <
@@ -1646,7 +1647,7 @@ nodes:
     local ext_opts = {
         -- these ext_opts are applied when the node is active (e.g. it has been
         -- jumped into, and not out yet).
-        active = 
+        active =
         -- this is the table actually passed to `nvim_buf_set_extmark`.
         {
             -- highlight the text inside the node red.
@@ -1661,9 +1662,9 @@ nodes:
         -- and these are applied when both the node and the snippet are inactive.
         snippet_passive = {}
     }
-    
+
     ...
-    
+
     s("trig", {
         i(1, "text1", {
             node_ext_opts = ext_opts
@@ -1695,7 +1696,7 @@ set of `ext_opts` should be applied to:
 
 >
     local types = require("luasnip.util.types")
-    
+
     ls.config.setup({
         ext_opts = {
             [types.insertNode] = {
@@ -1719,7 +1720,7 @@ snippets…
 
 >
     local types = require("luasnip.util.types")
-    
+
     s("trig", { i(1, "text1"), i(2, "text2") }, {
         child_ext_opts = {
             [types.insertNode] = {
@@ -1753,9 +1754,9 @@ It’s possible to prevent both of these merges by passing
             }
         }
     })
-    
+
     ...
-    
+
     s("trig", {
         i(1, "text1", {
             node_ext_opts = {
@@ -1781,7 +1782,7 @@ highlight-groups:
 >
     vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
     vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
-    
+
     -- needs to be called for resolving the actual ext_opts.
     ls.config.setup({})
 <
@@ -1984,7 +1985,7 @@ or some information about expansions
             local snippet = require("luasnip").session.event_node
             local expand_position =
                 require("luasnip").session.event_args.expand_pos
-    
+
             print(string.format("expanding snippet %s at %s:%s",
                 table.concat(snippet:get_docstring(), "\n"),
                 expand_position[1],

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1090,7 +1090,7 @@ Simple example:
 
 
 Also `require("luasnip.extras.fmt").fmta` and `require("luasnip.extras.fmt").fmts`. This is
-fmt`, using the default delimiters of the angle-brackets (`<>`) for fmta and the
+fmt`, using the default-delimiters of the angle-brackets (`<>`) for fmta and the
 square-brackets (`[]`) for fmts, respectively.
 
 ON THE FLY SNIPPETS                              *luasnip-on-the-fly-snippets*

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -98,6 +98,7 @@ local defaults = {
 		dl = require("luasnip.extras").dynamic_lambda,
 		fmt = require("luasnip.extras.fmt").fmt,
 		fmta = require("luasnip.extras.fmt").fmta,
+		fmts = require("luasnip.extras.fmt").fmts,
 		conds = require("luasnip.extras.expand_conditions"),
 		types = require("luasnip.util.types"),
 		events = require("luasnip.util.events"),

--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -254,4 +254,8 @@ return {
 		opts = vim.tbl_extend("force", opts or {}, { delimiters = "<>" })
 		return format_nodes(str, nodes, opts)
 	end,
+	fmts = function(str, nodes, opts) -- fmt with square brackets
+		opts = vim.tbl_extend("force", opts or {}, { delimiters = "[]" })
+		return format_nodes(str, nodes, opts)
+	end,
 }

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -46,7 +46,7 @@ end
 
 -- some values of the snippet are nil by default, list them here so snippets
 -- aren't instantiated because of them.
-local license_to_nil = {priority = true}
+local license_to_nil = { priority = true }
 
 -- context and opts are the same objects as in s(contex, nodes, opts), snippet
 -- is a string representing the snippet.

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -38,6 +38,7 @@ function M.session_setup_luasnip()
 	events = require("luasnip.util.events")
 	fmt = require("luasnip.extras.fmt").fmt
 	fmta = require("luasnip.extras.fmt").fmta
+	fmts = require("luasnip.extras.fmt").fmts
 	parse = ls.parser.parse_snippet
 	n = require("luasnip.extras").nonempty
 	m = require("luasnip.extras").match


### PR DESCRIPTION
`fmt` for `{}`.
`fmta` for `<>`.
each with their default delimited.

When I am making snippets for jsx, both `{}` and `<>` are used a lot, but `[]` is rarely used.
Therefore, I added `fmts` (an acronym for square) in addition to `fmta` because I thought it would be more convenient to have it without having to change the repeat setting.

thank you.