### PR TITLE
Fix a bug where the loading from_lua 

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 March 08
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 March 11
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -31,12 +31,10 @@ local M = {}
 
 local function load_files(ft, files, add_opts)
 	for _, file in ipairs(files) do
-		local func_string = path_mod.read_file(file)
-
-		local load_ok, func = pcall(loadstring, func_string)
-		if not load_ok then
+		local func, error_msg = loadfile(file)
+		if error_msg then
 			log.error("Failed to load %s\n: %s", file, func)
-			error("Failed to load " .. file .. "\n: " .. func)
+			error(string.format("Failed to load %s\n: %s", file, func))
 		end
 
 		-- the loaded file may add snippets to these tables, they'll be

--- a/lua/luasnip/nodes/multiSnippet.lua
+++ b/lua/luasnip/nodes/multiSnippet.lua
@@ -2,10 +2,14 @@ local snip_mod = require("luasnip.nodes.snippet")
 local node_util = require("luasnip.nodes.util")
 
 local VirtualSnippet = {}
-local VirtualSnippet_mt = {__index = VirtualSnippet}
+local VirtualSnippet_mt = { __index = VirtualSnippet }
 
-function VirtualSnippet:get_docstring() return self.snippet:get_docstring() end
-function VirtualSnippet:copy() return self.snippet:copy() end
+function VirtualSnippet:get_docstring()
+	return self.snippet:get_docstring()
+end
+function VirtualSnippet:copy()
+	return self.snippet:copy()
+end
 
 -- VirtualSnippet has all the fields for executing these methods.
 VirtualSnippet.matches = snip_mod.Snippet.matches
@@ -27,16 +31,18 @@ local function new_virtual_snippet(context, snippet, opts)
 	return o
 end
 
-
 local MultiSnippet = {}
-local MultiSnippet_mt = {__index = MultiSnippet}
+local MultiSnippet_mt = { __index = MultiSnippet }
 
 function MultiSnippet:retrieve_all()
 	return self.v_snips
 end
 
 local function new_multisnippet(contexts, nodes, opts)
-	assert(type(contexts) == "table", "multisnippet: expected contexts to be a table.")
+	assert(
+		type(contexts) == "table",
+		"multisnippet: expected contexts to be a table."
+	)
 	opts = opts or {}
 	local common_snip_opts = opts.common_opts or {}
 
@@ -45,16 +51,27 @@ local function new_multisnippet(contexts, nodes, opts)
 	-- create snippet without `context`-fields!
 	-- compare to `S` (aka `s`, the default snippet-constructor) in
 	-- `nodes/snippet.lua`.
-	local snippet = snip_mod._S(snip_mod.init_snippet_opts(common_snip_opts), nodes, common_snip_opts)
+	local snippet = snip_mod._S(
+		snip_mod.init_snippet_opts(common_snip_opts),
+		nodes,
+		common_snip_opts
+	)
 
 	local v_snips = {}
 	for _, context in ipairs(contexts) do
-		local complete_context = vim.tbl_extend("keep", node_util.wrap_context(context), common_context)
-		table.insert(v_snips, new_virtual_snippet(complete_context, snippet, common_snip_opts))
+		local complete_context = vim.tbl_extend(
+			"keep",
+			node_util.wrap_context(context),
+			common_context
+		)
+		table.insert(
+			v_snips,
+			new_virtual_snippet(complete_context, snippet, common_snip_opts)
+		)
 	end
 
 	local o = {
-		v_snips = v_snips
+		v_snips = v_snips,
 	}
 
 	setmetatable(o, MultiSnippet_mt)
@@ -63,5 +80,5 @@ local function new_multisnippet(contexts, nodes, opts)
 end
 
 return {
-	new_multisnippet = new_multisnippet
+	new_multisnippet = new_multisnippet,
 }

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -196,12 +196,19 @@ local function init_snippet_context(context, opts)
 	end
 
 	-- can't use `cond and ... or ...` since we have truthy values.
-	effective_context.wordTrig = util.ternary(context.wordTrig ~= nil, context.wordTrig, true)
-	effective_context.hidden = util.ternary(context.hidden ~= nil, context.hidden, false)
-	effective_context.regTrig = util.ternary(context.regTrig ~= nil, context.regTrig, false)
+	effective_context.wordTrig =
+		util.ternary(context.wordTrig ~= nil, context.wordTrig, true)
+	effective_context.hidden =
+		util.ternary(context.hidden ~= nil, context.hidden, false)
+	effective_context.regTrig =
+		util.ternary(context.regTrig ~= nil, context.regTrig, false)
 
