### PR TITLE
Make it easy to create functions that override the defaults of functions.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1219,6 +1219,78 @@ Contains some utility-functions that can be passed to the `ft_func` or
   })
   ```
 
+# EXTEND_DECORATOR
+
+Most of luasnip's functions have some arguments to control their behaviour.  
+Examples include `s`, where `wordTrig`, `regTrig`, ... can be set in the first
+argument to the function, or `fmt`, where the delimiter can be set in the third
+argument.  
+This is all good and well, but if these functions are often used with
+non-default settings, it can become cumbersome to always explicitly set them.
+
+This is where the `extend_decorator` comes in:  
+It can be used to create decorated functions which always extend the arguments
+passed directly with other, previously defined ones.  
+An example:
+```lua
+local fmt = require("luasnip.extras.fmt").fmt
+
+fmt("{}", {i(1)}) -- -> list of nodes, containing just the i(1).
+
+-- when authoring snippets for some filetype where `{` and `}` are common, they
+-- would always have to be escaped in the format-string. It might be preferable
+-- to use other delimiters, like `<` and `>`.
+
+fmt("<>", {i(1)}, {delimiters = "<>"}) -- -> same as above.
+
+-- but it's quite annoying to always pass the `{delimiters = "<>"}`.
+
+-- with extend_decorator:
+local fmt_angle = ls.extend_decorator.apply(fmt, {delimiters = "<>"})
+fmt_angle("<>", {i(1)}) -- -> same as above.
+
+-- the same also works with other functions provided by luasnip, for example all
+-- node/snippet-constructors and `parse_snippet`.
+```
+
+`extend_decorator.apply(fn, ...)` requires that `fn` is previously registered
+via `extend_decorator.register`.  
+(This is not limited to luasnip's functions!)  
+(although, for usage outside of luasnip, best copy the source-file
+`/lua/luasnip/util/extend_decorator.lua`).
+
+`register(fn, ...)`:
+* `fn`: the function.
+* `...`: any number of tables. Each specifies how to extend an argument of `fn`.
+  The tables accept:
+  * arg_indx, `number` (required): the position of the parameter to override.
+  * extend, `fn(arg, extend_value) -> effective_arg` (optional): this function
+    is used to extend the args passed to the decorated function.
+    It defaults to a function which just extends the the arg-table with the
+    extend-table (accepts `nil`).
+    This extend-behaviour is adaptable to accomodate `s`, where the first
+    argument may be string or table.
+
+`apply(fn, ...) -> decorated_fn`:
+* `fn`: the function to decorate.
+* `...`: The values to extend with. These should match the descriptions passed
+  in `register` (the argument first passed to `register` will be extended with
+  the first value passed here).
+
+One more example for registering a new function:
+```lua
+local function somefn(arg1, arg2, opts1, opts2)
+	... -- not important
+end
+
+-- note the reversed arg_indx!!
+extend_decorator.register(somefn, {arg_indx=4}, {arg_indx=3})
+local extended = extend_decorator.apply(somefn,
+	{key = "opts2 is extended with this"},
+	{key = "and opts1 with this"})
+extended(...)
+```
+
 # LSP-SNIPPETS
 
 Luasnip is capable of parsing lsp-style snippets using

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 13
+*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 25
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -22,22 +22,23 @@ Table of Contents                                  *luasnip-table-of-contents*
   - On The Fly snippets                          |luasnip-on-the-fly-snippets|
   - Select_choice                                      |luasnip-select_choice|
   - filetype_functions                            |luasnip-filetype_functions|
-15. LSP-SNIPPETS                                        |luasnip-lsp-snippets|
-16. VARIABLES                                              |luasnip-variables|
+15. EXTEND_DECORATOR                                |luasnip-extend_decorator|
+16. LSP-SNIPPETS                                        |luasnip-lsp-snippets|
+17. VARIABLES                                              |luasnip-variables|
   - Environment Namespaces                    |luasnip-environment-namespaces|
-17. LOADERS                                                  |luasnip-loaders|
+18. LOADERS                                                  |luasnip-loaders|
   - Troubleshooting                                  |luasnip-troubleshooting|
   - VSCODE                                                    |luasnip-vscode|
   - SNIPMATE                                                |luasnip-snipmate|
   - LUA                                                          |luasnip-lua|
   - EDIT_SNIPPETS                                      |luasnip-edit_snippets|
-18. SNIPPETPROXY                                        |luasnip-snippetproxy|
-19. EXT_OPTS                                                |luasnip-ext_opts|
-20. DOCSTRING                                              |luasnip-docstring|
-21. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
-22. EVENTS                                                    |luasnip-events|
-23. CLEANUP                                                  |luasnip-cleanup|
-24. API-REFERENCE                                      |luasnip-api-reference|
+19. SNIPPETPROXY                                        |luasnip-snippetproxy|
+20. EXT_OPTS                                                |luasnip-ext_opts|
+21. DOCSTRING                                              |luasnip-docstring|
+22. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
+23. EVENTS                                                    |luasnip-events|
+24. CLEANUP                                                  |luasnip-cleanup|
+25. API-REFERENCE                                      |luasnip-api-reference|
 
 >
                 __                       ____
@@ -1174,7 +1175,77 @@ Contains some utility-functions that can be passed to the `ft_func` or
 
 
 ==============================================================================
-15. LSP-SNIPPETS                                        *luasnip-lsp-snippets*
+15. EXTEND_DECORATOR                                *luasnip-extend_decorator*
+
+Most of luasnip’s functions have some arguments to control their behaviour.
+Examples include `s`, where `wordTrig`, `regTrig`, … can be set in the first
+argument to the function, or `fmt`, where the delimiter can be set in the third
+argument. This is all good and well, but if these functions are often used with
+non-default settings, it can become cumbersome to always explicitly set them.
+
+This is where the `extend_decorator` comes in: It can be used to create
+decorated functions which always extend the arguments passed directly with
+other, previously defined ones. An example:
+
+>
+    local fmt = require("luasnip.extras.fmt").fmt
+    
+    fmt("{}", {i(1)}) -- -> list of nodes, containing just the i(1).
+    
+    -- when authoring snippets for some filetype where `{` and `}` are common, they
+    -- would always have to be escaped in the format-string. It might be preferable
+    -- to use other delimiters, like `<` and `>`.
+    
+    fmt("<>", {i(1)}, {delimiters = "<>"}) -- -> same as above.
+    
+    -- but it's quite annoying to always pass the `{delimiters = "<>"}`.
+    
+    -- with extend_decorator:
+    local fmt_angle = ls.extend_decorator.apply(fmt, {delimiters = "<>"})
+    fmt_angle("<>", {i(1)}) -- -> same as above.
+    
+    -- the same also works with other functions provided by luasnip, for example all
+    -- node/snippet-constructors and `parse_snippet`.
+<
+
+
+`extend_decorator.apply(fn, ...)` requires that `fn` is previously registered
+via `extend_decorator.register`. (This is not limited to luasnip’s
+functions!) (although, for usage outside of luasnip, best copy the source-file
+`/lua/luasnip/util/extend_decorator.lua`).
+
+`register(fn, ...)`: * `fn`: the function. * `...`: any number of tables. Each
+specifies how to extend an argument of `fn`. The tables accept: * arg_indx,
+`number` (required): the position of the parameter to override. * extend,
+`fn(arg, extend_value) -> effective_arg` (optional): this function is used to
+extend the args passed to the decorated function. It defaults to a function
+which just extends the the arg-table with the extend-table (accepts `nil`).
+This extend-behaviour is adaptable to accomodate `s`, where the first argument
+may be string or table.
+
+`apply(fn, ...) -> decorated_fn`: * `fn`: the function to decorate. * `...`:
+The values to extend with. These should match the descriptions passed in
+`register` (the argument first passed to `register` will be extended with the
+first value passed here).
+
+One more example for registering a new function:
+
+>
+    local function somefn(arg1, arg2, opts1, opts2)
+        ... -- not important
+    end
+    
+    -- note the reversed arg_indx!!
+    extend_decorator.register(somefn, {arg_indx=4}, {arg_indx=3})
+    local extended = extend_decorator.apply(somefn,
+        {key = "opts2 is extended with this"},
+        {key = "and opts1 with this"})
+    extended(...)
+<
+
+
+==============================================================================
+16. LSP-SNIPPETS                                        *luasnip-lsp-snippets*
 
 Luasnip is capable of parsing lsp-style snippets using
 `ls.parser.parse_snippet(context, snippet_string)`:
@@ -1189,7 +1260,7 @@ choiceNode’s with: - the given snippet(`"this is ${1:nested}"`) and - an
 empty insertNode
 
 ==============================================================================
-16. VARIABLES                                              *luasnip-variables*
+17. VARIABLES                                              *luasnip-variables*
 
 All `TM_something`-variables are supported with two additions: `SELECT_RAW` and
 `SELECT_DEDENT`. These were introduced because `TM_SELECTED_TEXT` is designed
@@ -1274,7 +1345,7 @@ A simple example to make it more clear:
 
 
 ==============================================================================
-17. LOADERS                                                  *luasnip-loaders*
+18. LOADERS                                                  *luasnip-loaders*
 
 Luasnip is capable of loading snippets from different formats, including both
 the well-established vscode- and snipmate-format, as well as plain lua-files
@@ -1608,7 +1679,7 @@ One comfortable way to call this function is registering it as a command:
 
 
 ==============================================================================
-18. SNIPPETPROXY                                        *luasnip-snippetproxy*
+19. SNIPPETPROXY                                        *luasnip-snippetproxy*
 
 `SnippetProxy` is used internally to alleviate the upfront-cost of loading
 snippets from e.g. a snipmate-library or a vscode-package. This is achieved by
@@ -1632,7 +1703,7 @@ This will parse the snippet on startup…
 
 
 ==============================================================================
-19. EXT_OPTS                                                *luasnip-ext_opts*
+20. EXT_OPTS                                                *luasnip-ext_opts*
 
 `ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
 extmarks used for marking node-positions, either globally, per-snippet or
