### PR TITLE
Logging.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2569,6 +2569,22 @@ The function ls.cleanup()  triggers the `LuasnipCleanup` user-event, that you ca
 of cleaning in your own snippets, by default it will  empty the snippets table and the caches of
 the lazy_load.
 
+# Logging
+Luasnip uses logging to report unexpected program-states, and information on
+what's going on in general. If something does not work as expected, taking a
+look at the log (and potentially increasing the loglevel) might give some good
+hints towards what is going wrong.  
+
+The log is stored in `<vim.fn.stdpath("log")>/luasnip.log`, and can be opened by
+calling `ls.log.open()`.
+The loglevel (granularity of reported events) can be adjusted by calling
+`ls.log.set_loglevel("error"|"warn"|"info"|"debug")`. `"debug"` has the highest
+granularity, `"error"` the lowest, the default is `"warn"`.  
+
+Once this log grows too large (10MiB, currently not adjustable), it will be
+renamed to `luasnip.log.old`, and a new, empty log created in its place. If
+there already exists a `luasnip.log.old`, it will be deleted.
+
 # API-REFERENCE
 
 `require("luasnip")`:

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 December 05
+*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 December 09
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -52,7 +52,8 @@ Table of Contents                                  *luasnip-table-of-contents*
 21. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
 22. EVENTS                                                    |luasnip-events|
 23. CLEANUP                                                  |luasnip-cleanup|
-24. API-REFERENCE                                      |luasnip-api-reference|
+24. Logging                                                  |luasnip-logging|
+25. API-REFERENCE                                      |luasnip-api-reference|
 
 >
                 __                       ____
@@ -2554,7 +2555,25 @@ can listen to do some kind of cleaning in your own snippets, by default it will
 empty the snippets table and the caches of the lazy_load.
 
 ==============================================================================
-24. API-REFERENCE                                      *luasnip-api-reference*
+24. Logging                                                  *luasnip-logging*
+
+Luasnip uses logging to report unexpected program-states, and information on
+what’s going on in general. If something does not work as expected, taking a
+look at the log (and potentially increasing the loglevel) might give some good
+hints towards what is going wrong.
+
+The log is stored in `<vim.fn.stdpath("log")>/luasnip.log`, and can be opened
+by calling `ls.log.open()`. The loglevel (granularity of reported events) can
+be adjusted by calling `ls.log.set_loglevel("error"|"warn"|"info"|"debug")`.
+`"debug"` has the highest granularity, `"error"` the lowest, the default is
+`"warn"`.
+
+Once this log grows too large (10MiB, currently not adjustable), it will be
+renamed to `luasnip.log.old`, and a new, empty log created in its place. If
+there already exists a `luasnip.log.old`, it will be deleted.
+
+==============================================================================
+25. API-REFERENCE                                      *luasnip-api-reference*
 
 `require("luasnip")`:
 

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -417,7 +417,11 @@ local function active_update_dependents()
 
 		local ok, err = pcall(active.update_dependents, active)
 		if not ok then
-			log.warn("Error while updating dependents for snippet %s due to error %s", active.parent.snippet.trigger, err)
+			log.warn(
+				"Error while updating dependents for snippet %s due to error %s",
+				active.parent.snippet.trigger,
+				err
+			)
 			unlink_current()
 			return
 		end
@@ -425,7 +429,11 @@ local function active_update_dependents()
 		-- 'restore' orientation of extmarks, may have been changed by some set_text or similar.
 		ok, err = pcall(active.parent.enter_node, active.parent, active.indx)
 		if not ok then
-			log.warn("Error while entering node in snippet %s: %s", active.parent.snippet.trigger, err)
+			log.warn(
+				"Error while entering node in snippet %s: %s",
+				active.parent.snippet.trigger,
+				err
+			)
 			unlink_current()
 			return
 		end
