### PR TITLE
Move config reference to DOC.md, update links

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2747,6 +2747,54 @@ there already exists a `luasnip.log.old`, it will be deleted.
 `ls.log.ping()` can be used to verify the log is working correctly: it will
 print a short message to the log.
 
+# CONFIG-REFERENCE
+
+These are the settings you can provide to `luasnip.setup()`:
+
+- `history`: If true, Snippets that were exited can still be jumped back into.
+  As Snippets are not removed when their text is deleted, they have to be
+  removed manually via `LuasnipUnlinkCurrent` if `delete_check_events` is not
+  enabled (set to eg. `'TextChanged'`).
+- `update_events`: Choose which events trigger an update of the active nodes'
+  dependents. Default is just `'InsertLeave'`, `'TextChanged,TextChangedI'`
+  would update on every change.
+- `region_check_events`: Events on which to leave the current snippet if the
+  cursor is outside its' 'region'. Disabled by default, `'CursorMoved'`,
+  `'CursorHold'` or `'InsertEnter'` seem reasonable.
+- `delete_check_events`: When to check if the current snippet was deleted, and
+  if so, remove it from the history. Off by default, `'TextChanged'` (perhaps
+  `'InsertLeave'`, to react to changes done in Insert mode) should work just
+  fine (alternatively, this can also be mapped using
+  `<Plug>luasnip-delete-check`). 
+- `store_selection_keys`: Mapping for populating `TM_SELECTED_TEXT` and related
+  variables (not set by default).
+- `enable_autosnippets`: Autosnippets are disabled by default to minimize
+  performance penalty if unused. Set to `true` to enable.
+- `ext_opts`: Additional options passed to extmarks. Can be used to add
+  passive/active highlight on a per-node-basis (more info in DOC.md)
+- `parser_nested_assembler`: Override the default behaviour of inserting a
+  `choiceNode` containing the nested snippet and an empty `insertNode` for
+  nested placeholders (`"${1: ${2: this is nested}}"`). For an example
+  (behaviour more similar to vscode), check
+  [here](https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#imitate-vscodes-behaviour-for-nested-placeholders)
+- `ft_func`: Source of possible filetypes for snippets. Defaults to a function,
+  which returns `vim.split(vim.bo.filetype, ".", true)`, but check
+  [filetype_functions](lua/luasnip/extras/filetype_functions.lua) or [the
+  docs](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#filetype_functions)
+  for more options.
+- `load_ft_func`: Function to determine which filetypes belong to a given
+  buffer (used for `lazy_loading`). `fn(bufnr) -> filetypes (string[])`. Again,
+  there are some examples in
+  [filetype_functions](lua/luasnip/extras/filetype_functions.lua).
+- `snip_env`: The global environment will be extended with this table in some
+  places, eg. in files loaded by the
+  [lua-loader](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader).
+  Setting `snip_env` to `{ some_global = "a value" }` will add the global
+  variable `some_global` while evaluating these files. If you mind the
+  (probably) large number of generated warnings, consider adding the keys set
+  here to the globals recognized by lua-language-server or add 
+  `---@diagnostic disable: undefined-global` somewhere in the affected files.
+
 # API-REFERENCE
 
 `require("luasnip")`:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Here are some suggestions for getting started in either case:
   Of those two, SnipMate is definitely the more comfortable way of writing snippets.
 * **Lua snippets**: we suggest first watching or reading one of the introductory guides in the [Resources for new users](#resources-for-new-users) section below.
   After getting familiar with the basics, you should check out the important LuaSnip features in the following list:
-  * [`config`](https://github.com/L3MON4D3/LuaSnip#config): Notable: `region_check_events` for jumping to the end of snippets the cursor is no longer inside of,
+  * [`config`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#config-reference): Notable: `region_check_events` for jumping to the end of snippets the cursor is no longer inside of,
     `delete_check_events` for cleaning up snippets whose text was deleted,
     and `enable_autosnippets` to enable automatic snippet expansion.
   * [`extras`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#extras): This module contains many functions that make writing snippets
@@ -153,7 +153,7 @@ Note: instead of immediately reading the official documentation, you may want to
 - `:help luasnip.txt` is a plain text version of `DOC.md` available with Neovim's `:help` feature.
 - The file [`Examples/snippets.lua`](https://github.com/L3MON4D3/LuaSnip/blob/master/Examples/snippets.lua) contains many example snippets written in Lua—we highly recommend looking through (or better yet, `:luafile`ing) these example snippets before using LuaSnip's advanced features.
 - The [Wiki](https://github.com/L3MON4D3/LuaSnip/wiki) contains some useful LuaSnip extensions and some examples of advanced snippets and configs.
-- Configuration is documentated [at the bottom of this README](#config).
+- Configuration is documentated [in `DOC.md`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#config-reference) as well.
 
 【中文版】DOC in Chinese is [here](https://zjp-cn.github.io/neovim0.6-blogs/nvim/luasnip/doc1.html). 
 
@@ -164,22 +164,5 @@ Here are some LuaSnip videos and tutorials on the Web:
 - A [guide to writing snippets in Lua](https://www.ejmastnak.com/tutorials/vim-latex/luasnip.html) with LaTeX-themed GIFs and real-life examples by [@ejmastnak](https://github.com/ejmastnak)
 - A guide to [moving from UltiSnips to LuaSnip](https://github.com/evesdropper/dotfiles/tree/main/nvim/luasnip#readme) by [@evesdropper](https://github.com/evesdropper), also in a LaTeX context
 - An introductory LuaSnip [video tutorial for beginners](https://www.youtube.com/watch?v=ub0REXjhpmk) by Ziontee113
-
-# Config
-- `history`: If true, Snippets that were exited can still be jumped back into. As Snippets are not removed when their text is deleted, they have to be removed manually via `LuasnipUnlinkCurrent` if `delete_check_events` is not enabled (set to eg. `'TextChanged'`).
-- `update_events`: Choose which events trigger an update of the active nodes' dependents. Default is just `'InsertLeave'`, `'TextChanged,TextChangedI'` would update on every change.
-- `region_check_events`: Events on which to leave the current snippet if the cursor is outside its' 'region'. Disabled by default, `'CursorMoved'`, `'CursorHold'` or `'InsertEnter'` seem reasonable.
-- `delete_check_events`: When to check if the current snippet was deleted, and if so, remove it from the history. Off by default, `'TextChanged'` (perhaps `'InsertLeave'`, to react to changes done in Insert mode) should work just fine (alternatively, this can also be mapped using `<Plug>luasnip-delete-check`). 
-- `store_selection_keys`: Mapping for populating `TM_SELECTED_TEXT` and related variables (not set by default).
-- `enable_autosnippets`: Autosnippets are disabled by default to minimize performance penalty if unused. Set to `true` to enable.
-- `ext_opts`: Additional options passed to extmarks. Can be used to add passive/active highlight on a per-node-basis (more info in DOC.md)
-- `parser_nested_assembler`: Override the default behaviour of inserting a `choiceNode` containing the nested snippet and an empty `insertNode` for nested placeholders (`"${1: ${2: this is nested}}"`). For an example (behaviour more similar to vscode), check [here](https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#imitate-vscodes-behaviour-for-nested-placeholders)
-- `ft_func`: Source of possible filetypes for snippets. Defaults to a function, which returns `vim.split(vim.bo.filetype, ".", true)`, but check [filetype_functions](lua/luasnip/extras/filetype_functions.lua) or [the docs](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#filetype_functions) for more options.
-- `load_ft_func`: Function to determine which filetypes belong to a given buffer (used for `lazy_loading`). `fn(bufnr)
-  -> filetypes (string[])`. Again, there are some examples in [filetype_functions](lua/luasnip/extras/filetype_functions.lua).
-- `snip_env`: The global environment will be extended with this table in some places, eg. in files loaded by the [lua-loader](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader).  
-Setting `snip_env` to `{ some_global = "a value" }` will add the global variable `some_global` while evaluating these files.
-If you mind the (probably) large number of generated warnings, consider adding the keys set here to the globals
-recognized by lua-language-server or add `---@diagnostic disable: undefined-global` somewhere in the affected files.
 
 Inspired by [vsnip.vim](https://github.com/hrsh7th/vim-vsnip/)

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 January 27
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 February 02
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -54,7 +54,8 @@ Table of Contents                                  *luasnip-table-of-contents*
 22. EVENTS                                                    |luasnip-events|
 23. CLEANUP                                                  |luasnip-cleanup|
 24. Logging                                                  |luasnip-logging|
-25. API-REFERENCE                                      |luasnip-api-reference|
+25. CONFIG-REFERENCE                                |luasnip-config-reference|
+26. API-REFERENCE                                      |luasnip-api-reference|
 
 >
                 __                       ____
@@ -2722,7 +2723,58 @@ there already exists a `luasnip.log.old`, it will be deleted.
 print a short message to the log.
 
 ==============================================================================
-25. API-REFERENCE                                      *luasnip-api-reference*
+25. CONFIG-REFERENCE                                *luasnip-config-reference*
+
+These are the settings you can provide to `luasnip.setup()`:
+
+
+- `history`: If true, Snippets that were exited can still be jumped back into.
+    As Snippets are not removed when their text is deleted, they have to be
+    removed manually via `LuasnipUnlinkCurrent` if `delete_check_events` is not
+    enabled (set to eg. `'TextChanged'`).
+- `update_events`: Choose which events trigger an update of the active nodes’
+    dependents. Default is just `'InsertLeave'`, `'TextChanged,TextChangedI'`
+    would update on every change.
+- `region_check_events`: Events on which to leave the current snippet if the
+    cursor is outside its’ 'region'. Disabled by default, `'CursorMoved'`,
+    `'CursorHold'` or `'InsertEnter'` seem reasonable.
+- `delete_check_events`: When to check if the current snippet was deleted, and
+    if so, remove it from the history. Off by default, `'TextChanged'` (perhaps
+    `'InsertLeave'`, to react to changes done in Insert mode) should work just
+    fine (alternatively, this can also be mapped using
+    `<Plug>luasnip-delete-check`).
+- `store_selection_keys`: Mapping for populating `TM_SELECTED_TEXT` and related
+    variables (not set by default).
+- `enable_autosnippets`: Autosnippets are disabled by default to minimize
+    performance penalty if unused. Set to `true` to enable.
+- `ext_opts`: Additional options passed to extmarks. Can be used to add
+    passive/active highlight on a per-node-basis (more info in DOC.md)
+- `parser_nested_assembler`: Override the default behaviour of inserting a
+    `choiceNode` containing the nested snippet and an empty `insertNode` for
+    nested placeholders (`"${1: ${2: this is nested}}"`). For an example
+    (behaviour more similar to vscode), check
+    here <https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#imitate-vscodes-behaviour-for-nested-placeholders>
+- `ft_func`: Source of possible filetypes for snippets. Defaults to a function,
+    which returns `vim.split(vim.bo.filetype, ".", true)`, but check
+    filetype_functions <lua/luasnip/extras/filetype_functions.lua> or the
+    docs <https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#filetype_functions>
+    for more options.
+- `load_ft_func`: Function to determine which filetypes belong to a given
+    buffer (used for `lazy_loading`). `fn(bufnr) -> filetypes (string[])`. Again,
+    there are some examples in
+    filetype_functions <lua/luasnip/extras/filetype_functions.lua>.
+- `snip_env`: The global environment will be extended with this table in some
+    places, eg. in files loaded by the
+    lua-loader <https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader>.
+    Setting `snip_env` to `{ some_global = "a value" }` will add the global
+    variable `some_global` while evaluating these files. If you mind the
+    (probably) large number of generated warnings, consider adding the keys set
+    here to the globals recognized by lua-language-server or add
+    `---@diagnostic disable: undefined-global` somewhere in the affected files.
+
+
+==============================================================================
+26. API-REFERENCE                                      *luasnip-api-reference*
 
 `require("luasnip")`:
 


### PR DESCRIPTION
Took me a while to find what I could put into `luasnip.setup()`, and the end of the README is the _last_ place I would have looked normally. :) This just moves the config over to DOC.md so it'll also be in the vimdoc.