### PR TITLE
tests: implement better mechanism for making jsregexp unavailable.

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 January 22
+*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 January 23
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -11,6 +11,19 @@ function M.setup_jsregexp()
 	)
 end
 
+function M.prevent_jsregexp()
+	-- append default-path.
+	exec_lua([[
+		local old_require = require
+		require = function(modulename)
+			if modulename == "jsregexp" or modulename == "luasnip-jsregexp" then
+				error("Disabled by `prevent_jsregexp`")
+			end
+			return old_require(modulename)
+		end
+	]])
+end
+
 function M.session_setup_luasnip()
 	helpers.exec("set rtp+=" .. os.getenv("LUASNIP_SOURCE"))
 	helpers.exec(

--- a/tests/integration/parser_spec.lua
+++ b/tests/integration/parser_spec.lua
@@ -227,6 +227,7 @@ describe("Parser", function()
 	end)
 
 	it("just inserts the variable if jsregexp is not available.", function()
+		ls_helpers.prevent_jsregexp()
 		ls_helpers.session_setup_luasnip()
 		local snip = '"a${TM_LINE_INDEX/(.*)/asdf $1 asdf/g}a"'
 
@@ -259,6 +260,7 @@ describe("Parser", function()
 		})
 	end)
 	it("copies tabstop if jsregexp is not available.", function()
+		ls_helpers.prevent_jsregexp()
 		ls_helpers.session_setup_luasnip()
 		local snip = '"$1 a ${1/(.*)/asdf $1 asdf/} a"'
 


### PR DESCRIPTION
Noticed this myself just recently, this should make the tests for the fallbacks work as desired.