@@ -1831,7 +1902,7 @@ Here the highlight of an insertNode nested directly inside a choiceNode is
 always visible on top of it.
 
 ==============================================================================
-20. DOCSTRING                                              *luasnip-docstring*
+21. DOCSTRING                                              *luasnip-docstring*
 
 Snippet-docstrings can be queried using `snippet:get_docstring()`. The function
 evaluates the snippet as if it was expanded regularly, which can be problematic
@@ -1884,7 +1955,7 @@ A better example to understand `docTrig` and `docstring` can refer to #515
 <https://github.com/L3MON4D3/LuaSnip/pull/515>.
 
 ==============================================================================
-21. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
+22. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
 
 Although generation of docstrings is pretty fast, it’s preferable to not redo
 it as long as the snippets haven’t changed. Using
@@ -1901,7 +1972,7 @@ The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 `~/.cache/nvim/luasnip/docstrings.json`).
 
 ==============================================================================
-22. EVENTS                                                    *luasnip-events*
+23. EVENTS                                                    *luasnip-events*
 
 Events can be used to react to some action inside snippets. These callbacks can
 be defined per-snippet (`callbacks`-key in snippet constructor) or globally
@@ -1996,14 +2067,14 @@ or some information about expansions
 
 
 ==============================================================================
-23. CLEANUP                                                  *luasnip-cleanup*
+24. CLEANUP                                                  *luasnip-cleanup*
 
 The function ls.cleanup() triggers the `LuasnipCleanup` user-event, that you
 can listen to do some kind of cleaning in your own snippets, by default it will
 empty the snippets table and the caches of the lazy_load.
 
 ==============================================================================
