### PR TITLE
fix(snipmate): correctly escape backtick

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*          For NVIM v0.5.0          Last change: 2022 September 18
+*luasnip.txt*          For NVIM v0.5.0          Last change: 2022 September 20
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/parser/init.lua
+++ b/lua/luasnip/util/parser/init.lua
@@ -116,7 +116,7 @@ local function backticks_to_variable(body)
 	end
 
 	-- append remaining characters.
-	var_string = var_string .. body:sub(processed_to, -1)
+	var_string = var_string .. body:sub(processed_to, -1):gsub("\\`", "`")
 
 	return var_map, var_string
 end

--- a/tests/integration/parser_spec.lua
+++ b/tests/integration/parser_spec.lua
@@ -848,4 +848,17 @@ describe("Parser", function()
 			{2:-- INSERT --}                                      |]],
 		})
 	end)
+
+	it("correctly parses escaped characters.", function()
+		ls_helpers.session_setup_luasnip()
+		local snip = [["\\`\\`\\` `'abc' . '\\`lel'`"]]
+
+		exec_lua("ls.snip_expand(ls.parser.parse_snipmate('', " .. snip .. "))")
+		screen:expect({
+			grid = [[
+			``` abc\`lel^                                      |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
 end)


### PR DESCRIPTION
Let's have the following snippet:
```snippets
snippet src
	\`\`\`$1
	$0
	\`\`\`
```

Without this patch, it will expand into:
````
\`\`\`

\`\`\`
````

After this fix, it will expand into what is expected:
````
```

```
````