-	effective_context.condition = context.condition or opts.condition or true_func
-	effective_context.show_condition = context.show_condition or opts.show_condition or true_func
+	effective_context.condition = context.condition
+		or opts.condition
+		or true_func
+	effective_context.show_condition = context.show_condition
+		or opts.show_condition
+		or true_func
 
 	-- init invalidated here.
 	-- This is because invalidated is a key that can be populated without any
@@ -1204,7 +1211,7 @@ end
 
 -- used in add_snippets to get variants of snippet.
 function Snippet:retrieve_all()
-	return {self}
+	return { self }
 end
 
 return {

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -142,7 +142,6 @@ local function wrap_context(context)
 	end
 end
 
-
 return {
 	subsnip_init_children = subsnip_init_children,
 	init_child_positions_func = init_child_positions_func,

--- a/tests/integration/multisnippet_spec.lua
+++ b/tests/integration/multisnippet_spec.lua
@@ -37,10 +37,12 @@ describe("multisnippets", function()
 			add_ms({"a", "b", "c", "d"}, {t"a or b or c or d"})
 		]])
 		local function test()
-			screen:expect{grid=[[
+			screen:expect({
+				grid = [[
 				a or b or c or d^                                  |
 				{0:~                                                 }|
-				{2:-- INSERT --}                                      |]]}
+				{2:-- INSERT --}                                      |]],
+			})
 		end
 
 		feed("ia<Plug>luasnip-expand-or-jump")
