### PR TITLE
add meta data for each `add_snippets` call

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2157,6 +2157,19 @@ require("luasnip.loaders").edit_snippet_files {
   end
 }
 ```
+* `target_snippet`: `table:snippet` If you have config option `store_meta_data`
+    set to true, then passing a target snippet to the edit function will jump
+    the cursor to the location where the target snippet is declared.
+    Currently, this only works for snippets that have been loaded through
+    `loaders.from_lua`. NOTE: the edit function only uses props that are
+    returned from `ls.get_context()` so you can either supply a full snip or
+    the stripped down variant returned from `get_context`.
+```lua
+require("luasnip.loaders").edit_snippet_files({
+  target_snippet = my_snippet,
+})
+```
+
 
 One comfortable way to call this function is registering it as a command:
 ```vim

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 January 08
+*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 January 11
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -2262,18 +2262,26 @@ there are multiple) the associated file to edit.
                 string.format("%s/%s.snippets", <PERSONAL_SNIPPETS_FOLDER>, ft) }
             }
           end
-
+        
           return {}
         end
         }
     <
-- `target_snippet`: `table:snippet` - If you have config option `store_meta_data`
-    set to true, then passing a target snippet to the edit function will jump
-    the cursor to the location where the target snippet is declared.
-    Currently, this only works for snippets that have been loaded through
-    `loaders.from_lua`. NOTE: the edit function only uses props that are
-    returned from `ls.get_context()` so you can either supply a full snip or
-    the stripped down variant returned from `get_context`.
+- `target_snippet`: `table:snippet` If you have config option `store_meta_data`
+    set to true, then passing a target snippet to the edit function will jump the
+    cursor to the location where the target snippet is declared. Currently, this
+    only works for snippets that have been loaded through `loaders.from_lua`. NOTE:
+    the edit function only uses props that are returned from `ls.get_context()` so
+    you can either supply a full snip or the stripped down variant returned from
+    `get_context`.
+
+
+>
+    require("luasnip.loaders").edit_snippet_files({
+      target_snippet = my_snippet,
+    })
+<
+
 
 One comfortable way to call this function is registering it as a command:
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -2117,12 +2117,18 @@ there are multiple) the associated file to edit.
                 string.format("%s/%s.snippets", <PERSONAL_SNIPPETS_FOLDER>, ft) }
             }
           end
-        
+
           return {}
         end
         }
     <
