### PR TITLE
lua-loader: add file-global table through which snippets may be added

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2707,14 +2707,21 @@ the lazy_load.
 - `refresh_notify(ft:string)`: Triggers an autocmd that other plugins can hook
   into to perform various cleanup for the refreshed filetype.
   Useful for signaling that new snippets were added for the filetype `ft`.
+
 - `set_choice(indx:number)`: Changes to the `indx`th choice.
   If no `choiceNode` is active, an error is thrown.
   If the active `choiceNode` doesn't have an `indx`th choice, an error is
   thrown.
+
 - `get_current_choices() -> string[]`: Returns a list of multiline-strings
   (themselves lists, even if they have only one line), the `i`th string
   corresponding to the `i`th choice of the currently active `choiceNode`.
   If no `choiceNode` is active, an error is thrown.
+
+- `setup_snip_env()`: Adds the variables defined (during `setup`) in `snip_env`
+  to the callers environment.
+
+- `get_snip_env()`: Returns `snip_env`.
 
 Not covered in this section are the various node-constructors exposed by
 the module, their usage is shown either previously in this file or in

--- a/DOC.md
+++ b/DOC.md
@@ -2002,13 +2002,41 @@ Stuff to watch out for:
 ## LUA
 
 Instead of adding all snippets via `add_snippets`, it's possible to store them
-in separate files and load all of those.
+in separate files and load all of those.  
 The file-structure here is exactly the supported snipmate-structure, e.g.
 `<ft>.lua` or `<ft>/*.lua` to add snippets for the filetype `<ft>`.  
-The files need to return two lists of snippets (either may be `nil`). The
-snippets in the first are regular snippets for `<ft>`, the ones in the
-second are autosnippets (make sure they are enabled in `setup` or `set_config`
-if this table is used).
+
+There are two ways to add snippets:
+
+* the files may return two lists of snippets, the snippets in the first are all
+  added as regular snippets, while the snippets in the second will be added as
+  autosnippets (both are the defaults, if a snippet defines a different
+  `snippetType`, that will have preference)
+* snippets can also be appended to the global (only for these files! They are not
+  visible anywhere else) tables `ls_file_snippets` and `ls_file_autosnippets`.
+  This can be combined with a custom `snip_env` to define and add snippets with
+  one function-call:
+  ```lua
+  ls.setup({
+  	snip_env = {
+  		s = function(...)
+  			local snip = ls.s(...)
+  			-- we can't just access the global `ls_file_snippets`, since it will be
+  			-- resolved in the environment of the scope in which it was defined.
+  			table.insert(getfenv(2).ls_file_snippets, snip)
+  		end,
+  		parse = function(...)
+  			local snip = ls.parser.parse(...)
+  			table.insert(getfenv(2).ls_file_snippets, snip)
+  		end,
+  		-- remaining definitions.
+  		...
+  	},
+  	...
+  })
+  ```
+  This is more flexible than the previous approach since the snippets don't have
+  to be collected, they just have to be defined using the above `s` and `parse`.
 
 As defining all of the snippet-constructors (`s`, `c`, `t`, ...) in every file
 is rather cumbersome, luasnip will bring some globals into scope for executing

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 November 01
+*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 November 12
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -1972,10 +1972,42 @@ LUA                                                              *luasnip-lua*
 Instead of adding all snippets via `add_snippets`, it’s possible to store
 them in separate files and load all of those. The file-structure here is
 exactly the supported snipmate-structure, e.g. `<ft>.lua` or `<ft>/*.lua` to
