### PR TITLE
Fixed small typo in DOC.md

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -195,7 +195,7 @@ s({trig="trigger"}, {})
     LuaSnip on snippet expansion (and thus has access to the matched trigger and
 	captures), while `show_condition` is (should be) evaluated by the
 	completion-engine when scanning for available snippet candidates.
-  - `callbacks`: Contains functions that are called upon enterin/leaving a node
+  - `callbacks`: Contains functions that are called upon entering/leaving a node
     of this snippet.  
 	For example: to print text upon entering the _second_ node of a snippet,
 	`callbacks` should be set as follows:

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 November 27
+*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 December 01
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -261,7 +261,7 @@ The most direct way to define snippets is `s`:
         access to the matched trigger and captures), while `show_condition` is (should
         be) evaluated by the completion-engine when scanning for available snippet
         candidates.
-    - `callbacks`: Contains functions that are called upon enterin/leaving a node of
+    - `callbacks`: Contains functions that are called upon entering/leaving a node of
         this snippet. For example: to print text upon entering the _second_ node of a
         snippet, `callbacks` should be set as follows:
         >


### PR DESCRIPTION
Fixed type for:
`s(context, nodes, opts)`:
- `opts`:
  - `callbacks`: "enterin" -> "entering"