### PR TITLE
Parameterise LuaJIT path on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,10 @@ nvim: | ${NVIM_PATH}
 
 OS:=$(shell uname)
 LUAJIT:=$(shell nvim -v | grep -o LuaJIT)
+LUAJIT_OSX_PATH?=/opt/homebrew/opt/luajit
 ifeq ($(LUAJIT),LuaJIT)
 	ifeq ($(OS),Darwin)
-		LUA_LDLIBS=-lluajit-5.1.2 -L/opt/homebrew/opt/luajit/lib/
+		LUA_LDLIBS=-lluajit-5.1.2 -L${LUAJIT_OSX_PATH}/lib/
 	else
 		LUA_LDLIBS=-lluajit-5.1
 	endif

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 March 11
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 March 13
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*


### PR DESCRIPTION
Allow using LuaJIT installed by non-brew methods