-24. API-REFERENCE                                      *luasnip-api-reference*
+25. API-REFERENCE                                      *luasnip-api-reference*
 
 `require("luasnip")`:
 

--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -1,5 +1,6 @@
 local text_node = require("luasnip.nodes.textNode").T
 local wrap_nodes = require("luasnip.util.util").wrap_nodes
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 -- https://gist.github.com/tylerneylon/81333721109155b2d244
 local function copy3(obj, seen)
@@ -244,14 +245,12 @@ local function format_nodes(str, nodes, opts)
 		end
 	end, parts)
 end
+extend_decorator.register(format_nodes, { arg_indx = 3 })
 
 return {
 	interpolate = interpolate,
 	format_nodes = format_nodes,
 	-- alias
 	fmt = format_nodes,
-	fmta = function(str, nodes, opts) -- fmt with angle brackets
-		opts = vim.tbl_extend("force", opts or {}, { delimiters = "<>" })
-		return format_nodes(str, nodes, opts)
-	end,
+	fmta = extend_decorator.apply(format_nodes, { delimiters = "<>" }),
 }

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -3,6 +3,7 @@ local util = require("luasnip.util.util")
 local session = require("luasnip.session")
 local snippet_collection = require("luasnip.session.snippet_collection")
 local Environ = require("luasnip.util.environ")
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local loader = require("luasnip.loaders")
 