@@ -736,8 +744,7 @@ ls = {
 	env_namespace = Environ.env_namespace,
 	setup = require("luasnip.config").setup,
 	extend_decorator = extend_decorator,
-	log = require("luasnip.util.log")
-
+	log = require("luasnip.util.log"),
 }
 
 return ls

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -711,6 +711,10 @@ ls = {
 	env_namespace = Environ.env_namespace,
 	setup = require("luasnip.config").setup,
 	extend_decorator = extend_decorator,
+	-- don't lazy-load this somehow (right now nothing is, just for the future),
+	-- it should print the initial status-message.
+	log = require("luasnip.util.log")
+
 }
 
 return ls

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -99,7 +99,13 @@ local function load_files(ft, files, add_opts)
 				refresh_notify = false,
 			}, add_opts)
 		)
-		log.info("Adding %s snippets and %s autosnippets from %s to ft `%s`", #file_snippets, #file_autosnippets, file, ft)
+		log.info(
+			"Adding %s snippets and %s autosnippets from %s to ft `%s`",
+			#file_snippets,
+			#file_autosnippets,
+			file,
+			ft
+		)
 	end
 
 	ls.refresh_notify(ft)
@@ -159,7 +165,11 @@ function M.lazy_load(opts)
 		for ft, files in pairs(load_paths) do
 			if cache.lazy_loaded_ft[ft] then
 				-- instantly load snippets if they were already loaded...
-				log.info("Immediately loading lazy-load-snippets for already-active filetype `%s` from files:\n%s", ft, vim.inspect(files))
+				log.info(
+					"Immediately loading lazy-load-snippets for already-active filetype `%s` from files:\n%s",
+					ft,
+					vim.inspect(files)
+				)
 				load_files(ft, files, add_opts)
 
 				-- don't load these files again.

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -143,7 +143,13 @@ local function load_snippet_files(add_ft, paths, collection_files, add_opts)
 				key = string.format("__%s_autosnippets_%s", add_ft, path),
 			}, add_opts)
 		)
-		log.info("Adding %s snippets and %s autosnippets for filetype `%s` from %s", #snippet, #autosnippet, add_ft, path)
+		log.info(
+			"Adding %s snippets and %s autosnippets for filetype `%s` from %s",
+			#snippet,
+			#autosnippet,
+			add_ft,
+			path
+		)
 
 		for _, ft in ipairs(extends) do
 			load_snippet_files(
@@ -229,7 +235,11 @@ function M.lazy_load(opts)
 		for ft, paths in pairs(load_paths) do
 			if cache.lazy_loaded_ft[ft] then
 				-- instantly load snippets if the ft is already loaded...
-				log.info("Immediately loading lazy-load-snippets for already-active filetype `%s` from files:\n%s", ft, vim.inspect(paths))
+				log.info(
+					"Immediately loading lazy-load-snippets for already-active filetype `%s` from files:\n%s",
+					ft,
+					vim.inspect(paths)
+				)
 				load_snippet_files(ft, paths, collection_paths, add_opts)
 				-- clear from load_paths to prevent duplicat loads.
 				load_paths[ft] = nil
@@ -262,7 +272,11 @@ function M._reload_file(filename)
 	cache.path_snippets[filename] = nil
 
 	for ft, _ in pairs(cached_data.fts) do
-		log.info("Re-loading snippets contributed by %s for filetype `%s`", filename, ft)
+		log.info(
+			"Re-loading snippets contributed by %s for filetype `%s`",
+			filename,
+			ft
+		)
 		-- we can safely set collection to empty, the `extends` are already
 		-- "set up", eg are included via cached_data.fts.
 		load_snippet_files(ft, { filename }, {}, add_opts)

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -103,9 +103,19 @@ local function load_snippet_files(lang, files, add_opts)
 					refresh_notify = false,
 				}, add_opts)
 			)
