### PR TITLE
log: don't print a message on each startup

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2586,6 +2586,9 @@ Once this log grows too large (10MiB, currently not adjustable), it will be
 renamed to `luasnip.log.old`, and a new, empty log created in its place. If
 there already exists a `luasnip.log.old`, it will be deleted.
 
+`ls.log.ping()` can be used to verify the log is working correctly: it will
+print a short message to the log.
+
 # API-REFERENCE
 
 `require("luasnip")`:

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 December 11
+*luasnip.txt*           For NVIM v0.5.0          Last change: 2022 December 20
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -2572,6 +2572,9 @@ granularity, `"error"` the lowest, the default is `"warn"`.
 Once this log grows too large (10MiB, currently not adjustable), it will be
 renamed to `luasnip.log.old`, and a new, empty log created in its place. If
 there already exists a `luasnip.log.old`, it will be deleted.
+
+`ls.log.ping()` can be used to verify the log is working correctly: it will
+print a short message to the log.
 
 ==============================================================================
 25. API-REFERENCE                                      *luasnip-api-reference*

--- a/lua/luasnip/util/log.lua
+++ b/lua/luasnip/util/log.lua
@@ -100,9 +100,12 @@ function M.open()
 	vim.cmd(("tabnew %s"):format(log_location))
 end
 
--- manually append newline
-vim.loop.fs_write(luasnip_log_fd, "\n")
-log.info("New session: " .. os.date())
+-- to verify log is working.
+function M.ping()
+	log_line_append(("PONG  | pong! (%s)"):format(os.date()))
+end
+
+-- set default-loglevel.
 M.set_loglevel("warn")
 
 return M


### PR DESCRIPTION
Pretty straightforward, printing a message on each startup is not a good way to provide some quick way to verify that the log is working.
Instead, provide a `ping`-method which just appends something to the log.

I'll leave this up for a bit so whoever wants to, can comment on it.