@@ -680,6 +681,7 @@ ls = {
 	cleanup = cleanup,
 	refresh_notify = refresh_notify,
 	env_namespace = Environ.env_namespace,
+	extend_decorator = extend_decorator,
 }
 
 return ls

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -7,6 +7,7 @@ local events = require("luasnip.util.events")
 local mark = require("luasnip.util.mark").mark
 local session = require("luasnip.session")
 local sNode = require("luasnip.nodes.snippet").SN
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 function ChoiceNode:init_nodes()
 	for i, choice in ipairs(self.choices) do
@@ -73,6 +74,7 @@ local function C(pos, choices, opts)
 	c:init_nodes()
 	return c
 end
+extend_decorator.register(C, { arg_indx = 3 })
 
 function ChoiceNode:subsnip_init()
 	node_util.subsnip_init_children(self.parent, self.choices)

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -6,6 +6,7 @@ local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local FunctionNode = require("luasnip.nodes.functionNode").FunctionNode
 local SnippetNode = require("luasnip.nodes.snippet").SN
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local function D(pos, fn, args, opts)
 	opts = opts or {}
@@ -21,6 +22,7 @@ local function D(pos, fn, args, opts)
 		active = false,
 	}, opts)
 end
+extend_decorator.register(D, { arg_indx = 4 })
 
 function DynamicNode:input_enter()
 	self.active = true

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -5,6 +5,7 @@ local node_util = require("luasnip.nodes.util")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local tNode = require("luasnip.nodes.textNode").textNode
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local function F(fn, args, opts)
 	opts = opts or {}
@@ -17,6 +18,7 @@ local function F(fn, args, opts)
 		user_args = opts.user_args or {},
 	}, opts)
 end
+extend_decorator.register(F, { arg_indx = 3 })
 
 FunctionNode.input_enter = tNode.input_enter
 

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -4,6 +4,7 @@ local util = require("luasnip.util.util")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local session = require("luasnip.session")
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local function I(pos, static_text, opts)
 	static_text = util.to_string_table(static_text)
@@ -29,6 +30,7 @@ local function I(pos, static_text, opts)
 		}, opts)
 	end
 end
+extend_decorator.register(I, { arg_indx = 3 })
 
 function ExitNode:input_enter(no_move)
 	-- Don't enter node for -1-node, it isn't in the node-table.

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -8,6 +8,7 @@ local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local util = require("luasnip.util.util")
 local mark = require("luasnip.util.mark").mark
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local function R(pos, key, nodes, opts)
 	-- don't create nested snippetNodes, unnecessary.
@@ -24,6 +25,7 @@ local function R(pos, key, nodes, opts)
 		active = false,
 	}, opts)
 end
+extend_decorator.register(R, { arg_indx = 4 })
 
 function RestoreNode:exit()
 	self.visible = false

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -12,6 +12,7 @@ local session = require("luasnip.session")
 local pattern_tokenizer = require("luasnip.util.pattern_tokenizer")
 local dict = require("luasnip.util.dict")
 local snippet_collection = require("luasnip.session.snippet_collection")
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local true_func = function()
 	return true
@@ -259,6 +260,11 @@ local function S(context, nodes, opts)
 
 	return _S(snip, nodes, opts)
 end
+extend_decorator.register(
+	S,
+	{ arg_indx = 1, extend = node_util.snippet_extend_context },
+	{ arg_indx = 3 }
+)
 
 function SN(pos, nodes, opts)
 	local snip = Snippet:new(
@@ -278,6 +284,7 @@ function SN(pos, nodes, opts)
 
 	return snip
 end
+extend_decorator.register(SN, { arg_indx = 3 })
 
 local function ISN(pos, nodes, indent_text, opts)
 	local snip = SN(pos, nodes, opts)
@@ -321,6 +328,7 @@ local function ISN(pos, nodes, indent_text, opts)
 
 	return snip
 end
+extend_decorator.register(ISN, { arg_indx = 4 })
 
 function Snippet:remove_from_jumplist()
 	-- prev is i(-1)(startNode), prev of that is the outer/previous snippet.

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -9,6 +9,7 @@
 local parse = require("luasnip.util.parser").parse_snippet
 local snip_mod = require("luasnip.nodes.snippet")
 local node_util = require("luasnip.nodes.util")
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local SnippetProxy = {}
 
@@ -93,5 +94,10 @@ local function new(context, snippet, opts)
 
 	return sp
 end
+extend_decorator.register(
+	new,
+	{ arg_indx = 1, extend = node_util.snippet_extend_context },
+	{ arg_indx = 3 }
+)
 
 return new

--- a/lua/luasnip/nodes/textNode.lua
+++ b/lua/luasnip/nodes/textNode.lua
@@ -2,6 +2,7 @@ local node_mod = require("luasnip.nodes.node")
 local util = require("luasnip.util.util")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local TextNode = node_mod.Node:new()
 
@@ -12,6 +13,7 @@ local function T(static_text, opts)
 		type = types.textNode,
 	}, opts)
 end
