### PR TITLE
Hotfix nil in get snippets + adds test for error

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*          For NVIM v0.5.0          Last change: 2022 September 14
+*luasnip.txt*          For NVIM v0.5.0          Last change: 2022 September 15
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/session/snippet_collection.lua
+++ b/lua/luasnip/session/snippet_collection.lua
@@ -217,6 +217,7 @@ function M.clean_invalidated(opts)
 
 	for type, type_snippets in pairs(by_ft) do
 		by_ft[type] = without_invalidated(type_snippets)
+		setmetatable(by_ft[type], by_ft_snippets_mt)
 	end
 
 	for key, key_snippets in pairs(by_key) do

--- a/tests/unit/snippet_collection_spec.lua
+++ b/tests/unit/snippet_collection_spec.lua
@@ -54,7 +54,7 @@ describe("add_snippets invalidation", function()
 
 	it("", function()
 		local function foo()
-				return helpers.exec_lua([[
+			return helpers.exec_lua([[
 					local s,t = require("luasnip").snippet, require("luasnip").text_node
 					local collection = require("luasnip.session.snippet_collection")
 					collection.clear_snippets()

--- a/tests/unit/snippet_collection_spec.lua
+++ b/tests/unit/snippet_collection_spec.lua
@@ -46,3 +46,25 @@ describe("snippet_collection.add/get", function()
 		assert.is_true(foo())
 	end)
 end)
+
+describe("add_snippets invalidation", function()
+	-- apparently clear() needs to run before anything else...
+	helpers.clear()
+	helpers.exec("set rtp+=" .. os.getenv("LUASNIP_SOURCE"))
+
+	it("", function()
+		local function foo()
+				return helpers.exec_lua([[
+					local s,t = require("luasnip").snippet, require("luasnip").text_node
+					local collection = require("luasnip.session.snippet_collection")
+					collection.clear_snippets()
+					local s1,s2 = s("trig1", t("snippet1")), s("trig2", t("snippet2"))
+					local opts = {type="snippets", default_priority=1000, key="abc"}
+					collection.add_snippets({["txt"]={s1,s2}}, opts)
+					collection.clean_invalidated({ inv_limit = -1 })
+					local r = collection.get_snippets("nonExistantFT", "snippets")
+					]])
+		end
+		assert.has_no.errors(foo)
+	end)
+end)


### PR DESCRIPTION
Fixes #591. We've forgotten to add the metatable once again in `clean_invalidated` (should be the last occurrence where it was missing, checked (hopefully) all the other ones)

Please mention if you've got another idea how to test this by not simply checking for a thrown error.