### PR TITLE
Move lazy_table to a separated module

### DIFF
--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -1,3 +1,4 @@
+local lazy_table = require("luasnip.util.lazy_table")
 local util = require("luasnip.util.util")
 local session = require("luasnip.session")
 local snippet_collection = require("luasnip.session.snippet_collection")
@@ -713,9 +714,11 @@ local ls_lazy = {
 	restore_node = function() return require("luasnip.nodes.restoreNode").R end,
 	parser = function() return require("luasnip.util.parser") end,
 	config = function() return require("luasnip.config") end,
+	get_snippet_filetypes = function() return require("luasnip.util.util").get_snippet_filetypes end,
 }
 
-ls = util.lazy_table({
+
+ls = lazy_table({
 	expand_or_jumpable = expand_or_jumpable,
 	expand_or_locally_jumpable = expand_or_locally_jumpable,
 	locally_jumpable = locally_jumpable,
@@ -749,7 +752,6 @@ ls = util.lazy_table({
 	setup_snip_env = setup_snip_env,
 	get_snip_env = get_snip_env,
 	clean_invalidated = clean_invalidated,
-	get_snippet_filetypes = util.get_snippet_filetypes,
 	session = session,
 	cleanup = cleanup,
 	refresh_notify = refresh_notify,

--- a/lua/luasnip/util/lazy_table.lua
+++ b/lua/luasnip/util/lazy_table.lua
@@ -1,0 +1,13 @@
+return function (lazy_t, lazy_defs)
+	return setmetatable(lazy_t, {
+		__index = function(t, k)
+			local v = lazy_defs[k]
+			if v then
+				local v_resolved = v()
+				rawset(t, k, v_resolved)
+				return v_resolved
+			end
+			return nil
+		end,
+	})
+end

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -579,20 +579,6 @@ local function indx_of(t, v)
 	return nil
 end
 
-local function lazy_table(lazy_t, lazy_defs)
-	return setmetatable(lazy_t, {
-		__index = function(t, k)
-			local v = lazy_defs[k]
-			if v then
-				local v_resolved = v()
-				rawset(t, k, v_resolved)
-				return v_resolved
-			end
-			return nil
-		end,
-	})
-end
-
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -638,5 +624,5 @@ return {
 	reverse_lookup = reverse_lookup,
 	nop = nop,
 	indx_of = indx_of,
-	lazy_table = lazy_table,
+	lazy_table = require("luasnip.util.lazy_table"),
 }


### PR DESCRIPTION
This was causing me random errors at startup, complaining about looped imports. I think it's related to the changes in the events so it only happens when they get executed after (or before?) the main import but I'm not sure.