-add snippets for the filetype `<ft>`. The files need to return two lists of
-snippets (either may be `nil`). The snippets in the first are regular snippets
-for `<ft>`, the ones in the second are autosnippets (make sure they are enabled
-in `setup` or `set_config` if this table is used).
+add snippets for the filetype `<ft>`.
+
+There are two ways to add snippets:
+
+
+- the files may return two lists of snippets, the snippets in the first are all
+    added as regular snippets, while the snippets in the second will be added as
+    autosnippets (both are the defaults, if a snippet defines a different
+    `snippetType`, that will have preference)
+- snippets can also be appended to the global (only for these files! They are not
+    visible anywhere else) tables `ls_file_snippets` and `ls_file_autosnippets`.
+    This can be combined with a custom `snip_env` to define and add snippets with
+    one function-call:
+    >
+        ls.setup({
+          snip_env = {
+              s = function(...)
+                  local snip = ls.s(...)
+                  -- we can't just access the global `ls_file_snippets`, since it will be
+                  -- resolved in the environment of the scope in which it was defined.
+                  table.insert(getfenv(2).ls_file_snippets, snip)
+              end,
+              parse = function(...)
+                  local snip = ls.parser.parse(...)
+                  table.insert(getfenv(2).ls_file_snippets, snip)
+              end,
+              -- remaining definitions.
+              ...
+          },
+          ...
+        })
+    <
+    This is more flexible than the previous approach since the snippets don’t
+    have to be collected, they just have to be defined using the above `s` and
+    `parse`.
+
 
 As defining all of the snippet-constructors (`s`, `c`, `t`, …) in every file
 is rather cumbersome, luasnip will bring some globals into scope for executing
@@ -2644,6 +2676,9 @@ empty the snippets table and the caches of the lazy_load.
     (themselves lists, even if they have only one line), the `i`th string
     corresponding to the `i`th choice of the currently active `choiceNode`. If no
     `choiceNode` is active, an error is thrown.
+- `setup_snip_env()`: Adds the variables defined (during `setup`) in `snip_env`
+    to the callers environment.
+- `get_snip_env()`: Returns `snip_env`.
 
 
 Not covered in this section are the various node-constructors exposed by the

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -607,6 +607,9 @@ end
 local function setup_snip_env()
 	setfenv(2, vim.tbl_extend("force", _G, session.config.snip_env))
 end
+local function get_snip_env()
+	return session.config.snip_env
+end
 
 local function get_id_snippet(id)
 	return snippet_collection.get_id_snippet(id)
@@ -679,6 +682,7 @@ ls = {
 	get_snippets = get_snippets,
 	get_id_snippet = get_id_snippet,
 	setup_snip_env = setup_snip_env,
+	get_snip_env = get_snip_env,
 	clean_invalidated = clean_invalidated,
 	get_snippet_filetypes = util.get_snippet_filetypes,
 	s = snip_mod.S,

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -44,14 +44,19 @@ local function load_files(ft, files, add_opts)
 		local file_added_snippets = {}
 		local file_added_autosnippets = {}
 
-		setfenv(func, vim.tbl_extend(
-			"force",
-			-- extend the current(expected!) globals with the snip_env, and the two tables.
-			_G,
-			ls.get_snip_env(), {
-				ls_file_snippets = file_added_snippets,
-				ls_file_autosnippets = file_added_autosnippets
-			}) )
+		setfenv(
+			func,
+			vim.tbl_extend(
+				"force",
+				-- extend the current(expected!) globals with the snip_env, and the two tables.
+				_G,
+				ls.get_snip_env(),
+				{
+					ls_file_snippets = file_added_snippets,
+					ls_file_autosnippets = file_added_autosnippets,
+				}
+			)
+		)
 
 		local run_ok, file_snippets, file_autosnippets = pcall(func)
 		if not run_ok then


### PR DESCRIPTION
We can make the lua loader more flexible by not only loading snippets from the tables returned by each file, but by also loading snippets from some global (file-global via `setfenv`, because it shouldn't be visible from the outside, and every file needs its own) table.
Doing so allows us to, for example, add a new function to `snip_env`, which automatically adds snippets defined through it:
```lua
snip_env = {
	...,
	s = function(...)
		local snip = ls.s(...)
		-- getfenv is necessary here, just `ls.file_snippets` would immediately upvalue to `nil`.
		-- 2 to get the environment of the function calling this.
		table.insert(getfenv(2).ls_file_snippets, snip)
	end,
}
```
which I think is a pretty great improvement over the current "return it in a table"-approach.

I'm not sure yet how to best introduce this, afaict just replacing `s` in the default snip_env might break stuff.