### PR TITLE
fix: use stored snip for querying docstring in restoreNode (close #661)

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 November 22
+*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 November 27
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -191,7 +191,7 @@ end
 
 function RestoreNode:get_docstring()
 	if not self.docstring then
-		self.docstring = self.snip:get_docstring()
+		self.docstring = self.parent.snippet.stored[self.key]:get_docstring()
 	end
 	return self.docstring
 end

--- a/tests/integration/restore_spec.lua
+++ b/tests/integration/restore_spec.lua
@@ -53,14 +53,11 @@ describe("RestoreNode", function()
 		})
 
 		-- can use get_docstring on inactive restoreNode.
-		assert.are.same(
-			exec_lua("return ls.get_current_choices()"),
-			{
-				[[${${1:aaaa}}]],
-				[[${"${${1:aaaa}}"}]],
-				[[${'${${1:aaaa}}'}]]
-			}
-		)
+		assert.are.same(exec_lua("return ls.get_current_choices()"), {
+			[[${${1:aaaa}}]],
+			[[${"${${1:aaaa}}"}]],
+			[[${'${${1:aaaa}}'}]],
+		})
 
 		feed("bbbb")
 		exec_lua("ls.change_choice(1)")

--- a/tests/integration/restore_spec.lua
+++ b/tests/integration/restore_spec.lua
@@ -52,6 +52,16 @@ describe("RestoreNode", function()
 			{2:-- SELECT --}                                      |]],
 		})
 
+		-- can use get_docstring on inactive restoreNode.
+		assert.are.same(
+			exec_lua("return ls.get_current_choices()"),
+			{
+				[[${${1:aaaa}}]],
+				[[${"${${1:aaaa}}"}]],
+				[[${'${${1:aaaa}}'}]]
+			}
+		)
+
 		feed("bbbb")
 		exec_lua("ls.change_choice(1)")
 		screen:expect({


### PR DESCRIPTION
`self.snip` is not set (even actively removed, see `restoreNode:exit()`) for inactive restoreNodes. This can cause issues, as `get_docstring` might be called for an inactive restoreNode during `extras.select_choice`.
We can simply access the stored snippet through the parent-snippet.