### PR TITLE
Keep default `snip_env` and documentation in sync

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -46,6 +46,10 @@ local types = require("luasnip.util.types")
 local parse = require("luasnip.util.parser").parse_snippet
 ```
 
+As noted in [the Lua section](#lua):
+
+> By default, the names from [`luasnip.config.snip_env`][snip-env-src] will be used, but it's possible to customize them by setting `snip_env` in `setup`. 
+
 <!-- panvimdoc-ignore-start -->
 
 Note: the source code of snippets in GIFs is actually

--- a/DOC.md
+++ b/DOC.md
@@ -2014,7 +2014,7 @@ these files.
 By default, the names from [`luasnip.config.snip_env`][snip-env-src] will be used, but it's
 possible to customize them by setting `snip_env` in `setup`.  
 
-[snip-env-src]: https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L148
+[snip-env-src]: https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L147
 
 **Example**:
 

--- a/DOC.md
+++ b/DOC.md
@@ -31,12 +31,19 @@ local d = ls.dynamic_node
 local r = ls.restore_node
 local events = require("luasnip.util.events")
 local ai = require("luasnip.nodes.absolute_indexer")
-local fmt = require("luasnip.extras.fmt").fmt
 local extras = require("luasnip.extras")
-local m = extras.m
-local l = extras.l
+local l = extras.lambda
 local rep = extras.rep
+local p = extras.partial
+local m = extras.match
+local n = extras.nonempty
+local dl = extras.dynamic_lambda
+local fmt = require("luasnip.extras.fmt").fmt
+local fmta = require("luasnip.extras.fmt").fmta
+local conds = require("luasnip.extras.expand_conditions")
 local postfix = require("luasnip.extras.postfix").postfix
+local types = require("luasnip.util.types")
+local parse = require("luasnip.util.parser").parse_snippet
 ```
 
 <!-- panvimdoc-ignore-start -->

--- a/DOC.md
+++ b/DOC.md
@@ -50,6 +50,8 @@ As noted in [the Lua section](#lua):
 
 > By default, the names from [`luasnip.config.snip_env`][snip-env-src] will be used, but it's possible to customize them by setting `snip_env` in `setup`. 
 
+Furthermore, note that while this document assumes you have defined `ls` to be `require("luasnip")`, it is **not** provided in the default set of variables.
+
 <!-- panvimdoc-ignore-start -->
 
 Note: the source code of snippets in GIFs is actually

--- a/DOC.md
+++ b/DOC.md
@@ -2014,7 +2014,7 @@ these files.
 By default, the names from [`luasnip.config.snip_env`][snip-env-src] will be used, but it's
 possible to customize them by setting `snip_env` in `setup`.  
 
-[snip-env-src]: https://github.com/L3MON4D3/LuaSnip/blob/69cb81cf7490666890545fef905d31a414edc15b/lua/luasnip/config.lua#L82-L104
+[snip-env-src]: https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L148
 
 **Example**:
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -112,6 +112,9 @@ As noted in |luasnip-the-lua-section|:
   `setup`.
 
 
+Furthermore, note that while this document assumes you have defined `ls` to be
+`require("luasnip")`, it is **not** provided in the default set of variables.
+
 ==============================================================================
 1. BASICS                                                     *luasnip-basics*
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0           Last change: 2022 October 14
+*luasnip.txt*           For NVIM v0.5.0           Last change: 2022 October 30
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -87,12 +87,19 @@ All code-snippets in this help assume that
     local r = ls.restore_node
     local events = require("luasnip.util.events")
     local ai = require("luasnip.nodes.absolute_indexer")
-    local fmt = require("luasnip.extras.fmt").fmt
     local extras = require("luasnip.extras")
-    local m = extras.m
-    local l = extras.l
+    local l = extras.lambda
     local rep = extras.rep
+    local p = extras.partial
+    local m = extras.match
+    local n = extras.nonempty
+    local dl = extras.dynamic_lambda
+    local fmt = require("luasnip.extras.fmt").fmt
+    local fmta = require("luasnip.extras.fmt").fmta
+    local conds = require("luasnip.extras.expand_conditions")
     local postfix = require("luasnip.extras.postfix").postfix
+    local types = require("luasnip.util.types")
+    local parse = require("luasnip.util.parser").parse_snippet
 <
 
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0           Last change: 2022 October 30
+*luasnip.txt*           For NVIM v0.5.0           Last change: 2022 October 31
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -107,7 +107,7 @@ As noted in |luasnip-the-lua-section|:
 
 
   By default, the names from `luasnip.config.snip_env`
-  <https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L148>
+  <https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L147>
   will be used, but it’s possible to customize them by setting `snip_env` in
   `setup`.
 
@@ -1977,7 +1977,7 @@ in `setup` or `set_config` if this table is used).
 As defining all of the snippet-constructors (`s`, `c`, `t`, …) in every file
 is rather cumbersome, luasnip will bring some globals into scope for executing
 these files. By default, the names from `luasnip.config.snip_env`
-<https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L148>
+<https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L147>
 will be used, but it’s possible to customize them by setting `snip_env` in
 `setup`.
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -107,7 +107,7 @@ As noted in |luasnip-the-lua-section|:
 
 
   By default, the names from `luasnip.config.snip_env`
-  <https://github.com/L3MON4D3/LuaSnip/blob/69cb81cf7490666890545fef905d31a414edc15b/lua/luasnip/config.lua#L82-L104>
+  <https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L148>
   will be used, but it’s possible to customize them by setting `snip_env` in
   `setup`.
 