+extend_decorator.register(T, { arg_indx = 2 })
 
 function TextNode:input_enter(no_move)
 	self.mark:update_opts(self.ext_opts.active)

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -124,6 +124,15 @@ local function init_node_opts(opts)
 	return in_node
 end
 
+local function snippet_extend_context(arg, extend)
+	if type(arg) == "string" then
+		arg = { trig = arg }
+	end
+
+	-- both are table or nil now.
+	return vim.tbl_extend("keep", arg or {}, extend or {})
+end
+
 return {
 	subsnip_init_children = subsnip_init_children,
 	init_child_positions_func = init_child_positions_func,
@@ -135,4 +144,5 @@ return {
 	select_node = select_node,
 	print_dict = print_dict,
 	init_node_opts = init_node_opts,
+	snippet_extend_context = snippet_extend_context,
 }

--- a/lua/luasnip/util/extend_decorator.lua
+++ b/lua/luasnip/util/extend_decorator.lua
@@ -1,0 +1,82 @@
+local M = {}
+
+-- map fn -> {arg_indx = int, extend = fn}[]
+local function_properties = setmetatable({}, { __mode = "k" })
+
+local function default_extend(arg, extend)
+	return vim.tbl_extend("keep", arg or {}, extend or {})
+end
+
+---Create a new decorated version of `fn`.
+---@param fn The function to create a decorator for.
+---@vararg The values to extend with. These should match the descriptions passed
+---in `register`:
+---```lua
+---local function somefn(arg1, arg2, opts1, opts2)
+---...
+---end
+---register(somefn, {arg_indx=4}, {arg_indx=3})
+---apply(somefn,
+---	{key = "opts2 is extended with this"},
+---	{key = "and opts1 with this"})
+---```
+---@return function: The decorated function.
+function M.apply(fn, ...)
+	local extend_properties = function_properties[fn]
+	assert(
+		extend_properties,
+		"Cannot extend this function, it was not registered! Check :h luasnip-extend_decorator for more infos."
+	)
+
+	local extend_values = { ... }
+
+	local decorated_fn = function(...)
+		local direct_args = { ... }
+
+		-- override values of direct argument.
+		for i, ep in ipairs(extend_properties) do
+			local arg_indx = ep.arg_indx
+
+			-- still allow overriding with directly-passed keys.
+			direct_args[arg_indx] =
+				ep.extend(direct_args[arg_indx], extend_values[i])
+		end
+
+		-- important: http://www.lua.org/manual/5.3/manual.html#3.4
+		-- Passing arguments after the results from `unpack` would mess all this
+		-- up.
+		return fn(unpack(direct_args))
+	end
+
+	-- we know how to extend the decorated function!
+	function_properties[decorated_fn] = extend_properties
+
+	return decorated_fn
+end
+
+---Prepare a function for usage with extend_decorator.
+---To create a decorated function which extends `opts`-style tables passed to it, we need to know
+--- 1. which parameter-position the opts are in and
+--- 2. how to extend them.
+---@param fn function: the function that should be registered.
+---@vararg tables. Each describes how to extend one parameter to `fn`.
+---The tables accept the following keys:
+--- - arg_indx, number (required): the position of the parameter to override.
+--- - extend, fn(arg, extend_value) -> effective_arg (optional): this function
+---   is used to extend the args passed to the decorated function.
+---   It defaults to a function which just extends the the arg-table with the
+---   extend-table.
+---   This extend-behaviour is adaptable to accomodate `s`, where the first
+---   argument may be string or table.
+function M.register(fn, ...)
+	local fn_eps = { ... }
+
+	-- make sure ep.extend is set.
+	for _, ep in ipairs(fn_eps) do
+		ep.extend = ep.extend or default_extend
+	end
+
+	function_properties[fn] = fn_eps
+end
+
+return M

--- a/lua/luasnip/util/parser.lua
+++ b/lua/luasnip/util/parser.lua
@@ -8,6 +8,7 @@ local Environ = require("luasnip.util.environ")
 local functions = require("luasnip.util.functions")
 local util = require("luasnip.util.util")
 local session = require("luasnip.session")
+local extend_decorator = require("luasnip.util.extend_decorator")
 
 local function is_escaped(text, indx)
 	local count = 0
@@ -367,6 +368,24 @@ parse_snippet = function(context, body, tab_stops, brackets)
 		end
 	end
 end
+local function context_extend(arg, extend)
+	local argtype = type(arg)
+	if argtype == "string" then
+		arg = { trig = arg }
+	end
+
+	if argtype == "table" then
+		return vim.tbl_extend("keep", arg, extend or {})
+	end
+
+	-- fall back to unchanged arg.
+	-- log this, probably.
+	return arg
+end
+extend_decorator.register(
+	parse_snippet,
+	{ arg_indx = 1, extend = context_extend }
+)
 
 return {
 	parse_snippet = parse_snippet,

--- a/tests/unit/extend_decorator_spec.lua
+++ b/tests/unit/extend_decorator_spec.lua
@@ -1,0 +1,75 @@
+local helpers = require("test.functional.helpers")(after_each)
+local exec_lua = helpers.exec_lua
+local exec = helpers.exec
+local ls_helpers = require("helpers")
+
+describe("luasnip.util.extend_decorator", function()
+	local shared_setup1 = [[
+			local function passthrough(arg1, arg2)
+				return arg1, arg2
+			end
+
+			local ed = require("luasnip.util.extend_decorator")
+			ed.register(passthrough, {arg_indx = 1}, {arg_indx = 2})
+	]]
+	it("works", function()
+		exec("set rtp+=" .. os.getenv("LUASNIP_SOURCE"))
+
+		assert.is_true(exec_lua(shared_setup1 .. [[
+			ext = ed.apply(passthrough, {key = "first"}, {key = "second"})
+			return vim.deep_equal({ext()}, {{key = "first"}, {key = "second"}})
+		]]))
+	end)
+
+	it("extended variable can be overwritten", function()
+		exec("set rtp+=" .. os.getenv("LUASNIP_SOURCE"))
+
+		assert.is_true(exec_lua(shared_setup1 .. [[
+			ext = ed.apply(passthrough, {key = "first"}, {key = "second"})
+			return vim.deep_equal({ext({key = "override_first"})}, {{key = "override_first"}, {key = "second"}})
+		]]))
+	end)
+
+	it("extended variable can be overwritten", function()
+		exec("set rtp+=" .. os.getenv("LUASNIP_SOURCE"))
+
+		assert.is_true(exec_lua([[
+			local function passthrough(arg1, arg2)
+				return arg1, arg2
+			end
+
+			local ed = require("luasnip.util.extend_decorator")
+			ed.register(passthrough, {arg_indx = 1, extend = function(arg, extend_arg)
+				-- just something stupid to verify custom-extend works
+				return {key = "custom!!"}
+			end}, {arg_indx = 2})
+
+			ext = ed.apply(passthrough, {key = "first"}, {key = "second"})
+			return vim.deep_equal({ext({key = "override_first"})}, {{key = "custom!!"}, {key = "second"}})
+		]]))
+	end)
+
+	it("all default-extends are registered", function()
+		ls_helpers.session_setup_luasnip()
+
+		-- think of a better way to test this here, extending+checking every arg is
+		-- not feasible, so this will have to do until then.
+		exec_lua([[
+			local ed = ls.extend_decorator
+
+			-- just make sure all these extends are registered.
+			ed.apply(fmt)
+			ed.apply(s)
+			ed.apply(sn)
+			ed.apply(isn)
+			ed.apply(c)
+			ed.apply(t)
+			ed.apply(d)
+			ed.apply(f)
+			ed.apply(i)
+			ed.apply(r)
+			ed.apply(sp)
+			ed.apply(parse)
+		]])
+	end)
+end)


### PR DESCRIPTION
Sounds a bit cryptic, the general idea is to allow stuff like
```lua
-- this somewhere above: local override_fn = require("luasnip.extras.override_fn")
local fmts = override_fn.fmt({delimiters = "[]"})
```
This makes it easy to create functions with different defaults, like above for `fmt`, or maybe a `ls.snippet`-function that always sets `regTrig` or some combination of parameters. 

This needs some more work:
- [x] snippet does not really work yet, if the first arg is a string, we're in trouble.
- [x] add more functions beside `fmt`
- [x] think about exposing and documenting the generic function (`override_any`, currently) so it can be used to craft yet more of these override-functions (although that is really quick)
- [x] think of a better name, `override_fn` isn't very self-explanatory
