### PR TITLE
Move setup to root module

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1218,7 +1218,7 @@ Contains some utility-functions that can be passed to the `ft_func` or
   extending the filetypes properly.
 
   ```lua
-  ls.config.setup({
+  ls.setup({
   	load_ft_func =
   		-- Also load both lua and json when a markdown-file is opened,
   		-- javascript for html.
@@ -1734,7 +1734,7 @@ set of `ext_opts` should be applied to:
 ```lua
 local types = require("luasnip.util.types")
 
-ls.config.setup({
+ls.setup({
 	ext_opts = {
 		[types.insertNode] = {
 			active = {...},
@@ -1781,7 +1781,7 @@ It's possible to prevent both of these merges by passing
 `merge_node/child_ext_opts=false` to the snippet/node-opts:
 
 ```lua
-ls.config.setup({
+ls.setup({
 	ext_opts = {
 		[types.insertNode] = {
 			active = {...}
@@ -1817,7 +1817,7 @@ vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
 vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
 
 -- needs to be called for resolving the actual ext_opts.
-ls.config.setup({})
+ls.setup({})
 ```
 The names for the used highlight groups are
 `"Luasnip<node>{Passive,Active,SnippetPassive}"`, where `<node>` can be any kind of
@@ -1835,7 +1835,7 @@ is increased for each nesting level of snippets.
 Both the initial base-priority and its' increase and can be controlled using
 `ext_base_prio` and `ext_prio_increase`:
 ```lua
-ls.config.setup({
+ls.setup({
 	ext_opts = {
 		[types.insertNode] = {
 			active = {

--- a/Examples/snippets.lua
+++ b/Examples/snippets.lua
@@ -23,7 +23,7 @@ local conds = require("luasnip.extras.expand_conditions")
 -- where the actual snippet-definitions start.
 
 -- Every unspecified option will be set to the default.
-ls.config.set_config({
+ls.setup({
 	history = true,
 	-- Update more often, :h events for more info.
 	update_events = "TextChanged,TextChangedI",

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 18
+*luasnip.txt*            For NVIM v0.5.0           Last change: 2022 August 21
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -1170,7 +1170,7 @@ Contains some utility-functions that can be passed to the `ft_func` or
     filetypes that should be loaded additionaly returns a function that can be
     passed to `load_ft_func` and takes care of extending the filetypes properly.
     >
-        ls.config.setup({
+        ls.setup({
           load_ft_func =
               -- Also load both lua and json when a markdown-file is opened,
               -- javascript for html.
@@ -1706,7 +1706,7 @@ set of `ext_opts` should be applied to:
 >
     local types = require("luasnip.util.types")
     
-    ls.config.setup({
+    ls.setup({
         ext_opts = {
             [types.insertNode] = {
                 active = {...},
@@ -1756,7 +1756,7 @@ It’s possible to prevent both of these merges by passing
 `merge_node/child_ext_opts=false` to the snippet/node-opts:
 
 >
-    ls.config.setup({
+    ls.setup({
         ext_opts = {
             [types.insertNode] = {
                 active = {...}
@@ -1793,7 +1793,7 @@ highlight-groups:
     vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
     
     -- needs to be called for resolving the actual ext_opts.
-    ls.config.setup({})
+    ls.setup({})
 <
 
 
@@ -1815,7 +1815,7 @@ Both the initial base-priority and its’ increase and can be controlled using
 `ext_base_prio` and `ext_prio_increase`:
 
 >
-    ls.config.setup({
+    ls.setup({
         ext_opts = {
             [types.insertNode] = {
                 active = {

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -169,6 +169,8 @@ c = {
 		end
 	end,
 }
+
+-- Keep these two for backward compativility
 c.setup = c.set_config
 
 return c

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -4,7 +4,6 @@ local session = require("luasnip.session")
 local snippet_collection = require("luasnip.session.snippet_collection")
 local Environ = require("luasnip.util.environ")
 
-
 local loader = require("luasnip.loaders")
 
 local next_expand = nil
@@ -681,7 +680,7 @@ ls = {
 	cleanup = cleanup,
 	refresh_notify = refresh_notify,
 	env_namespace = Environ.env_namespace,
-        setup = require("luasnip.config").setup,
+	setup = require("luasnip.config").setup,
 }
 
 return ls

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -4,6 +4,7 @@ local session = require("luasnip.session")
 local snippet_collection = require("luasnip.session.snippet_collection")
 local Environ = require("luasnip.util.environ")
 
+
 local loader = require("luasnip.loaders")
 
 local next_expand = nil
@@ -680,6 +681,7 @@ ls = {
 	cleanup = cleanup,
 	refresh_notify = refresh_notify,
 	env_namespace = Environ.env_namespace,
+        setup = require("luasnip.config").setup,
 }
 
 return ls

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -19,7 +19,7 @@ function M.session_setup_luasnip()
 	vim.env.MYVIMRC = "/.vimrc"
 
 	ls = require("luasnip")
-	ls.config.setup({})
+	ls.setup({})
 
 	s = ls.s
 	sn = ls.sn


### PR DESCRIPTION
This does not break old configs as we still keep `setup` and `set_config` in the `luasnip.config` module.