### PR TITLE
Extend default `snip_env` by default.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2800,14 +2800,31 @@ These are the settings you can provide to `luasnip.setup()`:
   buffer (used for `lazy_loading`). `fn(bufnr) -> filetypes (string[])`. Again,
   there are some examples in
   [filetype_functions](lua/luasnip/extras/filetype_functions.lua).
-- `snip_env`: The global environment will be extended with this table in some
-  places, eg. in files loaded by the
+- `snip_env`: The best way to author snippets in lua involves the
   [lua-loader](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader).
-  Setting `snip_env` to `{ some_global = "a value" }` will add the global
-  variable `some_global` while evaluating these files. If you mind the
-  (probably) large number of generated warnings, consider adding the keys set
-  here to the globals recognized by lua-language-server or add 
-  `---@diagnostic disable: undefined-global` somewhere in the affected files.
+  Unfortunately, this requires that snippets are defined in separate files,
+  which means that common definitions like `s`, `i`, `sn`, `t`, `fmt`, ... have
+  to be repeated in each of them, and that adding more customized functions to
+  ease writing snippets also requires some setup.  
+  `snip_env` can be used to insert variables into exactly the places where
+  lua-snippets are defined (for now only the file loaded by the lua-loader).  
+  Setting `snip_env` to `{ some_global = "a value" }` will add (amongst the
+  defaults stated at the beginning of this documentation) the global variable
+  `some_global` while evaluating these files.  
+  There are special keys which, when set in `snip_env` change the behaviour of
+  this option, and are not passed through to the lua-files:
+  * `__snip_env_behaviour`, string: either `"set"` or `"extend"` (default
+    `"extend"`)  
+    If this is `"extend"`, the variables defined in `snip_env` will complement (and
+    override) the defaults. If this is not desired, `"set"` will not include the
+    defaults, but only the variables set here.
+
+  One side-effect of this is that analysis-tools (most likely
+  `lua-language-server`) for lua will generate diagnostics for the usage of
+  undefined symbols. If you mind the (probably) large number of generated
+  warnings, consider adding the undefined globals to the globals recognized by
+  `lua-language-server` or add `---@diagnostic disable: undefined-global`
+  somewhere in the affected files.
 
 # API-REFERENCE
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 February 07
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 February 11
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -2796,14 +2796,30 @@ These are the settings you can provide to `luasnip.setup()`:
     buffer (used for `lazy_loading`). `fn(bufnr) -> filetypes (string[])`. Again,
     there are some examples in
     filetype_functions <lua/luasnip/extras/filetype_functions.lua>.
-- `snip_env`: The global environment will be extended with this table in some
-    places, eg. in files loaded by the
+- `snip_env`: The best way to author snippets in lua involves the
     lua-loader <https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#lua-snippets-loader>.
-    Setting `snip_env` to `{ some_global = "a value" }` will add the global
-    variable `some_global` while evaluating these files. If you mind the
-    (probably) large number of generated warnings, consider adding the keys set
-    here to the globals recognized by lua-language-server or add
-    `---@diagnostic disable: undefined-global` somewhere in the affected files.
+    Unfortunately, this requires that snippets are defined in separate files,
+    which means that common definitions like `s`, `i`, `sn`, `t`, `fmt`, … have
+    to be repeated in each of them, and that adding more customized functions to
+    ease writing snippets also requires some setup.
+    `snip_env` can be used to insert variables into exactly the places where
+    lua-snippets are defined (for now only the file loaded by the lua-loader).
+    Setting `snip_env` to `{ some_global = "a value" }` will add (amongst the
+    defaults stated at the beginning of this documentation) the global variable
+    `some_global` while evaluating these files.
+    There are special keys which, when set in `snip_env` change the behaviour of
+    this option, and are not passed through to the lua-files:
+    - `__snip_env_behaviour`, string: either `"set"` or `"extend"` (default
+        `"extend"`)
+        If this is `"extend"`, the variables defined in `snip_env` will complement (and
+        override) the defaults. If this is not desired, `"set"` will not include the
+        defaults, but only the variables set here.
+    One side-effect of this is that analysis-tools (most likely
+    `lua-language-server`) for lua will generate diagnostics for the usage of
+    undefined symbols. If you mind the (probably) large number of generated
+    warnings, consider adding the undefined globals to the globals recognized by
+    `lua-language-server` or add `---@diagnostic disable: undefined-global`
+    somewhere in the affected files.
 
 
 ==============================================================================

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -160,8 +160,13 @@ local function set_snip_env(target_conf_defaults, user_config)
 	end
 
 	-- either "set" or "extend", make sure it does not appear in the final snip_env.
-	local snip_env_behaviour = user_config.snip_env.__snip_env_behaviour ~= nil and user_config.snip_env.__snip_env_behaviour or "extend"
-	assert(snip_env_behaviour == "set" or snip_env_behaviour == "extend", "Unknown __snip_env_behaviour, `" .. snip_env_behaviour .. "`")
+	local snip_env_behaviour = user_config.snip_env.__snip_env_behaviour ~= nil
+			and user_config.snip_env.__snip_env_behaviour
+		or "extend"
+	assert(
+		snip_env_behaviour == "set" or snip_env_behaviour == "extend",
+		"Unknown __snip_env_behaviour, `" .. snip_env_behaviour .. "`"
+	)
 	user_config.snip_env.__snip_env_behaviour = nil
 
 	if snip_env_behaviour == "set" then

--- a/tests/data/lua-snippets/luasnippets2_env_test_extend/all.lua
+++ b/tests/data/lua-snippets/luasnippets2_env_test_extend/all.lua
@@ -1,0 +1,3 @@
+assert(s ~= nil, "defaults loaded")
+assert(_s ~= nil, "custom snip_env loaded")
+assert(i == true, "custom snip_env overrides defaults")

--- a/tests/data/lua-snippets/luasnippets2_env_test_set/all.lua
+++ b/tests/data/lua-snippets/luasnippets2_env_test_set/all.lua
@@ -1,0 +1,2 @@
+assert(s == nil, "defaults not loaded")
+assert(_s ~= nil, "custom snip_env loaded")

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -517,4 +517,45 @@ describe("snippets_basic", function()
 			{2:-- INSERT --}                                      |]],
 		})
 	end)
+
+	it("snip_env respects behaviour (set)", function()
+		exec_lua([[
+			ls.setup({
+				snip_env = {
+					__snip_env_behaviour = "set",
+					_s = true
+				}
+			})
+			-- remove this variable from global environment.
+			s = nil
+		]])
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_lua").load({paths="%s"})]],
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/lua-snippets/luasnippets2_env_test_set"
+			)
+		)
+	end)
+	it("snip_env respects behaviour (extend)", function()
+		exec_lua([[
+			ls.setup({
+				snip_env = {
+					__snip_env_behaviour = "extend",
+					_s = true,
+					-- default has i as function, check override.
+					i = true
+				}
+			})
+			-- remove this variable from global environment.
+			s = nil
+		]])
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_lua").load({paths="%s"})]],
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/lua-snippets/luasnippets2_env_test_extend"
+			)
+		)
+	end)
 end)


### PR DESCRIPTION
Otherwise making changes is kind of prohibitive, and it's so much fun to add helpful functions to `snip_env` :)

Needs:
- [x] doc
- [x] test