-			log.info("Adding %s snippets and %s autosnippets for filetype `%s` from %s", #lang_snips, #auto_lang_snips, lang, file)
+			log.info(
+				"Adding %s snippets and %s autosnippets for filetype `%s` from %s",
+				#lang_snips,
+				#auto_lang_snips,
+				lang,
+				file
+			)
 		else
-			log.error("Trying to read snippets from file %s, but it does not exist.", lang, file)
+			log.error(
+				"Trying to read snippets from file %s, but it does not exist.",
+				lang,
+				file
+			)
 		end
 	end
 
@@ -133,8 +143,13 @@ local function package_files(root, filter)
 		log.error("Json in %s could not be parsed", package)
 		return {}
 	end
-	if not package_data.contributes or not package_data.contributes.snippets then
-		log.warn("Package %s does not contribute any snippets, skipping it", package)
+	if
+		not package_data.contributes or not package_data.contributes.snippets
+	then
+		log.warn(
+			"Package %s does not contribute any snippets, skipping it",
+			package
+		)
 		return {}
 	end
 
@@ -159,7 +174,11 @@ local function package_files(root, filter)
 				if normalized_snippet_file then
 					table.insert(ft_files[ft], normalized_snippet_file)
 				else
-					log.warn("Could not find file %s from advertised in %s", snippet_entry.path, root)
+					log.warn(
+						"Could not find file %s from advertised in %s",
+						snippet_entry.path,
+						root
+					)
 				end
 			end
 		end
@@ -252,7 +271,11 @@ function M.lazy_load(opts)
 		if cache.lazy_loaded_ft[ft] then
 			-- instantly load snippets if they were already loaded...
 			load_snippet_files(ft, files, add_opts)
-			log.info("Immediately loading lazy-load-snippets for already-active filetype %s from files:\n%s", ft, vim.inspect(files))
+			log.info(
+				"Immediately loading lazy-load-snippets for already-active filetype %s from files:\n%s",
+				ft,
+				vim.inspect(files)
+			)
 
 			-- don't load these files again.
 			ft_files[ft] = nil

--- a/lua/luasnip/util/log.lua
+++ b/lua/luasnip/util/log.lua
@@ -1,0 +1,99 @@
+local util = require("luasnip.util.util")
+-- just to be sure this dir exists.
+-- 448 = 0700
+vim.loop.fs_mkdir(vim.fn.stdpath("log"), 448)
+
+local log_location = vim.fn.stdpath("log") .. "/luasnip.log"
+local log_old_location = vim.fn.stdpath("log") .. "/luasnip.log.old"
+
+local luasnip_log_fd = vim.loop.fs_open(
+	log_location,
+	-- only append.
+	"a",
+	-- 420 = 0644
+	420)
+
+local logsize = vim.loop.fs_fstat(luasnip_log_fd).size
+if logsize > 10*2^20 then
+	-- logsize > 10MiB:
+	-- move log -> old log, start new log.
+	vim.loop.fs_rename(log_location, log_old_location)
+	luasnip_log_fd = vim.loop.fs_open(
+		log_location,
+		-- only append.
+		"a",
+		-- 420 = 0644
+		420)
+end
+
+local M = {}
+
+local function log_line_append(msg)
+	msg = msg:gsub("\n", "\n      | ")
+	vim.loop.fs_write(luasnip_log_fd, msg .. "\n")
+end
+
+local log = {
+	error = function(msg)
+		log_line_append("ERROR | " .. msg)
+	end,
+	warn = function(msg)
+		log_line_append("WARN  | " .. msg)
+	end,
+	info = function(msg)
+		log_line_append("INFO  | " .. msg)
+	end,
+	debug = function(msg)
+		log_line_append("DEBUG | " .. msg)
+	end
+}
+
+-- functions copied directly by deepcopy.
+-- will be initialized later on, by set_loglevel.
+local effective_log
+
+-- levels sorted by importance, descending.
+local loglevels = {"error", "warn", "info", "debug"}
+
+-- special key none disable all logging.
+function M.set_loglevel(target_level)
+	local target_level_indx = util.indx_of(loglevels, target_level)
+	if target_level == "none" then
+		target_level_indx = 0
+	end
+
+	assert(target_level_indx ~= nil, "invalid level!")
+
+	-- reset effective loglevels, set those with importance higher than
+	-- target_level, disable (nop) those with lower.
+	effective_log = {}
+	for i = 1, target_level_indx do
+		effective_log[loglevels[i]] = log[loglevels[i]]
+	end
+	for i = target_level_indx+1, #loglevels do
+		effective_log[loglevels[i]] = util.nop
+	end
+end
+
+function M.new(module_name)
+	local module_log = { }
+	for name, _ in pairs(log) do
+		module_log[name] = function(msg, ...)
+			-- don't immediately get the referenced function, we'd like to
+			-- allow changing the loglevel on-the-fly.
+			effective_log[name](module_name .. ": " .. msg:format(...))
+		end
+	end
+	return module_log
+end
+
+function M.open()
+	vim.cmd(("tabnew %s"):format(log_location))
+end
+
+-- manually append newline
+vim.loop.fs_write(luasnip_log_fd,"\n")
+log.info("New session: " .. os.date())
+M.set_loglevel("warn")
+
+return M

--- a/lua/luasnip/util/log.lua
+++ b/lua/luasnip/util/log.lua
@@ -11,10 +11,11 @@ local luasnip_log_fd = vim.loop.fs_open(
 	-- only append.
 	"a",
 	-- 420 = 0644
-	420)
+	420
+)
 
 local logsize = vim.loop.fs_fstat(luasnip_log_fd).size
