### PR TITLE
fix(util): Path.expond current working directory expansion expanding any '.' prefixed path

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 November 17
+*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 November 20
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/path.lua
+++ b/lua/luasnip/util/path.lua
@@ -61,7 +61,7 @@ end
 
 function Path.expand(filepath)
 	local expanded =
-		filepath:gsub("^~", vim.env.HOME):gsub("^[.]", MYCONFIG_ROOT)
+		filepath:gsub("^~", vim.env.HOME):gsub("^[.]" .. sep, MYCONFIG_ROOT)
 	return uv.fs_realpath(expanded)
 end
 


### PR DESCRIPTION
## Issue
`Path.expand()` incorrectly expands all `.` in paths as `MYCONFIG_ROOT`.
- eg. `Path.expand(".local/snippets")` will be expanded as `MYCONFIG_ROOT .. "local/snippets"` which is unintended.
- expanding just `.` is ambiguous : are we using `.` as part of a hidden path or alias for the current working directory?

## Contents
Patch `Path.expand()` to only substitute `.` + OS file separator   for `MYCONFIG_ROOT`  instead of just `.`
