### PR TITLE
Add path to luasnips loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,5 +163,6 @@ Here are some LuaSnip videos and tutorials on the Web:
 Setting `snip_env` to `{ some_global = "a value" }` will add the global variable `some_global` while evaluating these files.
 If you mind the (probably) large number of generated warnings, consider adding the keys set here to the globals
 recognized by lua-language-server or add `---@diagnostic disable: undefined-global` somewhere in the affected files.
+- `snip_path`: Define the require path of lua environment of files loaded by the [lua-loader](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader).
 
 Inspired by [vsnip.vim](https://github.com/hrsh7th/vim-vsnip/)

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0           Last change: 2022 October 14
+*luasnip.txt*           For NVIM v0.5.0           Last change: 2022 October 20
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -604,6 +604,12 @@ local function refresh_notify(ft)
 	end
 end
 
+local function setup_snip_path()
+	if session.config.snip_path then
+		package.path = session.config.snip_path
+	end
+end
+
 local function setup_snip_env()
 	setfenv(2, vim.tbl_extend("force", _G, session.config.snip_env))
 end
@@ -679,6 +685,7 @@ ls = {
 	get_snippets = get_snippets,
 	get_id_snippet = get_id_snippet,
 	setup_snip_env = setup_snip_env,
+	setup_snip_path = setup_snip_path,
 	clean_invalidated = clean_invalidated,
 	get_snippet_filetypes = util.get_snippet_filetypes,
 	s = snip_mod.S,

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -33,8 +33,14 @@ local M = {}
 local function load_files(ft, files, add_opts)
 	for _, file in ipairs(files) do
 		local func_string = path_mod.read_file(file)
-		-- bring snippet-constructors into global scope for that function.
-		func_string = 'require("luasnip").setup_snip_env() ' .. func_string
+		func_string = table.concat({
+			-- bring snippet-constructors into global scope for that function.
+			'require("luasnip").setup_snip_env()',
+			-- setup package.paths to allow custom imports
+			'require("luasnip").setup_snip_path()',
+			func_string,
+		}, "\n")
+
 		local ok, file_snippets, file_autosnippets =
 			pcall(loadstring(func_string))
 		if not ok then


### PR DESCRIPTION
In order to keep my snippets in better order, I wanted to split my snippets into multiple files (one snippet per file), as here:

```
~/.config/nvim/snippets
├── all.lua
├── ...
└── lua
    ├── init.lua
    ├── snippet_1.lua
    ├── snippet_2.lua
    └── snippet_3.lua
```

This means having a `snippets/lua/init.lua` file that imports the other files in the directory, e.g.

```lua
local snippets = {
    require('lua.snippet_1'),
    require('lua.snippet_2'),
    require('lua.snippet_3'),
}

return snippets, {}
```

The problem that I ran into was that the require function didn't work as it didn't have an appropriate path property, so could not resolve the imports.

In order to resolve this issue, I have implemented a new property on the config, `snip_path`, which takes a lua path string.

If this `snip_path` property exists it is then injected into the snippet (at the same time as the env is injected), changing the `package.path` property which is used in Neovim to resolve imports.