### PR TITLE
fix: replaced spaces with tabs

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0           Last change: 2022 October 13
+*luasnip.txt*           For NVIM v0.5.0           Last change: 2022 October 14
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -177,11 +177,11 @@ c = {
 		vim.cmd(
 			string.format(
 				[[
-        augroup luasnip
-            au!
-            autocmd %s * lua require("luasnip").unlink_current_if_deleted()
-            autocmd %s * lua require("luasnip").active_update_dependents()
-            autocmd %s * lua require("luasnip").exit_out_of_region(require("luasnip").session.current_nodes[vim.api.nvim_get_current_buf()])
+ 		augroup luasnip
+ 			au!
+ 			autocmd %s * lua require("luasnip").unlink_current_if_deleted()
+ 			autocmd %s * lua require("luasnip").active_update_dependents()
+ 			autocmd %s * lua require("luasnip").exit_out_of_region(require("luasnip").session.current_nodes[vim.api.nvim_get_current_buf()])
 			"Remove buffers' nodes on deletion+wipeout.
 			autocmd BufDelete,BufWipeout * lua current_nodes = require("luasnip").session.current_nodes if current_nodes then current_nodes[tonumber(vim.fn.expand("<abuf>"))] = nil end
 		]]


### PR DESCRIPTION
Those spaces cause an error (I couldn't get the error out again after fixed) when I startup my neovim.