@@ -1977,7 +1977,7 @@ in `setup` or `set_config` if this table is used).
 As defining all of the snippet-constructors (`s`, `c`, `t`, …) in every file
 is rather cumbersome, luasnip will bring some globals into scope for executing
 these files. By default, the names from `luasnip.config.snip_env`
-<https://github.com/L3MON4D3/LuaSnip/blob/69cb81cf7490666890545fef905d31a414edc15b/lua/luasnip/config.lua#L82-L104>
+<https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L148>
 will be used, but it’s possible to customize them by setting `snip_env` in
 `setup`.
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -103,6 +103,15 @@ All code-snippets in this help assume that
 <
 
 
+As noted in |luasnip-the-lua-section|:
+
+
+  By default, the names from `luasnip.config.snip_env`
+  <https://github.com/L3MON4D3/LuaSnip/blob/69cb81cf7490666890545fef905d31a414edc15b/lua/luasnip/config.lua#L82-L104>
+  will be used, but it’s possible to customize them by setting `snip_env` in
+  `setup`.
+
+
 ==============================================================================
 1. BASICS                                                     *luasnip-basics*
 

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -120,14 +120,19 @@ local defaults = {
 	load_ft_func = ft_functions.from_filetype_load,
 	-- globals injected into luasnippet-files.
 	snip_env = {
+		ls = require("luasnip"),
 		s = require("luasnip.nodes.snippet").S,
 		sn = require("luasnip.nodes.snippet").SN,
+		isn = require("luasnip.nodes.snippet").ISN,
 		t = require("luasnip.nodes.textNode").T,
-		f = require("luasnip.nodes.functionNode").F,
 		i = require("luasnip.nodes.insertNode").I,
+		f = require("luasnip.nodes.functionNode").F,
 		c = require("luasnip.nodes.choiceNode").C,
 		d = require("luasnip.nodes.dynamicNode").D,
 		r = require("luasnip.nodes.restoreNode").R,
+		events = require("luasnip.util.events"),
+		ai = require("luasnip.nodes.absolute_indexer"),
+		extras = require("luasnip.extras"),
 		l = require("luasnip.extras").lambda,
 		rep = require("luasnip.extras").rep,
 		p = require("luasnip.extras").partial,
@@ -137,10 +142,9 @@ local defaults = {
 		fmt = require("luasnip.extras.fmt").fmt,
 		fmta = require("luasnip.extras.fmt").fmta,
 		conds = require("luasnip.extras.expand_conditions"),
+		postfix = require("luasnip.extras.postfix").postfix,
 		types = require("luasnip.util.types"),
-		events = require("luasnip.util.events"),
 		parse = require("luasnip.util.parser").parse_snippet,
-		ai = require("luasnip.nodes.absolute_indexer"),
 	},
 }
 

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -120,7 +120,6 @@ local defaults = {
 	load_ft_func = ft_functions.from_filetype_load,
 	-- globals injected into luasnippet-files.
 	snip_env = {
-		ls = require("luasnip"),
 		s = require("luasnip.nodes.snippet").S,
 		sn = require("luasnip.nodes.snippet").SN,
 		isn = require("luasnip.nodes.snippet").ISN,

--- a/lua/luasnip/extras/postfix.lua
+++ b/lua/luasnip/extras/postfix.lua
@@ -1,4 +1,4 @@
-local snip = require("luasnip").snippet
+local snip = require("luasnip.nodes.snippet").S
 local events = require("luasnip.util.events")
 local matches = {
 	default = [[[%w%.%_%-%"%']+$]],


### PR DESCRIPTION
This PR closes #643.

As I noted in the linked issue, the default configuration of the shorthand forms of the snippet variables (defined here:)

https://github.com/L3MON4D3/LuaSnip/blob/69cb81cf7490666890545fef905d31a414edc15b/lua/luasnip/config.lua#L82-L104

does not match what the documentation tells you the default variables are. This PR synchronizes them, so that both have the following variables defined:

```lua
        ls = require("luasnip"),
        s = require("luasnip.nodes.snippet").S,
        sn = require("luasnip.nodes.snippet").SN,
        isn = require("luasnip.nodes.snippet").ISN,
        t = require("luasnip.nodes.textNode").T,
        i = require("luasnip.nodes.insertNode").I,
        f = require("luasnip.nodes.functionNode").F,
        c = require("luasnip.nodes.choiceNode").C,
        d = require("luasnip.nodes.dynamicNode").D,
        r = require("luasnip.nodes.restoreNode").R,
        events = require("luasnip.util.events"),
        ai = require("luasnip.nodes.absolute_indexer"),
        extras = require("luasnip.extras"),
        l = require("luasnip.extras").lambda,
        rep = require("luasnip.extras").rep,
        p = require("luasnip.extras").partial,
        m = require("luasnip.extras").match,
        n = require("luasnip.extras").nonempty,
        dl = require("luasnip.extras").dynamic_lambda,
        fmt = require("luasnip.extras.fmt").fmt,
        fmta = require("luasnip.extras.fmt").fmta,
        conds = require("luasnip.extras.expand_conditions"),
        postfix = require("luasnip.extras.postfix").postfix,
        types = require("luasnip.util.types"),
        parse = require("luasnip.util.parser").parse_snippet,
```