### PR TITLE
Remove \r from strings before parsing

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*          For NVIM v0.5.0          Last change: 2022 September 16
+*luasnip.txt*          For NVIM v0.5.0          Last change: 2022 September 18
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/parser/init.lua
+++ b/lua/luasnip/util/parser/init.lua
@@ -33,6 +33,8 @@ function M.parse_snippet(context, body, opts)
 		opts.trim_empty = true
 	end
 
+	body = Str.sanitize(body)
+
 	local lines = vim.split(body, "\n")
 	Str.process_multiline(lines, opts)
 	body = table.concat(lines, "\n")

--- a/lua/luasnip/util/str.lua
+++ b/lua/luasnip/util/str.lua
@@ -109,4 +109,8 @@ function M.aupatescape(s)
 	return vim.fn.fnameescape(escaped)
 end
 
+function M.sanitize(str)
+	return str:gsub("%\r", "")
+end
+
 return M

--- a/tests/integration/parser_spec.lua
+++ b/tests/integration/parser_spec.lua
@@ -57,10 +57,12 @@ describe("Parser", function()
 			{ "adsf", "asdf" }
 		)
 		exec_lua("ls.lsp_expand(" .. snip .. ")")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			adsf                                              |
 			asdf^                                              |
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 	end)
 
 	it("Can create snippets with tabstops.", function()

--- a/tests/integration/parser_spec.lua
+++ b/tests/integration/parser_spec.lua
@@ -44,6 +44,25 @@ describe("Parser", function()
 		})
 	end)
 
+	it("Omits \\r in passed text.", function()
+		ls_helpers.session_setup_luasnip()
+		local snip = '"adsf\\r\\nasdf"'
+
+		assert.are.same(
+			exec_lua(
+				'return ls.parser.parse_snippet("", '
+					.. snip
+					.. "):get_static_text()"
+			),
+			{ "adsf", "asdf" }
+		)
+		exec_lua("ls.lsp_expand(" .. snip .. ")")
+		screen:expect{grid=[[
+			adsf                                              |
+			asdf^                                              |
+			{2:-- INSERT --}                                      |]]}
+	end)
+
 	it("Can create snippets with tabstops.", function()
 		ls_helpers.session_setup_luasnip()
 		local snip = '"a$2 $0b$1 c"'


### PR DESCRIPTION
I guess this is the correct thing to do here, seems like jdtls also separates (not terminates) lines with `\r\n` (at least).
(also means we can't re-use the function for reading an entire file from `loaders.util`, where line-terminators are assumed).