@@ -52,11 +54,15 @@ describe("multisnippets", function()
 		feed("<Esc>ccd<Plug>luasnip-expand-or-jump")
 		test()
 		-- can expand multiple at once.
-		feed("<Esc>cca<Plug>luasnip-expand-or-jump<Space>b<Plug>luasnip-expand-or-jump")
-		screen:expect{grid=[[
+		feed(
+			"<Esc>cca<Plug>luasnip-expand-or-jump<Space>b<Plug>luasnip-expand-or-jump"
+		)
+		screen:expect({
+			grid = [[
 			a or b or c or d a or b or c or d^                 |
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 
 		exec_lua([[
 			m_snip = ms({"a", "b", "c", "d"}, {t"a or b or c or d"})
@@ -73,10 +79,12 @@ describe("multisnippets", function()
 			add_ms({{trig="a",snippetType="autosnippet"}, "b", "c", "d"}, {t"a or b or c or d"})
 		]])
 		local function test()
-			screen:expect{grid=[[
+			screen:expect({
+				grid = [[
 				a or b or c or d^                                  |
 				{0:~                                                 }|
-				{2:-- INSERT --}                                      |]]}
+				{2:-- INSERT --}                                      |]],
+			})
 		end
 		-- autotriggered!
 		feed("ia")
@@ -95,10 +103,12 @@ describe("multisnippets", function()
 			add_ms({common={trig="a",snippetType="autosnippet"}, "b", "c", {snippetType="snippet"}}, {t"a or b or c or d"})
 		]])
 		local function test()
-			screen:expect{grid=[[
+			screen:expect({
+				grid = [[
 				a or b or c or d^                                  |
 				{0:~                                                 }|
-				{2:-- INSERT --}                                      |]]}
+				{2:-- INSERT --}                                      |]],
+			})
 		end
 		feed("ia<Plug>luasnip-expand-or-jump")
 		test()

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -686,35 +686,86 @@ describe("snippets_basic", function()
 		end
 	)
 
-	it("wordTrig, regTrig, hidden, name, description, docstring work and default correctly", function()
-		local snip_wt_val = {
-			{[[ s({trig="a", wordTrig = false}, { t"justsometext" }) ]], "wordTrig", "false"},
-			{[[ s({trig="a", wordTrig = true}, { t"justsometext" }) ]], "wordTrig", "true"},
-			{[[ s({trig="a"}, { t"justsometext" }) ]], "wordTrig", "true"},
+	it(
+		"wordTrig, regTrig, hidden, name, description, docstring work and default correctly",
+		function()
+			local snip_wt_val = {
+				{
+					[[ s({trig="a", wordTrig = false}, { t"justsometext" }) ]],
+					"wordTrig",
+					"false",
+				},
+				{
+					[[ s({trig="a", wordTrig = true}, { t"justsometext" }) ]],
+					"wordTrig",
+					"true",
+				},
+				{
+					[[ s({trig="a"}, { t"justsometext" }) ]],
+					"wordTrig",
+					"true",
+				},
 
-			{[[ s({trig="a", regTrig = false}, { t"justsometext" }) ]], "regTrig", "false"},
-			{[[ s({trig="a", regTrig = true}, { t"justsometext" }) ]], "regTrig", "true"},
-			{[[ s({trig="a"}, { t"justsometext" }) ]], "regTrig", "false"},
+				{
+					[[ s({trig="a", regTrig = false}, { t"justsometext" }) ]],
+					"regTrig",
+					"false",
+				},
+				{
+					[[ s({trig="a", regTrig = true}, { t"justsometext" }) ]],
+					"regTrig",
+					"true",
+				},
+				{
+					[[ s({trig="a"}, { t"justsometext" }) ]],
+					"regTrig",
+					"false",
+				},
 
-			{[[ s({trig="a", hidden = false}, { t"justsometext" }) ]], "hidden", "false"},
-			{[[ s({trig="a", hidden = true}, { t"justsometext" }) ]], "hidden", "true"},
-			{[[ s({trig="a"}, { t"justsometext" }) ]], "hidden", "false"},
+				{
+					[[ s({trig="a", hidden = false}, { t"justsometext" }) ]],
+					"hidden",
+					"false",
+				},
+				{
+					[[ s({trig="a", hidden = true}, { t"justsometext" }) ]],
+					"hidden",
+					"true",
+				},
+				{ [[ s({trig="a"}, { t"justsometext" }) ]], "hidden", "false" },
 
-			{[[ s({trig="a", name = "thename"}, { t"justsometext" }) ]], "name", [["thename"]]},
-			{[[ s({trig="a"}, { t"justsometext" }) ]], "name", [["a"]]},
+				{
+					[[ s({trig="a", name = "thename"}, { t"justsometext" }) ]],
+					"name",
+					[["thename"]],
+				},
+				{ [[ s({trig="a"}, { t"justsometext" }) ]], "name", [["a"]] },
 
-			{[[ s({trig="a", dscr = "thedescription"}, { t"justsometext" }) ]], "dscr", [[{"thedescription"}]]},
-			{[[ s({trig="a"}, { t"justsometext" }) ]], "dscr", [[{"a"}]]},
+				{
+					[[ s({trig="a", dscr = "thedescription"}, { t"justsometext" }) ]],
+					"dscr",
+					[[{"thedescription"}]],
+				},
+				{ [[ s({trig="a"}, { t"justsometext" }) ]], "dscr", [[{"a"}]] },
 
-			{[[ s({trig="a", docstring = "thedocstring"}, { t"justsometext" }) ]], "docstring", [[{"thedocstring"}]]},
-			{[[ s({trig="a"}, { t"justsometext" }) ]], "docstring", "nil"},
-		}
+				{
+					[[ s({trig="a", docstring = "thedocstring"}, { t"justsometext" }) ]],
+					"docstring",
+					[[{"thedocstring"}]],
+				},
+				{
+					[[ s({trig="a"}, { t"justsometext" }) ]],
+					"docstring",
+					"nil",
+				},
+			}
 
-		for _, pair in ipairs(snip_wt_val) do
-			assert.is_true(exec_lua(([[
+			for _, pair in ipairs(snip_wt_val) do
+				assert.is_true(exec_lua(([[
 				local snip = %s
 				return vim.deep_equal(snip.%s, %s)
 			]]):format(pair[1], pair[2], pair[3])))
+			end
 		end
-	end)
+	)
 end)

--- a/tests/unit/snippetProxy_spec.lua
+++ b/tests/unit/snippetProxy_spec.lua
@@ -37,7 +37,7 @@ describe("snippetProxy", function()
 		".priority",
 		':matches("asd")',
 		":get_docstring()",
-		":retrieve_all()"
+		":retrieve_all()",
 	}) do
 		no_inst_on_access_test(v)
 	end


### PR DESCRIPTION
Fix a bug where loading from_lua with invalid content provides an incorrect error message. This change also uses loadfile instead of loadstring.