### PR TITLE
unset needs to be in the same subshell as the make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,5 @@ nvim:
 # Expects to be run from repo-location (eg. via `make -C path/to/luasnip`).
 test: nvim
 	# unset both to prevent env leaking into the neovim-build.
-	unset LUA_PATH LUA_CPATH
 	# add helper-functions to lpath.
-	LUASNIP_SOURCE=$(shell pwd) TEST_FILE=$(realpath tests) BUSTED_ARGS=--lpath=$(shell pwd)/tests/?.lua make -C ${NVIM_PATH} functionaltest
+	unset LUA_PATH LUA_CPATH ; LUASNIP_SOURCE=$(shell pwd) TEST_FILE=$(realpath tests) BUSTED_ARGS=--lpath=$(shell pwd)/tests/?.lua make -C ${NVIM_PATH} functionaltest

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 13
+*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 16
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*


### PR DESCRIPTION
Since `make` by default (can be changed with [`.ONESHELL`](https://www.gnu.org/software/make/manual/html_node/One-Shell.html)) creates a new subshell for each new command, the current way of unsetting does not work.
We need to either use `.ONESHELL` or (in my opinion the nicer way) do `unset LUA_PATH LUA_CPATH ; ...`