-if logsize > 10*2^20 then
+if logsize > 10 * 2 ^ 20 then
 	-- logsize > 10MiB:
 	-- move log -> old log, start new log.
 	vim.loop.fs_rename(log_location, log_old_location)
@@ -23,7 +24,8 @@ if logsize > 10*2^20 then
 		-- only append.
 		"a",
 		-- 420 = 0644
-		420)
+		420
+	)
 end
 
 local M = {}
@@ -45,7 +47,7 @@ local log = {
 	end,
 	debug = function(msg)
 		log_line_append("DEBUG | " .. msg)
-	end
+	end,
 }
 
 -- functions copied directly by deepcopy.
@@ -53,7 +55,7 @@ local log = {
 local effective_log
 
 -- levels sorted by importance, descending.
-local loglevels = {"error", "warn", "info", "debug"}
+local loglevels = { "error", "warn", "info", "debug" }
 
 -- special key none disable all logging.
 function M.set_loglevel(target_level)
@@ -70,13 +72,13 @@ function M.set_loglevel(target_level)
 	for i = 1, target_level_indx do
 		effective_log[loglevels[i]] = log[loglevels[i]]
 	end
-	for i = target_level_indx+1, #loglevels do
+	for i = target_level_indx + 1, #loglevels do
 		effective_log[loglevels[i]] = util.nop
 	end
 end
 
 function M.new(module_name)
-	local module_log = { }
+	local module_log = {}
 	for name, _ in pairs(log) do
 		module_log[name] = function(msg, ...)
 			-- don't immediately get the referenced function, we'd like to
@@ -92,7 +94,7 @@ function M.open()
 end
 
 -- manually append newline
-vim.loop.fs_write(luasnip_log_fd,"\n")
+vim.loop.fs_write(luasnip_log_fd, "\n")
 log.info("New session: " .. os.date())
 M.set_loglevel("warn")
 

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -568,6 +568,17 @@ local function reverse_lookup(t)
 	return rev
 end
 
+local function nop() end
+
+local function indx_of(t, v)
+	for i, value in ipairs(t) do
+		if v == value then
+			return i
+		end
+	end
+	return nil
+end
+
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -611,4 +622,6 @@ return {
 	no = no,
 	yes = yes,
 	reverse_lookup = reverse_lookup,
+	nop = nop,
+	indx_of = indx_of,
 }


### PR DESCRIPTION
Logging.

Current behaviour:
- will always append, even when a new session is started
  +: older logs still accessible
  -: log could grow too large
- can log either info,warn,debug,error. We'll probably want a way to turn off certain logging, based either on the severity or the source (I think turning off some sources could be pretty useful, or setting severities separately (`marks`="info", `loaders`="debug", something like that) otherwise I'd worry about drowning the user in uninteresting information (although, what do we have grep for :D)))