### PR TITLE
Return a better error when from_lua loader fails

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*          For NVIM v0.5.0          Last change: 2022 September 20
+*luasnip.txt*          For NVIM v0.5.0          Last change: 2022 September 28
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -35,7 +35,8 @@ local function load_files(ft, files, add_opts)
 		local func_string = path_mod.read_file(file)
 		-- bring snippet-constructors into global scope for that function.
 		func_string = 'require("luasnip").setup_snip_env() ' .. func_string
-		local file_snippets, file_autosnippets = loadstring(func_string)()
+		local ok, file_snippets, file_autosnippets = pcall(loadstring(func_string))
+		if not ok then error('Failed to load ' .. file) end
 
 		-- make sure these aren't nil.
 		file_snippets = file_snippets or {}


### PR DESCRIPTION
Prior to this patch a erroneous snippet file would lead to an error
along the lines of: `attempting to call a nil value`
With this the error clearly points to the faulty file.

Signed-off-by: Robert Günzler <r@gnzler.io>
