### PR TITLE
parser: add camelcase and pascalcase-modifiers for lsp-snippets.

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 January 20
+*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 January 22
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/parser/ast_utils.lua
+++ b/lua/luasnip/util/parser/ast_utils.lua
@@ -310,7 +310,10 @@ local function apply_modifier(text, modifier)
 		-- this can't really be reached, since only correct and available
 		-- modifiers are parsed successfully
 		-- (https://github.com/L3MON4D3/LuaSnip/blob/5fbebf6409f86bc4b7b699c2c80745e1ed190c16/lua/luasnip/util/parser/neovim_parser.lua#L239-L245).
-		log.warn("Tried to apply unknown modifier `%s` while parsing snippet, recovering by applying identity instead.", modifier)
+		log.warn(
+			"Tried to apply unknown modifier `%s` while parsing snippet, recovering by applying identity instead.",
+			modifier
+		)
 		return text
 	end
 end

--- a/lua/luasnip/util/str.lua
+++ b/lua/luasnip/util/str.lua
@@ -135,7 +135,7 @@ M.vscode_string_modifiers = {
 	camelcase = function(str)
 		-- same as pascalcase, but first character lowercased.
 		return pascalcase(str):gsub("^.", string.lower)
-	end
+	end,
 }
 
 return M

--- a/lua/luasnip/util/str.lua
+++ b/lua/luasnip/util/str.lua
@@ -113,4 +113,29 @@ function M.sanitize(str)
 	return str:gsub("%\r", "")
 end
 
+-- string-operations implemented according to
+-- https://github.com/microsoft/vscode/blob/71c221c532996c9976405f62bb888283c0cf6545/src/vs/editor/contrib/snippet/browser/snippetParser.ts#L372-L415
+-- such that they can be used for snippet-transformations in vscode-snippets.
+local function capitalize(str)
+	-- uppercase first character.
+	return str:gsub("^.", string.upper)
+end
+local function pascalcase(str)
+	local pascalcased = ""
+	for match in str:gmatch("[a-zA-Z0-9]+") do
+		pascalcased = pascalcased .. capitalize(match)
+	end
+	return pascalcased
+end
+M.vscode_string_modifiers = {
+	upcase = string.upper,
+	downcase = string.lower,
+	capitalize = capitalize,
+	pascalcase = pascalcase,
+	camelcase = function(str)
+		-- same as pascalcase, but first character lowercased.
+		return pascalcase(str):gsub("^.", string.lower)
+	end
+}
+
 return M

--- a/tests/integration/parser_spec.lua
+++ b/tests/integration/parser_spec.lua
@@ -281,6 +281,39 @@ describe("Parser", function()
 		})
 	end)
 
+	local function check_case_transform(text, expected_map)
+		local supported_modifiers = {
+			upcase = true,
+			downcase = true,
+			capitalize = true,
+			camelcase = true,
+			pascalcase = true
+		}
+
+		for modifier, modified_expected in pairs(expected_map) do
+			if not supported_modifiers[modifier] then
+				error("unexpected key " .. modifier .. " in expected_map")
+			end
+
+			it("applies " .. modifier .. " correctly", function()
+				ls_helpers.setup_jsregexp()
+				ls_helpers.session_setup_luasnip()
+				local snip = ('"${1:%s} ${1/(.*)/${1:/%s}/}"'):format(text, modifier)
+
+				-- should be sufficient to test this.
+				ls_helpers.lsp_static_test(snip, { "test text Text " .. modified_expected })
+			end)
+		end
+	end
+
+	check_case_transform("test text Text", {
+		upcase = "TEST TEXT TEXT",
+		downcase = "test text text",
+		capitalize = "Test text Text",
+		camelcase = "testTextText",
+		pascalcase = "TestTextText"
+	})
+
 	it("modifies invalid $0 with choice.", function()
 		ls_helpers.session_setup_luasnip()
 		-- this can't work in luasnip.

--- a/tests/integration/parser_spec.lua
+++ b/tests/integration/parser_spec.lua
@@ -287,7 +287,7 @@ describe("Parser", function()
 			downcase = true,
 			capitalize = true,
 			camelcase = true,
-			pascalcase = true
+			pascalcase = true,
 		}
 
 		for modifier, modified_expected in pairs(expected_map) do
@@ -298,10 +298,16 @@ describe("Parser", function()
 			it("applies " .. modifier .. " correctly", function()
 				ls_helpers.setup_jsregexp()
 				ls_helpers.session_setup_luasnip()
-				local snip = ('"${1:%s} ${1/(.*)/${1:/%s}/}"'):format(text, modifier)
+				local snip = ('"${1:%s} ${1/(.*)/${1:/%s}/}"'):format(
+					text,
+					modifier
+				)
 
 				-- should be sufficient to test this.
-				ls_helpers.lsp_static_test(snip, { "test text Text " .. modified_expected })
+				ls_helpers.lsp_static_test(
+					snip,
+					{ "test text Text " .. modified_expected }
+				)
 			end)
 		end
 	end
@@ -311,7 +317,7 @@ describe("Parser", function()
 		downcase = "test text text",
 		capitalize = "Test text Text",
 		camelcase = "testTextText",
-		pascalcase = "TestTextText"
+		pascalcase = "TestTextText",
 	})
 
 	it("modifies invalid $0 with choice.", function()


### PR DESCRIPTION
Yeah, pretty much title.

Needs:
- [x] doc (doesn't really need any documentation)
- [x] tests