-
+- `target_snippet`: `table:snippet` - If you have config option `store_meta_data`
+    set to true, then passing a target snippet to the edit function will jump
+    the cursor to the location where the target snippet is declared.
+    Currently, this only works for snippets that have been loaded through
+    `loaders.from_lua`. NOTE: the edit function only uses props that are
+    returned from `ls.get_context()` so you can either supply a full snip or
+    the stripped down variant returned from `get_context`.
 
 One comfortable way to call this function is registering it as a command:
 

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -24,6 +24,7 @@ local defaults = {
 	region_check_events = "User None",
 	delete_check_events = "User None",
 	store_selection_keys = nil, -- Supossed to be the same as the expand shortcut
+	store_meta_data = false, -- For each snippet, eg. source path.
 	ext_opts = {
 		[types.textNode] = {
 			active = { hl_group = "LuasnipTextNodeActive" },

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -25,15 +25,15 @@ local defaults = {
 	delete_check_events = "User None",
 	store_selection_keys = nil, -- Supossed to be the same as the expand shortcut
 
-  -- TODO: generates a function which, given a filename produces the metadata
-  -- that shall badded to snippets loaded by one of the loaders.
-  --
-  -- @params table:
-  --        may contain: filename
-  --        ...
+	-- TODO: generates a function which, given a filename produces the metadata
+	-- that shall badded to snippets loaded by one of the loaders.
+	--
+	-- @params table:
+	--        may contain: filename
+	--        ...
 	store_meta_data = false, -- For each snippet, eg. source path.
 	store_meta_data2 = function(opts)
-	  return {}
+		return {}
 	end,
 
 	ext_opts = {

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -24,7 +24,18 @@ local defaults = {
 	region_check_events = "User None",
 	delete_check_events = "User None",
 	store_selection_keys = nil, -- Supossed to be the same as the expand shortcut
+
+  -- TODO: generates a function which, given a filename produces the metadata
+  -- that shall badded to snippets loaded by one of the loaders.
+  --
+  -- @params table:
+  --        may contain: filename
+  --        ...
 	store_meta_data = false, -- For each snippet, eg. source path.
+	store_meta_data2 = function(opts)
+	  return {}
+	end,
+
 	ext_opts = {
 		[types.textNode] = {
 			active = { hl_group = "LuasnipTextNodeActive" },

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -115,10 +115,13 @@ end
 
 -- TODO: MOVE TO OWN MODULE
 local function jump_to_snip(snip)
-	local meta_data = require("luasnip.session.snippet_collection").get_meta_data_by_snip_id(snip.id)
+	local meta_data =
+		require("luasnip.session.snippet_collection").get_meta_data_by_snip_id(
+			snip.id
+		)
 	local source = meta_data.source
-	if  source then
-	  vim.cmd("edit " .. source)
+	if source then
+		vim.cmd("edit " .. source)
 		if snip.name then
 			local feed_str = vim.api.nvim_replace_termcodes(
 				"/" .. snip.name .. "<CR>",

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -113,6 +113,27 @@ local function match(index, _match, _then, _else)
 	return F(func, index)
 end
 
+local function jump_to_snip(snip)
+	local meta_data = require("luasnip.session.snippet_collection").get_meta_data_by_snip_id(snip.id)
+	local source = meta_data.source
+	if  source then
+	  vim.cmd("edit " .. source)
+		if snip.name then
+			local feed_str = vim.api.nvim_replace_termcodes(
+				"/" .. snip.name .. "<CR>",
+				true,
+				true,
+				true
+			)
+			vim.fn.feedkeys(feed_str, "n")
+		end
+	else
+		print(
+			"No source found for id: " .. snip.id .. " with name: " .. snip.name
+		)
+	end
+end
+
 return {
 	lambda = lambda,
 	match = match,
@@ -161,4 +182,6 @@ return {
 	--alias
 	l = lambda,
 	m = match,
+
+	jump_to_snip = jump_to_snip,
 }

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -113,6 +113,7 @@ local function match(index, _match, _then, _else)
 	return F(func, index)
 end
 
+-- TODO: MOVE TO OWN MODULE
 local function jump_to_snip(snip)
 	local meta_data = require("luasnip.session.snippet_collection").get_meta_data_by_snip_id(snip.id)
 	local source = meta_data.source

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -56,6 +56,7 @@ end
 local function get_context(snip)
 	return {
 	  id = snip.id,
+	  meta_data = snip.meta_data,
 		name = snip.name,
 		trigger = snip.trigger,
 		description = snip.dscr,

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -705,7 +705,6 @@ local function add_snippets(ft, snippets, opts)
 	opts.refresh_notify = opts.refresh_notify or true
 	-- alternatively, "autosnippets"
 	opts.type = opts.type or "snippets"
-	opts.store_meta_data = session.config.store_meta_data
 
 	-- if ft is nil, snippets already has this format.
 	if ft then

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -55,8 +55,6 @@ end
 
 local function default_snip_info(snip)
 	return {
-	  id = snip.id,
-	  meta_data = snip.meta_data,
 		name = snip.name,
 		trigger = snip.trigger,
 		description = snip.dscr,

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -662,6 +662,7 @@ local function add_snippets(ft, snippets, opts)
 	opts.refresh_notify = opts.refresh_notify or true
 	-- alternatively, "autosnippets"
 	opts.type = opts.type or "snippets"
+	opts.store_meta_data = session.config.store_meta_data
 
 	-- if ft is nil, snippets already has this format.
 	if ft then

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -55,6 +55,7 @@ end
 
 local function get_context(snip)
 	return {
+	  id = snip.id,
 		name = snip.name,
 		trigger = snip.trigger,
 		description = snip.dscr,

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -28,6 +28,7 @@ local util = require("luasnip.util.util")
 local str_util = require("luasnip.util.str")
 local ls = require("luasnip")
 local log = require("luasnip.util.log").new("lua-loader")
+local session = require("luasnip.session")
 
 local M = {}
 
@@ -83,6 +84,8 @@ local function load_files(ft, files, add_opts)
 			ft,
 			file_snippets,
 			vim.tbl_extend("keep", {
+			  -- TODO: redo `source` here by passing the entire meta-table
+			  -- metadata =
 			  source = file,
 				type = "snippets",
 				key = "__snippets_" .. file,

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -84,9 +84,9 @@ local function load_files(ft, files, add_opts)
 			ft,
 			file_snippets,
 			vim.tbl_extend("keep", {
-			  -- TODO: redo `source` here by passing the entire meta-table
-			  -- metadata =
-			  source = file,
+				-- TODO: redo `source` here by passing the entire meta-table
+				-- metadata =
+				source = file,
 				type = "snippets",
 				key = "__snippets_" .. file,
 				-- prevent refresh here, will be done outside loop.
@@ -97,7 +97,7 @@ local function load_files(ft, files, add_opts)
 			ft,
 			file_autosnippets,
 			vim.tbl_extend("keep", {
-			  source = file,
+				source = file,
 				type = "autosnippets",
 				key = "__autosnippets_" .. file,
 				-- prevent refresh here, will be done outside loop.

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -83,6 +83,7 @@ local function load_files(ft, files, add_opts)
 			ft,
 			file_snippets,
 			vim.tbl_extend("keep", {
+			  source = file,
 				type = "snippets",
 				key = "__snippets_" .. file,
 				-- prevent refresh here, will be done outside loop.
@@ -93,6 +94,7 @@ local function load_files(ft, files, add_opts)
 			ft,
 			file_autosnippets,
 			vim.tbl_extend("keep", {
+			  source = file,
 				type = "autosnippets",
 				key = "__autosnippets_" .. file,
 				-- prevent refresh here, will be done outside loop.

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -20,7 +20,8 @@ local function default_edit(file)
 end
 
 local function edit_specific_snippet(data, edit)
-	local source =data.meta_data.source
+	local meta_data = require("luasnip.session.snippet_collection").get_meta_data_by_snip_id(data.id)
+	local source = meta_data.source
 	if  source then
 		edit(source)
 		if data.name then

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -25,6 +25,10 @@ local function edit_specific_snippet(data, edit)
 	local source_file = get_source_by_snip_id(data.id)
 	if source_file then
 		edit(source_file)
+		if data.name then
+	    local feed_str = vim.api.nvim_replace_termcodes("/"..data.name.."<CR>", true, true, true)
+			vim.fn.feedkeys(feed_str, "n")
+		end
 	else
 		print(
 			"No source found for id: " .. data.id .. " with name: " .. data.name

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -1,8 +1,6 @@
 local Cache = require("luasnip.loaders._caches")
 local util = require("luasnip.util.util")
 local Path = require("luasnip.util.path")
-local get_source_by_snip_id =
-	require("luasnip.session.snippet_collection").get_source_by_snip_id
 
 local M = {}
 
@@ -22,11 +20,17 @@ local function default_edit(file)
 end
 
 local function edit_specific_snippet(data, edit)
-	local source_file = get_source_by_snip_id(data.id)
+	local sc = require("luasnip.session.snippet_collection")
+	local source_file = sc.get_source_by_snip_id(data.id)
 	if source_file then
 		edit(source_file)
 		if data.name then
-	    local feed_str = vim.api.nvim_replace_termcodes("/"..data.name.."<CR>", true, true, true)
+			local feed_str = vim.api.nvim_replace_termcodes(
+				"/" .. data.name .. "<CR>",
+				true,
+				true,
+				true
+			)
 			vim.fn.feedkeys(feed_str, "n")
 		end
 	else

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -19,27 +19,6 @@ local function default_edit(file)
 	vim.cmd("edit " .. file)
 end
 
-local function edit_specific_snippet(data, edit)
-	local meta_data = require("luasnip.session.snippet_collection").get_meta_data_by_snip_id(data.id)
-	local source = meta_data.source
-	if  source then
-		edit(source)
-		if data.name then
-			local feed_str = vim.api.nvim_replace_termcodes(
-				"/" .. data.name .. "<CR>",
-				true,
-				true,
-				true
-			)
-			vim.fn.feedkeys(feed_str, "n")
-		end
-	else
-		print(
-			"No source found for id: " .. data.id .. " with name: " .. data.name
-		)
-	end
-end
-
 --- Quickly jump to snippet-file from any source for the active filetypes.
 ---@param opts table, options for this function:
 --- - format: fn(path:string, source_name:string) -> string|nil
@@ -56,11 +35,6 @@ function M.edit_snippet_files(opts)
 	local edit = opts.edit or default_edit
 	local extend = opts.extend or function()
 		return {}
-	end
-
-	if opts.target_snippet then
-		edit_specific_snippet(opts.target_snippet, edit)
-		return
 	end
 
 	local fts = util.get_snippet_filetypes()

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -20,10 +20,9 @@ local function default_edit(file)
 end
 
 local function edit_specific_snippet(data, edit)
-	local sc = require("luasnip.session.snippet_collection")
-	local source_file = sc.get_source_by_snip_id(data.id)
-	if source_file then
-		edit(source_file)
+	local source =data.meta_data.source
+	if  source then
+		edit(source)
 		if data.name then
 			local feed_str = vim.api.nvim_replace_termcodes(
 				"/" .. data.name .. "<CR>",

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -1,6 +1,8 @@
 local Cache = require("luasnip.loaders._caches")
 local util = require("luasnip.util.util")
 local Path = require("luasnip.util.path")
+local get_source_by_snip_id =
+	require("luasnip.session.snippet_collection").get_source_by_snip_id
 
 local M = {}
 
@@ -19,6 +21,17 @@ local function default_edit(file)
 	vim.cmd("edit " .. file)
 end
 
+local function edit_specific_snippet(data, edit)
+	local source_file = get_source_by_snip_id(data.id)
+	if source_file then
+		edit(source_file)
+	else
+		print(
+			"No source found for id: " .. data.id .. " with name: " .. data.name
+		)
+	end
+end
+
 --- Quickly jump to snippet-file from any source for the active filetypes.
 ---@param opts table, options for this function:
 --- - format: fn(path:string, source_name:string) -> string|nil
@@ -35,6 +48,11 @@ function M.edit_snippet_files(opts)
 	local edit = opts.edit or default_edit
 	local extend = opts.extend or function()
 		return {}
+	end
+
+	if opts.target_snippet then
+		edit_specific_snippet(opts.target_snippet, edit)
+		return
 	end
 
 	local fts = util.get_snippet_filetypes()

--- a/lua/luasnip/session/snippet_collection.lua
+++ b/lua/luasnip/session/snippet_collection.lua
@@ -137,27 +137,23 @@ local by_id = setmetatable({}, {
 local snippets_meta_data = {}
 local snip_id_to_meta_map = {}
 
-
 local function initialize_snippet_meta_data(opts)
-  -- If we use two funcs one for module and one for each snip then the following
-  -- block would obviously have to be modified to work with that
-  --
-  -- config.store_snippets_data = {
-  --     get_module_module_data = function(opts) return { source = opts.source },
-  --     for_each_snippet = function(ft, snip, opts) ... end
-  -- }
+	-- If we use two funcs one for module and one for each snip then the following
+	-- block would obviously have to be modified to work with that
+	--
+	-- config.store_snippets_data = {
+	--     get_module_module_data = function(opts) return { source = opts.source },
+	--     for_each_snippet = function(ft, snip, opts) ... end
+	-- }
 
-
-  -- func / table
+	-- func / table
 	if type(session.config.store_meta_data) == "function" then
-	  -- NOTE: use function is still a bit wip
-	  table.insert(snippets_meta_data, session.config.store_meta_data(opts))
+		-- NOTE: use function is still a bit wip
+		table.insert(snippets_meta_data, session.config.store_meta_data(opts))
 
-
-    -- if bool
+	-- if bool
 	elseif session.config.store_meta_data then
-	  table.insert(snippets_meta_data, { source = opts.source })
-
+		table.insert(snippets_meta_data, { source = opts.source })
 	end
 end
 
@@ -276,9 +272,8 @@ local current_id = 0
 -- opts.source = path to snip module which is assigned in
 -- `from_lua.load`
 function M.add_snippets(snippets, opts)
-
-  if session.config.store_meta_data then
-	  initialize_snippet_meta_data(opts)
+	if session.config.store_meta_data then
+		initialize_snippet_meta_data(opts)
 	end
 
 	for ft, ft_snippets in pairs(snippets) do
@@ -317,7 +312,7 @@ function M.add_snippets(snippets, opts)
 				-- TODO: (wip) following line would store single snippet specific data
 				--      we are not sure yet how this would be done but I leave it here
 				--      for reference
-			  -- snippets_meta_data[#snippets_meta_data].snippet_specific[snip.id] = session.config.store_meta_data.each_snippet(ft, snip, opts)
+				-- snippets_meta_data[#snippets_meta_data].snippet_specific[snip.id] = session.config.store_meta_data.each_snippet(ft, snip, opts)
 			end
 		end
 	end
@@ -361,7 +356,7 @@ function M.get_id_snippet(id)
 end
 
 function M.get_meta_data_by_snip_id(id)
-  return snippets_meta_data[snip_id_to_meta_map[id]]
+	return snippets_meta_data[snip_id_to_meta_map[id]]
 end
 
 return M

--- a/lua/luasnip/session/snippet_collection.lua
+++ b/lua/luasnip/session/snippet_collection.lua
@@ -1,3 +1,4 @@
+local session = require("luasnip.session")
 -- store snippets by some key.
 -- also ordered by filetype, eg.
 -- {
@@ -276,7 +277,7 @@ function M.add_snippets(snippets, opts)
 			table.insert(by_ft[snip.snippetType][ft], snip)
 			by_id[snip.id] = snip
 
-			if opts.source then
+			if opts.source and opts.store_meta_data then
 			  id_to_source_map[snip.id] = opts.source
 			end
 		end

--- a/lua/luasnip/session/snippet_collection.lua
+++ b/lua/luasnip/session/snippet_collection.lua
@@ -128,6 +128,10 @@ local by_id = setmetatable({}, {
 	__mode = "v",
 })
 
+-- This map allows user to get the source file of a specific snippet given its
+-- snippet id.
+local id_to_source_map = {}
+
 -- ft: any filetype, optional.
 function M.clear_snippets(ft)
 	if ft then
@@ -236,6 +240,7 @@ local function invalidate_snippets(snippets_by_ft)
 	M.clean_invalidated({ inv_limit = 100 })
 end
 
+
 local current_id = 0
 -- snippets like {ft1={<snippets>}, ft2={<snippets>}}, opts should be properly
 -- initialized with default values.
@@ -270,6 +275,10 @@ function M.add_snippets(snippets, opts)
 			table.insert(by_prio[snip.snippetType][snip.priority][ft], snip)
 			table.insert(by_ft[snip.snippetType][ft], snip)
 			by_id[snip.id] = snip
+
+			if opts.source then
+			  id_to_source_map[snip.id] = opts.source
+			end
 		end
 	end
 
@@ -309,6 +318,10 @@ end
 
 function M.get_id_snippet(id)
 	return by_id[id]
+end
+
+function M.get_source_by_snip_id(id)
+  return id_to_source_map[id]
 end
 
 return M

--- a/lua/luasnip/session/snippet_collection.lua
+++ b/lua/luasnip/session/snippet_collection.lua
@@ -134,6 +134,7 @@ local by_id = setmetatable({}, {
 -- table which then each snippet points to so that one can `jump-to-snip`
 -- by calling `loaders.edit_snippet_files({ target_snippet = snip_context_x })`
 local snippets_meta_data = {}
+local snip_id_to_meta_map = {}
 
 -- ft: any filetype, optional.
 function M.clear_snippets(ft)
@@ -286,7 +287,7 @@ function M.add_snippets(snippets, opts)
 			by_id[snip.id] = snip
 
 			if opts.source and opts.store_meta_data then
-				snip["meta_data"] = snippets_meta_data[#snippets_meta_data]
+				snip_id_to_meta_map[snip.id] = #snippets_meta_data
 			end
 		end
 	end
@@ -327,6 +328,10 @@ end
 
 function M.get_id_snippet(id)
 	return by_id[id]
+end
+
+function M.get_meta_data_by_snip_id(id)
+  return snippets_meta_data[snip_id_to_meta_map[id]]
 end
 
 return M


### PR DESCRIPTION
- implements basis for adding meta data to snippets w/new config param.
- improves `available()` to be a bit more versatile.
- adds `jump_to_snip()` under extras