### PR TITLE
Fix a loader bug: from_lua

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 March 08
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 March 11
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -31,12 +31,10 @@ local M = {}
 
 local function load_files(ft, files, add_opts)
 	for _, file in ipairs(files) do
-		local func_string = path_mod.read_file(file)
-
-		local load_ok, func = pcall(loadstring, func_string)
-		if not load_ok then
+		local func, error_msg = loadfile(file)
+		if error_msg then
 			log.error("Failed to load %s\n: %s", file, func)
-			error("Failed to load " .. file .. "\n: " .. func)
+			error(string.format("Failed to load %s\n: %s", file, func))
 		end
 
 		-- the loaded file may add snippets to these tables, they'll be


### PR DESCRIPTION
This fixes #810 

Fix an issue where loading from lua with invalid content provides an incorrect error message. This change also uses loadfile instead of loadstring.