### PR TITLE
feat(LSP-Snippets): add basic support for `scope` field

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -10,13 +10,13 @@
                                                               \/_/
 ```
 
-Luasnip is a snippet-engine written entirely in lua. It has some great
+LuaSnip is a snippet engine written entirely in Lua. It has some great
 features like inserting text (`luasnip-function-node`) or nodes
 (`luasnip-dynamic-node`) based on user input, parsing LSP syntax and switching
 nodes (`luasnip-choice-node`).
 For basic setup like mappings and installing, check the README.
 
-All code-snippets in this help assume that
+All code snippets in this help assume the following:
 
 ```lua
 local ls = require("luasnip")
@@ -44,9 +44,10 @@ local conds = require("luasnip.extras.expand_conditions")
 local postfix = require("luasnip.extras.postfix").postfix
 local types = require("luasnip.util.types")
 local parse = require("luasnip.util.parser").parse_snippet
+local ms = ls.multi_snippet
 ```
 
-As noted in [the Lua section](#lua):
+As noted in the [Loaders-Lua](#lua)-section:
 
 > By default, the names from [`luasnip.config.snip_env`][snip-env-src] will be used, but it's possible to customize them by setting `snip_env` in `setup`. 
 
@@ -56,11 +57,11 @@ Furthermore, note that while this document assumes you have defined `ls` to be `
 
 Note: the source code of snippets in GIFs is actually
 [here](https://github.com/zjp-CN/neovim0.6-blogs/commit/2bff84ef53f8da5db9dcf2c3d97edb11b2bf68cd),
-and it's slightly different with the code below.
+and it's slightly different from the code below.
 
 <!-- panvimdoc-ignore-end -->
 
-# BASICS
+# Basics
 In LuaSnip, snippets are made up of `nodes`. These can contain either
 
 - static text (`textNode`)
@@ -73,12 +74,12 @@ In LuaSnip, snippets are made up of `nodes`. These can contain either
 - or nodes that can be generated based on input (`dynamicNode`).
 
 Snippets are always created using the `s(trigger:string, nodes:table)`-function.
-It is explained in more detail in [SNIPPETS](#snippets), but the gist is that
+It is explained in more detail in [Snippets](#snippets), but the gist is that
 it creates a snippet that contains the nodes specified in `nodes`, which will be
 inserted into a buffer if the text before the cursor matches `trigger` when
 `ls.expand` is called.  
 
-## Jump-index
+## Jump-Index
 Nodes that can be jumped to (`insertNode`, `choiceNode`, `dynamicNode`,
 `restoreNode`, `snippetNode`) all require a "jump-index" so luasnip knows the
 order in which these nodes are supposed to be visited ("jumped to").  
@@ -114,22 +115,32 @@ ls.add_snippets("all", {
 })
 ```
 It is possible to make snippets from one filetype available to another using
-`ls.filetype_extend`, more info on that [here](#api-reference).
+`ls.filetype_extend`, more info on that in the section [API](#api-2).
 
-# NODE
+# Node
 
 Every node accepts, as its last parameter, an optional table of arguments.
-There are some common ones (e.g. [`node_ext_opts`](#ext_opts)), and some that
-only apply to some nodes (`user_args` for both function and dynamicNode).
-These `opts` are only mentioned if they accept options that are not common to
-all nodes.
+There are some common ones (e.g. `node_ext_opts`, described in
+[ext_opts](#ext_opts)), and some that only apply to some nodes (`user_args`
+for both function and dynamicNode). These `opts` are only mentioned if they
+accept options that are not common to all nodes.
 
-## Node-Api:
+## Api
 
 - `get_jump_index()`: this method returns the jump-index of a node. If a node 
   doesn't have a jump-index, this method returns `nil` instead.
+- `get_buf_position(opts) -> {from_position, to_position}`:
+  Determines the range of the buffer occupied by this node. `from`- and
+  `to_position` are `row,column`-tuples, `0,0`-indexed (first line is 0, first
+  column is 0) and end-inclusive (see `:h api-indexing`, this is extmarks
+  indexing).
+  - `opts`: `table|nil`, options, valid keys are:
+    - `raw`: `bool`, default `true`. This can be used to switch between
+	  byte-columns (`raw=true`) and visual columns (`raw=false`). This makes a
+	  difference if the line contains characters represented by multiple bytes
+	  in UTF, for example `ÿ`.
 
-# SNIPPETS
+# Snippets
 
 The most direct way to define snippets is `s`:
 ```lua
@@ -173,12 +184,6 @@ s({trig="trigger"}, {})
     `ls.config.setup({ enable_autosnippets = true })` if you want to use this
     feature). If unset it depends on how the snippet is added of which type the
     snippet will be.
-
-- `nodes`: A single node, or a list of nodes. The nodes that make up the
-  snippet.
-
-- `opts`: A table, with the following valid keys:
-
   - `condition`: `fn(line_to_cursor, matched_trigger, captures) -> bool`, where
       - `line_to_cursor`: `string`, the line up to the cursor.
       - `matched_trigger`: `string`, the fully matched trigger (can be retrieved
@@ -186,20 +191,21 @@ s({trig="trigger"}, {})
       - `captures`: if the trigger is pattern, this list contains the
       	capture-groups. Again, could be computed from `line_to_cursor`, but we
       	already did so.
-
-	The snippet will be expanded only if this function returns true (default is
-	a function that just returns `true`).  
-    The function is called before the text on the line is modified in any way.
   - `show_condition`: `f(line_to_cursor) -> bool`.  
     - `line_to_cursor`: `string`, the line up to the cursor.  
 
-	This function is (should be) evaluated by completion-engines, indicating
+	This function is (should be) evaluated by completion engines, indicating
 	whether the snippet should be included in current completion candidates.  
     Defaults to a function returning `true`.  
     This is different from `condition` because `condition` is evaluated by
     LuaSnip on snippet expansion (and thus has access to the matched trigger and
 	captures), while `show_condition` is (should be) evaluated by the
-	completion-engine when scanning for available snippet candidates.
+	completion engines when scanning for available snippet candidates.
+
+- `nodes`: A single node or a list of nodes. The nodes that make up the
+  snippet.
+
+- `opts`: A table with the following valid keys:
   - `callbacks`: Contains functions that are called upon entering/leaving a node
     of this snippet.  
 	For example: to print text upon entering the _second_ node of a snippet,
@@ -215,21 +221,24 @@ s({trig="trigger"}, {})
     ```
     To register a callback for the snippets' own events, the key `[-1]` may
     be used.
-    More info on events [here](#events)
+    More info on events in [events](#events)
   - `child_ext_opts`, `merge_child_ext_opts`: Control `ext_opts` applied to the
-  	children of this snippet. More info on those [here](#ext_opts).
+    children of this snippet. More info on those in the
+    [ext_opts](#ext_opts)-section.
 
-The `opts`-table can also be passed to e.g. `snippetNode` and
-`indentSnippetNode`, but only `callbacks` and the `ext_opts`-related options are
-used there.
+The `opts`-table, as described here, can also be passed to e.g. `snippetNode`
+and `indentSnippetNode`.  
+It is also possible to set `condition` and `show_condition` (described in the
+documentation of the `context`-table) from `opts`. They should, however, not be
+set from both.
 
-### Snippet-Data
+## Data
 
 Snippets contain some interesting tables during runtime:
 
 - `snippet.env`: Contains variables used in the LSP-protocol, for example
   `TM_CURRENT_LINE` or `TM_FILENAME`. It's possible to add customized variables
-  here too, check [Environment Namespaces](#environment-namespaces)
+  here too, check [Variables-Environment Namespaces](#environment-namespaces)
 - `snippet.captures`: If the snippet was triggered by a pattern (`regTrig`), and
   the pattern contained capture-groups, they can be retrieved here.
 - `snippet.trigger`: The string that triggered this snippet. Again, only
@@ -242,7 +251,7 @@ which is passed to the function.
 (in most cases `parent == parent.snippet`, but the `parent` of the dynamicNode
 is not always the surrounding snippet, it could be a `snippetNode`).
 
-## Snippet-Api:
+## Api
 
 - `invalidate()`: call this method to effectively remove the snippet. The
   snippet will no longer be able to expand via `expand` or `expand_auto`. It
@@ -251,7 +260,7 @@ is not always the surrounding snippet, it could be a `snippetNode`).
   `ls.refresh_notify(ft)` after invalidating snippets.
 
 
-# TEXTNODE
+# TextNode
 
 The most simple kind of node; just text.
 ```lua
@@ -262,8 +271,9 @@ This snippet expands to
 ```
     Wow! Text!⎵
 ```
-Where ⎵ is the cursor.
-Multiline-strings can be defined by passing a table of lines rather than a
+where ⎵ is the cursor.
+
+Multiline strings can be defined by passing a table of lines rather than a
 string:
 
 ```lua
@@ -275,9 +285,9 @@ s("trigger", {
 `t(text, node_opts)`:
 
 - `text`: `string` or `string[]`
-- `node_opts`: `table`, see [here](#node)
+- `node_opts`: `table`, see [Node](#node)
 
-# INSERTNODE
+# InsertNode
 
 These Nodes contain editable text and can be jumped to- and from (e.g.
 traditional placeholders and tabstops, like `$1` in textmate-snippets).
@@ -298,7 +308,7 @@ s("trigger", {
 
 <!-- panvimdoc-ignore-end -->
 
-The InsertNodes are visited in order `1,2,3,..,n,0`.  
+The Insert Nodes are visited in order `1,2,3,..,n,0`.  
 (The jump-index 0 also _has_ to belong to an `insertNode`!)
 So the order of InsertNode-jumps is as follows:
 
@@ -323,7 +333,7 @@ The above snippet will behave as follows:
 2. After jumping forward, we will be at InsertNode 2.
 3. After jumping forward again, we will be at InsertNode 0.
 
-An **important** (because here luasnip differs from other snippet-engines) detail
+An **important** (because here Luasnip differs from other snippet engines) detail
 is that the jump-indices restart at 1 in nested snippets:
 ```lua
 s("trigger", {
@@ -343,7 +353,7 @@ s("trigger", {
 
 <!-- panvimdoc-ignore-end -->
 
-as opposed to e.g. the textmate-syntax, where tabstops are snippet-global:
+as opposed to e.g. the textmate syntax, where tabstops are snippet-global:
 ```snippet
 ${1:First jump} :: ${2: ${3:Third jump} : ${4:Fourth jump}}
 ```
@@ -353,17 +363,18 @@ textmate-snippet will expand correctly when parsed).
 
 `i(jump_index, text, node_opts)`
 
-- [`jump_index`](#jump-index): `number`, this determines when this node will be jumped to.
+- `jump_index`: `number`, this determines when this node will be jumped to (see
+  [Basics-Jump-Index](#jump-index)).
 - `text`: `string|string[]`, a single string for just one line, a list with >1
   entries for multiple lines.
   This text will be SELECTed when the `insertNode` is jumped into.
-- `node_opts`: `table`, see [here](#node)
+- `node_opts`: `table`, described in [Node](#node)
 
 If the `jump_index` is `0`, replacing its' `text` will leave it outside the
 `insertNode` (for reasons, check out Luasnip#110).
 
 
-# FUNCTIONNODE
+# FunctionNode
 
 Function Nodes insert text based on the content of other nodes using a
 user-defined function:
@@ -396,12 +407,12 @@ s("trig", {
 `f(fn, argnode_references, node_opts)`:
 - `fn`: `function(argnode_text, parent, user_args1,...,user_argsn) -> text`  
   - `argnode_text`: `string[][]`, the text currently contained in the argnodes
-    (e.g. `{{line1}, {line1, line2}}`). The snippet-indent will be removed from
+    (e.g. `{{line1}, {line1, line2}}`). The snippet indent will be removed from
     all lines following the first.
 
   - `parent`: The immediate parent of the `functionNode`.  
     It is included here as it allows easy access to some information that could
-    be useful in functionNodes (see [here](#snippet-data) for some examples).  
+    be useful in functionNodes (see [Snippets-Data](#data) for some examples).  
     Many snippets access the surrounding snippet just as `parent`, but if the
     `functionNode` is nested within a `snippetNode`, the immediate parent is a
     `snippetNode`, not the surrounding snippet (only the surrounding snippet
@@ -410,18 +421,18 @@ s("trig", {
   - `user_args`: The `user_args` passed in `opts`. Note that there may be multiple user_args
     (e.g. `user_args1, ..., user_argsn`).
   
-  `fn` shall return a string, which will be inserted as-is, or a table of
-  strings for multiline-string, here all lines following the first will be
+  `fn` shall return a string, which will be inserted as is, or a table of
+  strings for multiline strings, where all lines following the first will be
   prefixed with the snippets' indentation.
 
 - `argnode_references`: `node_reference[]|node_refernce|nil`.  
-  Either no, a single, or multiple [node-references](#node_reference).
+  Either no, a single, or multiple [Node Reference](#node-reference)s.
   Changing any of these will trigger a re-evaluation of `fn`, and insertion of
   the updated text.  
-  If no node-reference is passed, the `functionNode` is evaluated once upon
+  If no node reference is passed, the `functionNode` is evaluated once upon
   expansion.
 
-- `node_opts`: `table`, see [here](#node). One additional key is supported:
+- `node_opts`: `table`, see [Node](#node). One additional key is supported:
   - `user_args`: `any[]`, these will be passed to `fn` as `user_arg1`-`user_argn`.
     These make it easier to reuse similar functions, for example a functionNode
     that wraps some text in different delimiters (`()`, `[]`, ...).
@@ -449,7 +460,7 @@ s("trig", {
 
 **Examples**:
 
-- Use captures from the regex-trigger using a functionNode:
+- Use captures from the regex trigger using a functionNode:
 
   ```lua
   s({trig = "b(%d)", regTrig = true},
@@ -464,7 +475,7 @@ s("trig", {
   
   <!-- panvimdoc-ignore-end -->
 
-- `argnodes_text` during function-evaluation:
+- `argnodes_text` during function evaluation:
 
   ```lua
   s("trig", {
@@ -497,7 +508,7 @@ s("trig", {
   
   <!-- panvimdoc-ignore-end -->
 
-- [`absolute_indexer`](#absolute_indexer):
+- [Absolute Indexer](#absolute-indexer):
 
   ```lua
   s("trig", {
@@ -516,27 +527,28 @@ s("trig", {
   <!-- panvimdoc-ignore-end -->
 
 If the function only performs simple operations on text, consider using
-the `lambda` from [`luasnip.extras`](#extras)
+the `lambda` from `luasnip.extras` (See [Extras-Lambda](#lambda))
 
-## NODE_REFERENCE
-Node-references are used to refer to other nodes in various parts of luasnip's
+# Node Reference
+Node references are used to refer to other nodes in various parts of luasnip's
 API.  
 For example, argnodes in functionNode, dynamicNode or lambda are
-node-references.  
+node references.  
 These references can be either of:
   - `number`: the jump-index of the node.
   This will be resolved relative to the parent of the node this is passed to.
   (So, only nodes with the same parent can be referenced. This is very easy to
   grasp, but also limiting)
-  - [`absolute_indexer`](#absolute_indexer): the absolute position of the
-  node. This will come in handy if the referred-to node is not in the same
-  snippet/snippetNode as the one this node-reference is passed to.
-  - `node`: just the node. Usage of this is discouraged, since it can lead to
-  subtle errors (for example if the node passed here is captured in a closure
-  and therefore not copied with the remaining tables in the snippet (there's a
-  big comment about just this in commit 8bfbd61)).
+  - `absolute_indexer`: the absolute position of the
+  node. This will come in handy if the node that is being referred to is not in the same
+  snippet/snippetNode as the one the node reference is passed to (More in
+  [Absolute Indexer](#absolute-indexer)).
+  - `node`: just the node. Usage of this is discouraged since it can lead to
+  subtle errors (for example, if the node passed here is captured in a closure
+  and therefore not copied with the remaining tables in the snippet; there's a
+  big comment about just this in commit 8bfbd61).
 
-# CHOICENODE
+# ChoiceNode
 
 ChoiceNodes allow choosing between multiple nodes.
 
@@ -556,36 +568,37 @@ ChoiceNodes allow choosing between multiple nodes.
 
 `c(jump_index, choices, node_opts)`
 
-- [`jump_index`](#jump-index): `number`, since choiceNodes can be jumped to, they need their
-  jump-indx.
+- `jump_index`: `number`, since choiceNodes can be jumped to, they need a
+  jump-index (Info in [Basics-Jump-Index](#jump-index)).
 - `choices`: `node[]|node`, the choices. The first will be initialliy active.
   A list of nodes will be turned into a `snippetNode`.
 - `node_opts`: `table`. `choiceNode` supports the keys common to all nodes
-  described [here](#node), and one additional key:
+  described in [Node](#node), and one additional key:
   - `restore_cursor`: `false` by default. If it is set, and the node that was
-    being edited also appears in the switched-to choice (can be the case if a
+    being edited also appears in the switched to choice (can be the case if a
     `restoreNode` is present in both choice) the cursor is restored relative to
     that node.  
     The default is `false` as enabling might lead to decreased performance. It's
-    possible to override the default by wrapping the `choiceNode`-constructor
+    possible to override the default by wrapping the `choiceNode` constructor
     in another function that sets `opts.restore_cursor` to `true` and then using
     that to construct `choiceNode`s:
-      ```lua
-      local function restore_cursor_choice(pos, choices, opts)
-          if opts then
-              opts.restore_cursor = true
-          else
-              opts = {restore_cursor = true}
-          end
-          return c(pos, choices, opts)
-      end
-      ```
+    ```lua
+    local function restore_cursor_choice(pos, choices, opts)
+        if opts then
+            opts.restore_cursor = true
+        else
+            opts = {restore_cursor = true}
+        end
+        return c(pos, choices, opts)
+    end
+    ```
 
 Jumpable nodes that normally expect an index as their first parameter don't
 need one inside a choiceNode; their jump-index is the same as the choiceNodes'.
 
 As it is only possible (for now) to change choices from within the choiceNode,
-make sure that all of the choices have some place for the cursor to stop at!  
+make sure that all of the choices have some place for the cursor to stop at! 
+
 This means that in `sn(nil, {...nodes...})` `nodes` has to contain e.g. an
 `i(1)`, otherwise luasnip will just "jump through" the nodes, making it
 impossible to change the choice.
@@ -601,7 +614,8 @@ c(1, {
 
 The active choice for a choiceNode can be changed by either calling one of
 `ls.change_choice(1)` (forwards) or `ls.change_choice(-1)` (backwards), or by
-calling `ls.set_choice(choice_indx)`.  
+calling `ls.set_choice(choice_indx)`.
+
 One way to easily interact with choiceNodes is binding `change_choice(1/-1)` to
 keys:
 
@@ -613,10 +627,11 @@ vim.api.nvim_set_keymap("i", "<C-p>", "<Plug>luasnip-prev-choice", {})
 vim.api.nvim_set_keymap("s", "<C-p>", "<Plug>luasnip-prev-choice", {})
 ```
 
-Apart from this, there is also a [picker](#select_choice) where no cycling is necessary and any
-choice can be selected right away, via `vim.ui.select`.
+Apart from this, there is also a picker (see [select_choice](#select_choice)
+where no cycling is necessary and any choice can be selected right away, via
+`vim.ui.select`.
 
-# SNIPPETNODE
+# SnippetNode
 
 SnippetNodes directly insert their contents into the surrounding snippet.
 This is useful for `choiceNode`s, which only accept one child, or
@@ -642,18 +657,19 @@ a jump-index.
 
 `sn(jump_index, nodes, node_opts)`
 
-- [`jump_index`](#jump-index): `number`, the usual.
+- `jump_index`: `number`, the usual [Jump-Index](#jump-index).
 - `nodes`: `node[]|node`, just like for `s`.  
   Note that `snippetNode`s don't accept an `i(0)`, so the jump-indices of the nodes
   inside them have to be in `1,2,...,n`.
-- `node_opts`: `table`: again, all [common](#node) keys are supported, but also
+- `node_opts`: `table`: again, the keys common to all nodes (documented in
+  [Node](#node)) are supported, but also
   - `callbacks`,
   - `child_ext_opts` and
   - `merge_child_ext_opts`,
 
-  which are further explained in [`SNIPPETS`](#snippets).
+  which are further explained in [Snippets](#snippets).
 
-# INDENTSNIPPETNODE
+# IndentSnippetNode
 
 By default, all nodes are indented at least as deep as the trigger. With these
 nodes it's possible to override that behaviour:
@@ -677,9 +693,9 @@ s("isn", {
 
 Indent is only applied after linebreaks, so it's not possible to remove indent
 on the line where the snippet was triggered using `ISN` (That is possible via
-regex-triggers where the entire line before the trigger is matched).
+regex triggers where the entire line before the trigger is matched).
 
-Another nice usecase for `ISN` is inserting text, e.g. `//` or some other comment-
+Another nice use case for `ISN` is inserting text, e.g. `//` or some other comment
 string before the nodes of the snippet:
 
 ```lua
@@ -696,56 +712,58 @@ s("isn2", {
 
 Here the `//` before `This is` is important, once again, because indent is only
 applied after linebreaks.
+
 To enable such usage, `$PARENT_INDENT` in the indentstring is replaced by the
-parent's indent (duh).
+parent's indent.
 
 `isn(jump_index, nodes, indentstring, node_opts)`
 
-All of these except `indentstring` are exactly the same as [`snippetNode`](#snippetnode).
+All of these parameters except `indentstring` are exactly the same as in
+[SnippetNode](#snippetnode).
 
 - `indentstring`: `string`, will be used to indent the nodes inside this
   `snippetNode`.  
   All occurences of `"$PARENT_INDENT"` are replaced with the actual indent of
   the parent.
 
-# DYNAMICNODE
+# DynamicNode
 
 Very similar to functionNode, but returns a snippetNode instead of just text,
 which makes them very powerful as parts of the snippet can be changed based on
-user-input.
+user input.
 
 `d(jump_index, function, node-references, opts)`:
 
-- [`jump_index`](#jump-index): `number`, just like all jumpable nodes, its' position in the
-   jump-list.
+- `jump_index`: `number`, just like all jumpable nodes, its' position in the
+   jump-list ([Basics-Jump-Index](#jump-index)).
 - `function`: `fn(args, parent, old_state, user_args) -> snippetNode`
    This function is called when the argnodes' text changes. It should generate
-   and returns (wrapped inside a `snippetNode`) nodes, these will be inserted at
-   the dynamicNodes place.  
+   and return (wrapped inside a `snippetNode`) nodes, which will be inserted at
+   the dynamicNode's place.  
    `args`, `parent` and `user_args` are also explained in
-   [FUNCTIONNODE](#functionnode)
+   [FunctionNode](#functionnode)
    - `args`: `table of text` (`{{"node1line1", "node1line2"}, {"node2line1"}}`)
      from nodes the `dynamicNode` depends on.
    - `parent`: the immediate parent of the `dynamicNode`.
-   - `old_state`: a user-defined table. This table may contain anything, its
+   - `old_state`: a user-defined table. This table may contain anything; its
    	 intended usage is to preserve information from the previously generated
-   	 `snippetNode`: If the `dynamicNode` depends on other nodes it may be
+   	 `snippetNode`. If the `dynamicNode` depends on other nodes, it may be
    	 reconstructed, which means all user input (text inserted in `insertNodes`,
-   	 changed choices) to the previous dynamicNode is lost.  
+   	 changed choices) to the previous `dynamicNode` is lost.  
      The `old_state` table must be stored in `snippetNode` returned by
      the function (`snippetNode.old_state`).  
      The second example below illustrates the usage of `old_state`.
-   - `user_args`: passed through from `dynamicNode`-opts, may be more than one
+   - `user_args`: passed through from `dynamicNode`-opts; may have more than one
    	 argument.
 - `node_references`: `node_reference[]|node_references|nil`,
-  [References](#node_reference) to the nodes the dynamicNode depends on: if any
-  of these trigger an update (for example if the text inside them
+  [Node References](#node-reference) to the nodes the dynamicNode depends on: if any
+  of these trigger an update (for example, if the text inside them
   changes), the `dynamicNode`s' function will be executed, and the result
-  inserted at the `dynamicNodes` place.  
+  inserted at the `dynamicNode`s place.  
   (`dynamicNode` behaves exactly the same as `functionNode` in this regard).
 
-- `opts`: In addition to the [usual](#node) keys, there is, again, 
-  - `user_args`, which is described in [FUNCTIONNODE](#functionnode).
+- `opts`: In addition to the common [Node](#node)-keys, there is, again, 
+  - `user_args`, which is described in [FunctionNode](#functionnode).
 
 **Examples**:
 
@@ -772,7 +790,8 @@ s("trig", {
 
 <!-- panvimdoc-ignore-end -->
 
-This snippet makes use of `old_state` to count the number of updates.  
+This snippet makes use of `old_state` to count the number of updates.
+
 To store/restore values generated by the `dynamicNode` or entered into
 `insert/choiceNode`, consider using the shortly-introduced `restoreNode` instead
 of `old_state`.
@@ -812,9 +831,9 @@ ls.add_snippets("all",
 As with `functionNode`, `user_args` can be used to reuse similar `dynamicNode`-
 functions.
 
-# RESTORENODE
+# RestoreNode
 
-This node can store and restore a snippetNode as-is. This includes changed
+This node can store and restore a snippetNode as is. This includes changed
 choices and changed text. Its' usage is best demonstrated by an example:
 
 ```lua
@@ -842,7 +861,7 @@ Here the text entered into `user_text` is preserved upon changing choice.
 
 `r(jump_index, key, nodes, node_opts)`:
 
-- [`jump_index`](#jump-index), when to jump to this node.
+- `jump_index`, when to jump to this node.
 - `key`, `string`: `restoreNode`s with the same key share their content.
 - `nodes`, `node[]|node`: the content of the `restoreNode`.  
   Can either be a single node, or a table of nodes (both of which will be
@@ -900,7 +919,7 @@ s("rest", {
 ```
 Now the entered text is stored.
 
-`RestoreNode`s indent is not influenced by `indentSnippetNodes` right now. If
+`restoreNode`s indent is not influenced by `indentSnippetNodes` right now. If
 that really bothers you feel free to open an issue.
 
 <!-- panvimdoc-ignore-start -->
@@ -909,10 +928,10 @@ that really bothers you feel free to open an issue.
 
 <!-- panvimdoc-ignore-end -->
 
-# ABSOLUTE_INDEXER
+# Absolute Indexer
 
-A more capable way of [referencing nodes](#node_reference)!  
-Using only [`jump indices`](#jump-index), accessing an outer `i(1)` isn't possible
+The most capable way of referencing nodes ([Node Reference](#node-reference)).  
+Using only a [Jump-Index](#jump-index), accessing an outer `i(1)` isn't possible
 from inside e.g. a snippetNode, since only nodes with the same parent can be
 referenced (jump indices are interpreted relative to the parent of the node
 that's passed the reference).  
@@ -989,11 +1008,75 @@ to be accessed as `ai[restoreNodeIndx][0][1]`.
 ai[1][2][3] == ai(1, 2, 3) == ai{1, 2, 3}
 ```
 
-# EXTRAS
+# MultiSnippet
+
+There are situations where it might be comfortable to access a snippet in
+different ways. For example, one might want to enable auto-triggering in regions
+where the snippets usage is common, while leaving it manual-only in others.  
+This is where `ms` should be used: A single snippet can be associated with multiple
+`context`s (the `context`-table determines the conditions under which a snippet
+may be triggered).  
+This has the advantage (compared with just registering copies) that all
+`context`s are backed by a single snippet, and not multiple, and it's (at least
+should be :D) more comfortable to use.
+
+`ms(contexts, nodes, opts) -> addable`:
+
+- `contexts`: table containing list of `contexts`, and some keywords.  
+  `context` are described in [Snippets](#snippets), here they may also be tables
+  or strings.  
+  So far, there is only one valid keyword:
+  - `common`: Accepts yet another context.  
+    The options in `common` are applied to (but don't override) the other
+    contexts specified in `contexts`.
+- `nodes`: List of nodes, exactly like in [Snippets](#snippets).
+- `opts`: Table, options for this function:
+  - `common_opts`: The snippet-options (see also [Snippets](#snippets)) applied
+    to the snippet generated from `nodes`.
+
+The returned object is an `addable`, something which can be passed to
+`add_snippets`, or returned from the lua-loader.
+
+**Examples**:
+```lua
+ls.add_snippets("all", {
+    ms({"a", "b"}, {t"a or b"})
+})
+```
+
+```lua
+ls.add_snippets("all", {
+    ms({
+        common = {snippetType = "autosnippet"},
+        "a",
+        "b"
+    }, {
+        t"a or b (but autotriggered!!)"
+    })
+})
+```
+
+```lua
+ls.add_snippets("all", {
+    ms({
+        common = {snippetType = "autosnippet"},
+        {trig = "a", snippetType = "snippet"},
+        "b",
+        {trig = "c", condition = function(line_to_cursor)
+            return line_to_cursor == ""
+        end}
+    }, {
+        t"a or b (but autotriggered!!)"
+    })
+})
+```
+
+# Extras
 
 ## Lambda
-A shortcut for `functionNode`s that only do very basic string-
-manipulation.  
+A shortcut for `functionNode`s that only do very basic string
+manipulation.
+
 `l(lambda, argnodes)`:
 
 - `lambda`: An object created by applying string-operations to `l._n`, objects
@@ -1001,10 +1084,10 @@ manipulation.
   For example: 
   - `l._1:gsub("a", "e")` replaces all occurences of "a" in the text of the
   first argnode with "e", or
-  - `l._1 .. l._2` concats text of the first and second argnode.
+  - `l._1 .. l._2` concatenates text of the first and second argnode.
   If an argnode contains multiple lines of text, they are concatenated with
   `"\n"` prior to any operation.  
-- `argnodes`, [`node-references`](#node_reference), just like in function- and
+- `argnodes`, a [Node Reference](#node-reference), just like in function- and
   dynamicNode.
 
 There are many examples for `lambda` in `Examples/snippets.lua`
@@ -1012,18 +1095,18 @@ There are many examples for `lambda` in `Examples/snippets.lua`
 ## Match
 `match` can insert text based on a predicate (again, a shorthand for `functionNode`).
 
-`match(argnodes, condition, then, else)`, where
+`match(argnodes, condition, then, else)`:
 
-* `argnode`: A single [`node-reference`](#node_reference). May not be nil, or
+* `argnode`: A single [Node Reference](#node-reference). May not be nil, or
 	a table.
 * `condition` may be either of
-  * `string`: interpreted as a lua-pattern. Matched on the `\n`-joined (in case
+  * `string`: interpreted as a lua pattern. Matched on the `\n`-joined (in case
     it's multiline) text of the first argnode (`args[1]:match(condition)`).
   * `function`: `fn(args, snip) -> bool`: takes the same parameters as the
     `functionNode`-function, any value other than nil or false is interpreted
     as a match.
   * `lambda`: `l._n` is the `\n`-joined text of the nth argnode.  
-    Useful if string-manipulations have to be performed before the string is matched.  
+    Useful if string manipulations have to be performed before the string is matched.  
     Should end with `match`, but any other truthy result will be interpreted
     as matching.
 
@@ -1100,7 +1183,7 @@ Examples:
 Inserts the text of the passed node.
 
 `rep(node_reference)`
-- `node_reference`, a single [`node-reference`](#node_reference).
+- `node_reference`, a single [Node Reference](#node-reference).
 
 ```lua
 s("extras4", { i(1), t { "", "" }, extras.rep(1) }),
@@ -1114,7 +1197,7 @@ s("extras4", { i(1), t { "", "" }, extras.rep(1) }),
 
 ## Partial
 
-Evaluates a function on expand and inserts its' value.
+Evaluates a function on expand and inserts its value.
 
 `partial(fn, params...)`
 - `fn`: any function
@@ -1134,9 +1217,11 @@ s("extras5", { extras.partial(os.date, "%Y") }),
 <!-- panvimdoc-ignore-end -->
 
 ## Nonempty
-Inserts text if the referenced node doesn't contain any text.  
-`nonempty(node_reference, not_empty, empty)`
-- `node_reference`, a single [node-reference](#node_reference).  
+Inserts text if the referenced node doesn't contain any text.
+
+`nonempty(node_reference, not_empty, empty)`:
+
+- `node_reference`, a single [Node Reference](#node-reference).  
 - `not_empty`, `string`: inserted if the node is not empty.
 - `empty`, `string`: inserted if the node is empty.
 
@@ -1152,7 +1237,7 @@ s("extras6", { i(1, ""), t { "", "" }, extras.nonempty(1, "not empty!", "empty!"
 
 ## Dynamic Lambda
 
-Pretty much the same as lambda, it just inserts the resulting text as an
+Pretty much the same as lambda, but it inserts the resulting text as an
 insertNode, and, as such, it can be quickly overridden.
 
 `dynamic_lambda(jump_indx, lambda, node_references)`
@@ -1174,12 +1259,14 @@ s("extras7", { i(1), t { "", "" }, extras.dynamic_lambda(2, l._1 .. l._1, 1) }),
 
 Authoring snippets can be quite clunky, especially since every second node is
 probably a `textNode`, inserting a small number of characters between two more
-complicated nodes.  
+complicated nodes.
+
 `fmt` can be used to define snippets in a much more readable way. This is
 achieved by borrowing (as the name implies) from `format`-functionality (our
 syntax is very similar to
-[python's](https://docs.python.org/3/library/stdtypes.html#str.format)).  
-`fmt` accepts a string and a table of nodes. Each occurrence of a delimiter-pair
+[python's](https://docs.python.org/3/library/stdtypes.html#str.format)).
+
+`fmt` accepts a string and a table of nodes. Each occurrence of a delimiter pair
 in the string is replaced by one node from the table, while text outside the
 delimiters is turned into textNodes.
 
@@ -1230,7 +1317,7 @@ any way, correspond to the jump-index of the nodes!
 
 `fmt(format:string, nodes:table of nodes, opts:table|nil) -> table of nodes`
 
-* `format`: a string. Occurences of `{<somekey>}` ( `{,}` are customizable, more
+* `format`: a string. Occurences of `{<somekey>}` ( `{}` are customizable; more
   on that later) are replaced with `content[<somekey>]` (which should be a
   node), while surrounding text becomes `textNode`s.  
   To escape a delimiter, repeat it (`"{{"`).  
@@ -1243,7 +1330,7 @@ any way, correspond to the jump-index of the nodes!
   subsequent occurences.
 * `nodes`: just a table of nodes.
 * `opts`: optional arguments:
-  * `delimiters`: string, two characters. Change `{,}` to some other pair, e.g.
+  * `delimiters`: string, two characters. Change `{}` to some other pair, e.g.
   	`"<>"`.
   * `strict`: Warn about unused nodes (default true).
   * `trim_empty`: remove empty (`"%s*"`) first and last line in `format`. Useful
@@ -1251,15 +1338,15 @@ any way, correspond to the jump-index of the nodes!
   * `dedent`: remove indent common to all lines in `format`. Again, makes
   	passing multiline-strings a bit nicer (default true).
   * `repeat_duplicates`: repeat nodes when a key is reused instead of copying
-        the node if it has a jump-index, refer to [jump-index](#jump-index) to
+        the node if it has a jump-index, refer to [Basics-Jump-Index](#jump-index) to
         know which nodes have a jump-index (default false).
 
 There is also `require("luasnip.extras.fmt").fmta`. This only differs from `fmt`
-by using angle-brackets (`<>`) as the default-delimiter.
+by using angle brackets (`<>`) as the default delimiter.
 
 ## Conditions
 
-This module (`luasnip.extras.condition`) contains function that can be passed to
+This module (`luasnip.extras.condition`) contains functions that can be passed to
 a snippet's `condition` or `show_condition`. These are grouped accordingly into
 `luasnip.extras.conditions.expand` and `luasnip.extras.conditions.show`:
 
@@ -1269,11 +1356,11 @@ a snippet's `condition` or `show_condition`. These are grouped accordingly into
 **`show`**:
 - `line_end`: only expand at the end of the line.
 
-`expand` contains, additionally, all conditions provided by `show`.
+Additionally, `expand` contains all conditions provided by `show`.
 
-### Condition-Objects
+### Condition Objects
 
-`luasnip.extras.conditions` also contains condition-objects. These can, just
+`luasnip.extras.conditions` also contains condition objects. These can, just
 like functions, be passed to `condition` or `show_condition`, but can also be
 combined with each other into logical expressions:
 
@@ -1299,20 +1386,21 @@ with the more verbose
 condition = function(...) return conditions.expand.line_end(...) or conditions.expand.line_begin(...) end
 ```
 
-The conditions provided in `show` and `expand` are already condition-objects. To
+The conditions provided in `show` and `expand` are already condition objects. To
 create new ones, use
 `require("luasnip.extras.conditions").make_condition(condition_fn)`
 
 
-## On The Fly snippets
+## On The Fly-Snippets
 
 Sometimes it's desirable to create snippets tailored for exactly the current
 situation. For example inserting repetitive, but just slightly different
-invocations of some function, or supplying data in some schema.  
-On The Fly-snippets enable exactly this usecase: they can be quickly created
-and expanded, with as little disruption as possible.  
+invocations of some function, or supplying data in some schema.
 
-Since they should mainly fast to write, and don't necessarily need all bells and
+On-the-fly snippets enable exactly this use case: they can be quickly created
+and expanded with as little disruption as possible.  
+
+Since they should mainly fast to write and don't necessarily need all bells and
 whistles, they don't make use of lsp/textmate-syntax, but a more simplistic one:  
 
 * `$anytext` denotes a placeholder (`insertNode`) with text "anytext". The text
@@ -1321,16 +1409,16 @@ whistles, they don't make use of lsp/textmate-syntax, but a more simplistic one:
 * ... That's it. `$` can be escaped by preceding it with a second `$`, all other
   symbols will be interpreted literally.
 
-There is currently only one way to expand On The Fly-snippets:  
+There is currently only one way to expand on-the-fly snippets:  
 `require('luasnip.extras.otf').on_the_fly("<some-register>")` will interpret
 whatever text is in the register `<some-register>` as a snippet, and expand it
-immediately.  
+immediately.
 The idea behind this mechanism is that it enables a very immediate way of
 supplying and retrieving (expanding) the snippet: write the snippet-body into
 the buffer, cut/yank it into some register, and call `on_the_fly("<register>")`
 to expand the snippet.  
 
-Here's one set of example-keybindings:
+Here's one set of example keybindings:
 
 ```vim
 " in the first call: passing the register is optional since `on_the_fly`
@@ -1340,9 +1428,9 @@ vnoremap <c-f>  "ec<cmd>lua require('luasnip.extras.otf').on_the_fly("e")<cr>
 inoremap <c-f>  <cmd>lua require('luasnip.extras.otf').on_the_fly("e")<cr>
 ```
 
-Obviously, `<c-f>` is arbritary, and can be changed to any other key-combo.
-Another interesting application is allowing multiple on the fly-snippets at the
-same time, by retrieving snippets from multiple registers:
+Obviously, `<c-f>` is arbritary and can be changed to any other key combo.
+Another interesting application is allowing multiple on-the-fly snippets at the
+same time by retrieving snippets from multiple registers:
 ```vim
 " For register a
 vnoremap <c-f>a  "ac<cmd>lua require('luasnip.extras.otf').on_the_fly()<cr>
@@ -1360,7 +1448,7 @@ inoremap <c-f>b  <cmd>lua require('luasnip.extras.otf').on_the_fly("b")<cr>
 
 <!-- panvimdoc-ignore-end -->
 
-## Select_choice
+## select_choice
 
 It's possible to leverage `vim.ui.select` for selecting a choice directly,
 without cycling through the available choices.  
@@ -1379,23 +1467,23 @@ The `opts.kind` hint for `vim.ui.select` will be set to `luasnip`.
 
 <!-- panvimdoc-ignore-end -->
 
-## filetype_functions
+## Filetype-Functions
 
-Contains some utility-functions that can be passed to the `ft_func` or
+Contains some utility functions that can be passed to the `ft_func` or
 `load_ft_func`-settings.
 
 * `from_filetype`: the default for `ft_func`. Simply returns the filetype(s) of
   the buffer.
 * `from_cursor_pos`: uses treesitter to determine the filetype at the cursor.
   With that, it's possible to expand snippets in injected regions, as long as
-  the treesitter-parser supports them.
+  the treesitter parser supports them.
   If this is used in conjuction with `lazy_load`, extra care must be taken that
   all the filetypes that can be expanded in a given buffer are also returned by
   `load_ft_func` (otherwise their snippets may not be loaded).
   This can easily be achieved with `extend_load_ft`.
 * `extend_load_ft`: `fn(extend_ft:map) -> fn`
   A simple solution to the problem described above is loading more filetypes
-  than just that of the target-buffer when `lazy_load`ing. This can be done
+  than just that of the target buffer when `lazy_load`ing. This can be done
   ergonomically via `extend_load_ft`: calling it with a table where the keys are
   filetypes, and the values are the filetypes that should be loaded additionaly
   returns a function that can be passed to `load_ft_func` and takes care of
@@ -1414,11 +1502,11 @@ Contains some utility-functions that can be passed to the `ft_func` or
   })
   ```
 
-## POSTFIX SNIPPET
+## Postfix-Snippet
 
 Postfix snippets, famously used in 
 [rust analyzer](https://rust-analyzer.github.io/) and various IDEs, are a type
-of snippet, which alters text before the snippets trigger. While these
+of snippet which alters text before the snippet's trigger. While these
 can be implemented using regTrig snippets, this helper makes the process easier
 in most cases.
 
@@ -1426,12 +1514,11 @@ The simplest example, which surrounds the text preceeding the `.br` with
 brackets `[]`, looks like:
 
 ```lua
-
-      postfix(".br", {
-              f(function(_, parent)
-                    return "[" .. parent.snippet.env.POSTFIX_MATCH .. "]"
-              end, {}),
-      })
+postfix(".br", {
+    f(function(_, parent)
+        return "[" .. parent.snippet.env.POSTFIX_MATCH .. "]"
+    end, {}),
+})
 ```
 
 <!-- panvimdoc-ignore-start -->
@@ -1451,17 +1538,17 @@ usable within dynamic nodes.
 This field can also be used within lambdas and dynamic nodes.
 
 ```lua
-      postfix(".br", {
-              l("[" .. l.POSTFIX_MATCH .. "]"),
-      })
+postfix(".br", {
+	l("[" .. l.POSTFIX_MATCH .. "]"),
+})
 ```
 
 ```lua
-	postfix(".brd", {
-	  d(1, function (_, parent)
-	    return sn(nil, {t("[" .. parent.env.POSTFIX_MATCH .. "]")})
-	  end)
-	}),
+postfix(".brd", {
+	d(1, function (_, parent)
+		return sn(nil, {t("[" .. parent.env.POSTFIX_MATCH .. "]")})
+	end)
+}),
 ```
 
 <!-- panvimdoc-ignore-start -->
@@ -1503,17 +1590,16 @@ below) it will get run after the builtin callback. This means that your
 callback will have access to the `POSTFIX_MATCH` field as well.
 
 ```lua
-
-      {
-        callbacks = {
-              [-1] = {
-                      [events.pre_expand] = function(snippet, event_args)
-                          -- function body to match before the dot
-                          -- goes here
-                       end
-                      }
-                    }
-        }
+{
+	callbacks = {
+	[-1] = {
+		[events.pre_expand] = function(snippet, event_args)
+		-- function body to match before the dot
+		-- goes here
+		end
+		}
+	}
+}
 ```
 
 ## Snippet List
@@ -1632,13 +1718,13 @@ string representation of the snippets. The display function uses the results
 from the printer function, therefore by **default** the display function is
 expecting that result to be a string.
 
-This doesn't have to be the case however. You can for example implement your
+However, this doesn't have to be the case. For example, you can implement your
 own printer function that returns a table representation of the snippets
 **but** you would have to then implement your own display function or some
-other function in order to stringify this result.
+other function in order to return the result as a string.
 
-An `options` table is available which has functionality in it that can be used
-to customize 'common' settings.
+An `options` table, which has some core functionality that can be used
+to customize 'common' settings, is provided.
 
 * `sl.options`: options table:
     * `display`: `display(opts:table|nil) -> function(printer_result:string)`
@@ -1675,7 +1761,7 @@ sl.open({display = modified_default_display})
 
 <!-- panvimdoc-ignore-end -->
 
-# EXTEND_DECORATOR
+# Extend Decorator
 
 Most of luasnip's functions have some arguments to control their behaviour.  
 Examples include `s`, where `wordTrig`, `regTrig`, ... can be set in the first
@@ -1684,9 +1770,10 @@ argument.
 This is all good and well, but if these functions are often used with
 non-default settings, it can become cumbersome to always explicitly set them.
 
-This is where the `extend_decorator` comes in:  
-It can be used to create decorated functions which always extend the arguments
-passed directly with other, previously defined ones.  
+This is where the `extend_decorator` comes in:
+it can be used to create decorated functions which always extend the arguments
+passed directly with other previously defined ones.
+
 An example:
 ```lua
 local fmt = require("luasnip.extras.fmt").fmt
@@ -1710,10 +1797,9 @@ fmt_angle("<>", {i(1)}) -- -> same as above.
 ```
 
 `extend_decorator.apply(fn, ...)` requires that `fn` is previously registered
-via `extend_decorator.register`.  
-(This is not limited to luasnip's functions!)  
-(although, for usage outside of luasnip, best copy the source-file
-`/lua/luasnip/util/extend_decorator.lua`).
+via `extend_decorator.register`.
+(This is not limited to LuaSnip's functions; although, for usage outside of
+LuaSnip, best copy the source file: `/lua/luasnip/util/extend_decorator.lua`).
 
 `register(fn, ...)`:
 
@@ -1724,8 +1810,8 @@ via `extend_decorator.register`.
   * extend, `fn(arg, extend_value) -> effective_arg` (optional): this function
     is used to extend the args passed to the decorated function.
     It defaults to a function which just extends the the arg-table with the
-    extend-table (accepts `nil`).
-    This extend-behaviour is adaptable to accomodate `s`, where the first
+    extend table (accepts `nil`).
+    This extend behaviour is adaptable to accomodate `s`, where the first
     argument may be string or table.
 
 `apply(fn, ...) -> decorated_fn`:
@@ -1749,9 +1835,9 @@ local extended = extend_decorator.apply(somefn,
 extended(...)
 ```
 
-# LSP-SNIPPETS
+# LSP-Snippets
 
-Luasnip is capable of parsing lsp-style snippets using
+LuaSnip is capable of parsing LSP-style snippets using
 `ls.parser.parse_snippet(context, snippet_string, opts)`:
 ```lua
 ls.parser.parse_snippet({trig = "lsp"}, "$1 is ${2|hard,easy,challenging|}")
@@ -1772,7 +1858,7 @@ ls.parser.parse_snippet({trig = "lsp"}, "$1 is ${2|hard,easy,challenging|}")
     like `fmt`.
 
 Nested placeholders(`"${1:this is ${2:nested}}"`) will be turned into
-choiceNode's with:
+choiceNodes with:
   - the given snippet(`"this is ${1:nested}"`) and
   - an empty insertNode
 
@@ -1786,7 +1872,7 @@ This behaviour can be modified by changing `parser_nested_assembler` in
 `ls.setup()`.
 
 
-Luasnip will also modify some snippets it's incapable of representing
+LuaSnip will also modify some snippets that it is incapable of representing
 accurately:
   - if the `$0` is a placeholder with something other than just text inside
   - if the `$0` is a choice
@@ -1808,25 +1894,28 @@ Both `trim_empty` and `dedent` will be disabled for snippets parsed via
 
 ## Snipmate Parser
 
-It is furthermore possible to parse snipmate-snippets (this includes support for
-vimscript-evaluation!!)  
-Snipmate-snippets have to be parsed with a different function,
+It is furthermore possible to parse SnipMate snippets (this includes support for
+vimscript-evaluation!!)
+
+SnipMate snippets need to be parsed with a different function,
 `ls.parser.parse_snipmate`:
 ```lua
 ls.parser.parse_snipmate("year", "The year is `strftime('%Y')`")
 ```
 
 `parse_snipmate` accepts the same arguments as `parse_snippet`, only the
-snippet-body is parsed differently.
+snippet body is parsed differently.
 
 ## Transformations
 
 To apply
 [Variable/Placeholder-transformations](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variable-transforms),
 luasnip needs to apply ECMAScript regexes.
-This is implemented by relying on [`jsregexp`](https://github.com/kmarius/jsregexp).  
-The easiest, but potentially error-prone way to install it is by calling `make
-install_jsregexp` in the repo-root.
+This is implemented by relying on [`jsregexp`](https://github.com/kmarius/jsregexp).
+
+The easiest (but potentially error-prone) way to install it is by calling `make
+install_jsregexp` in the repo root.
+
 This process can be automated by `packer.nvim`:
 ```lua
 use { "L3MON4D3/LuaSnip", run = "make install_jsregexp" }
@@ -1841,13 +1930,35 @@ Alternatively, `jsregexp` can be cloned locally, `make`d, and the resulting
 `jsregexp.so` placed in some place where nvim can find it (probably
 `~/.config/nvim/lua/`).
 
-If `jsregexp` is not available, transformation are replaced by a simple copy.
+If `jsregexp` is not available, transformations are replaced by a simple copy.
+
+## VSCode snippet extra fields
+<!-- Works only in github -->
+> **Note** See also this [Issue 705] for more info
+```json 
+    
+    {
+        "prefix": ...
+        "scope": "javascript,typescript",
+        "body": ...
+    }
+``` 
+The [`"scope": `](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-scope)
+field is honored when loaded into the LuaSnip engine.
+If it isn't part of the current buffer (editor) language, then it's not imported.
+Let's say you have `shared.json` that has snippets for different languages specified via `scope`.
+When specific language mapped to a `.code-snippets` (or `.json`) file by a `package.json`
+then only snippets `scope`-ed to the same language are loaded. The rest is ignored.
+
+`"isFileTemplate" :` field isn't handled in anyway.
+
+[Issue 705]: https://github.com/L3MON4D3/LuaSnip/issues/705
 
 # VARIABLES
 
 All `TM_something`-variables are supported with two additions:
 `LS_SELECT_RAW` and `LS_SELECT_DEDENT`. These were introduced because
-`TM_SELECTED_TEXT` is designed to be compatible with vscodes' behavior, which
+`TM_SELECTED_TEXT` is designed to be compatible with VSCode's behavior, which
 can be counterintuitive when the snippet can be expanded at places other than
 the point where selection started (or when doing transformations on selected text).
 Besides those we also provide `LS_TRIGGER` which contains the trigger of the snippet,
@@ -1867,7 +1978,7 @@ end, {}))
 
 To use any `*SELECT*` variable, the `store_selection_keys` must be set via
 `require("luasnip").config.setup({store_selection_keys="<Tab>"})`. In this case,
-hitting `<Tab>` while in Visualmode will populate the `*SELECT*`-vars for the next
+hitting `<Tab>` while in visual mode will populate the `*SELECT*`-vars for the next
 snippet and then clear them.
 
 <!-- panvimdoc-ignore-start -->
@@ -1885,7 +1996,7 @@ You can also add your own variables by using the `ls.env_namespace(name, opts)` 
     * `vars`: `(fn(name:string)->EnvVal) | map[string, EnvVal]`
     Is a function that receives a string and returns a value for the var with that name
     or a table from var name to a value
-    (in this case, if the value is a function it will be executed  lazily once per snippet expansion).
+    (in this case, if the value is a function it will be executed lazily once per snippet expansion).
     * `init`: `fn(info: table)->map[string, EnvVal]`  Returns
         a table of variables that will set to the environment of the snippet on expansion,
         use this for vars that have to be calculated in that moment or that depend on each other.
@@ -1898,7 +2009,7 @@ You can also add your own variables by using the `ls.env_namespace(name, opts)` 
         [issue#510](https://github.com/L3MON4D3/LuaSnip/issues/510#issuecomment-1209333698) for more information.
 
 The four fields of `opts` are optional but you need to provide either `init` or  `vars`, and `eager` can't be without `vars`.
-Also you can't use namespaces that override default vars.
+Also, you can't use namespaces that override default vars.
 
 
 A simple example to make it more clear:
@@ -1941,7 +2052,7 @@ end, {}))
 ## LSP-Variables
 
 All variables, even ones added via `env_namespace`, can be accessed in
-lsp-snippets as `$VAR_NAME`.
+LSP snippets as `$VAR_NAME`.
 
 The lsp-spec states:
 
@@ -1955,16 +2066,16 @@ When a variable is unknown (that is, its name isn’t defined) the name of the v
 
 The above necessiates a differentiation between `unknown` and `unset` variables:
 
-For Luasnip, a variable `VARNAME` is `unknown` when `env.VARNAME` returns `nil` and `unset`
+For LuaSnip, a variable `VARNAME` is `unknown` when `env.VARNAME` returns `nil` and `unset`
 if it returns an empty string.
 
-Consider this when adding env-variables which might be used in lsp-snippets.
+Consider this when adding env-variables which might be used in LSP snippets.
 
-# LOADERS
+# Loaders
 
 Luasnip is capable of loading snippets from different formats, including both
-the well-established vscode- and snipmate-format, as well as plain lua-files for
-snippets written in lua
+the well-established VSCode and SnipMate format, as well as plain Lua files for
+snippets written in Lua.
 
 All loaders share a similar interface:
 ```lua
@@ -1989,8 +2100,8 @@ where `opts` can contain the following keys:
 - `exclude`: List of languages to exclude, empty by default.
 - `include`: List of languages to include, includes everything by default.
 - `{override,default}_priority`: These keys are passed straight to the
-  [`add_snippets`](#api-reference)-calls and can therefore change the priority
-  of snippets loaded from some colletion (or, in combination with
+  `add_snippets`-calls (documented in [API](#api)) and can therefore change the
+  priority of snippets loaded from some colletion (or, in combination with
   `{in,ex}clude`, only some of its snippets).
 
 While `load` will immediately load the snippets, `lazy_load` will defer loading until
@@ -2002,26 +2113,26 @@ a `bufnr`, returns the filetypes that should be loaded (`fn(bufnr) -> filetypes
 (string[])`)).
 
 All of the loaders support reloading, so simply editing any file contributing
-snippets will reload its snippets (only in the session the file was edited in,
+snippets will reload its snippets (only in the session the file was edited in;
 we use `BufWritePost` for reloading, not some lower-level mechanism).
 
-For easy editing of these files, Luasnip provides a [`vim.ui.select`-based
-dialog](#edit_snippets) where first the filetype, and then the file can be
-selected.
+For easy editing of these files, LuaSnip provides a `vim.ui.select`-based dialog
+([Loaders-edit_snippets](#edit_snippets)) where first the filetype, and then the
+file can be selected.
 
 ## Troubleshooting
 
-* Luasnip uses `all` as the global filetype. As most snippet collections don't
-  explicitly target luasnip, they may not provide global snippets for this
+* LuaSnip uses `all` as the global filetype. As most snippet collections don't
+  explicitly target LuaSnip, they may not provide global snippets for this
   filetype, but another, like `_` (`honza/vim-snippets`).
-  In these cases, it's necessary to extend luasnip's global filetype with the
+  In these cases, it's necessary to extend LuaSnip's global filetype with the
   collection's global filetype:
   ```lua
   ls.filetype_extend("all", { "_" })
   ```
 
   In general, if some snippets don't show up when loading a collection, a good
-  first step is checking the filetype luasnip is actually looking into (print
+  first step is checking the filetype LuaSnip is actually looking into (print
   them for the current buffer via `:lua
   print(vim.inspect(require("luasnip").get_snippet_filetypes()))`), against the
   one the missing snippet is provided for (in the collection).  
@@ -2031,18 +2142,19 @@ selected.
   ls.filetype_extend("<luasnip-filetype>", { "<collection-filetype>" })
   ```
 
-* As we only load `lazy_load`ed snippet on some events, `lazy_load` will
+* As we only load `lazy_load`ed snippets on some events, `lazy_load` will
   probably not play nice when a non-default `ft_func` is used: if it depends on
-  e.g. the cursor-position, only the filetypes for the cursor-position when the
-  `lazy_load`-events are triggered will be loaded. Check
-  [filetype_function's `extend_load_ft`](#filetype_functions) for a solution.
+  e.g. the cursor position, only the filetypes for the cursor position when the
+  `lazy_load` events are triggered will be loaded. Check
+  [Extras-Filetype-Function](#filetype-functions)'s `extend_load_ft` for a
+  solution.
 
-## VSCODE
+## VS-Code
 
-As a reference on the structure of these snippet-libraries, see
+As a reference on the structure of these snippet libraries, see
 [`friendly-snippets`](https://github.com/rafamadriz/friendly-snippets).
 
-We support a small extension: snippets can contain luasnip-specific options in
+We support a small extension: snippets can contain LuaSnip-specific options in
 the `luasnip`-table:
 ```json
 "example1": {
@@ -2057,6 +2169,12 @@ the `luasnip`-table:
 	}
 }
 ```
+
+Files with the extension `jsonc` will be parsed as `jsonc`, [json with
+comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments),
+while `*.json` are parsed with a regular `json` parser, where comments are
+disallowed. (the json-parser is a bit faster, so don't default to `jsonc` if
+it's not necessary).
 
 **Example**:
 
@@ -2123,6 +2241,7 @@ require("luasnip.loaders.from_vscode").lazy_load({paths = "~/.config/nvim/my_sni
 -- or relative to the directory of $MYVIMRC
 require("luasnip.loaders.from_vscode").load({paths = "./my_snippets"})
 ```
+
 ## SNIPMATE
 
 Luasnip does not support the full snipmate format: Only `./{ft}.snippets` and
@@ -2130,8 +2249,8 @@ Luasnip does not support the full snipmate format: Only `./{ft}.snippets` and
 [honza/vim-snippets](https://github.com/honza/vim-snippets) for lots of
 examples.
 
-Like vscode, the snipmate-format is also extended to make use of some of
-luasnips more advanced capabilities:
+Like VSCode, the SnipMate format is also extended to make use of some of
+LuaSnip's more advanced capabilities:
 ```snippets
 priority 2000
 autosnippet options
@@ -2169,11 +2288,11 @@ Stuff to watch out for:
 * Using both `extends <ft2>` in `<ft1>.snippets` and
   `ls.filetype_extend("<ft1>", {"<ft2>"})` leads to duplicate snippets.
 * `${VISUAL}` will be replaced by `$TM_SELECTED_TEXT` to make the snippets
-  compatible with luasnip
+  compatible with LuaSnip
 * We do not implement eval using \` (backtick). This may be implemented in the
   future.
 
-## LUA
+## Lua
 
 Instead of adding all snippets via `add_snippets`, it's possible to store them
 in separate files and load all of those.  
@@ -2186,10 +2305,10 @@ There are two ways to add snippets:
   added as regular snippets, while the snippets in the second will be added as
   autosnippets (both are the defaults, if a snippet defines a different
   `snippetType`, that will have preference)
-* snippets can also be appended to the global (only for these files! They are not
+* snippets can also be appended to the global (only for these files - they are not
   visible anywhere else) tables `ls_file_snippets` and `ls_file_autosnippets`.
   This can be combined with a custom `snip_env` to define and add snippets with
-  one function-call:
+  one function call:
   ```lua
   ls.setup({
   	snip_env = {
@@ -2210,10 +2329,10 @@ There are two ways to add snippets:
   })
   ```
   This is more flexible than the previous approach since the snippets don't have
-  to be collected, they just have to be defined using the above `s` and `parse`.
+  to be collected; they just have to be defined using the above `s` and `parse`.
 
-As defining all of the snippet-constructors (`s`, `c`, `t`, ...) in every file
-is rather cumbersome, luasnip will bring some globals into scope for executing
+As defining all of the snippet constructors (`s`, `c`, `t`, ...) in every file
+is rather cumbersome, LuaSnip will bring some globals into scope for executing
 these files.
 By default, the names from [`luasnip.config.snip_env`][snip-env-src] will be used, but it's
 possible to customize them by setting `snip_env` in `setup`.  
@@ -2242,11 +2361,12 @@ Load via
 require("luasnip.loaders.from_lua").load({paths = "~/snippets"})
 ```
 
-## EDIT_SNIPPETS
+## edit_snippets
 
 To easily edit snippets for the current session, the files loaded by any loader
 can be quickly edited via
-`require("luasnip.loaders").edit_snippet_files(opts:table|nil)`  
+`require("luasnip.loaders").edit_snippet_files(opts:table|nil)`
+
 When called, it will open a `vim.ui.select`-dialog to select first a filetype,
 and then (if there are multiple) the associated file to edit.
 
@@ -2256,8 +2376,12 @@ and then (if there are multiple) the associated file to edit.
 
 <!-- panvimdoc-ignore-end -->
 
-`opts` contains three settings:
+`opts` contains four settings:
 
+* `ft_filter`: `fn(filetype:string) -> bool`
+  Optionally filter initially listed filetypes.
+  `true` -> filetype will be listed, `false` -> not listed.
+  Accepts all filetypes by default.
 * `format`: `fn(file:string, source_name:string) -> string|nil`  
   `file` is simply the path to the file, `source_name` is one of `"lua"`,
   `"snipmate"` or `"vscode"`.  
@@ -2300,7 +2424,7 @@ and then (if there are multiple) the associated file to edit.
   second is the path that will be passed to the `edit()` function if that item
   was selected.
 
-  This can be used to create a new snippet-file for the current filetype:
+  This can be used to create a new snippet file for the current filetype:
 ```lua
 require("luasnip.loaders").edit_snippet_files {
   extend = function(ft, paths)
@@ -2321,20 +2445,20 @@ One comfortable way to call this function is registering it as a command:
 command! LuaSnipEdit :lua require("luasnip.loaders").edit_snippet_files()
 ```
 
-# SNIPPETPROXY
+# SnippetProxy
 
-`SnippetProxy` is used internally to alleviate the upfront-cost of
-loading snippets from e.g. a snipmate-library or a vscode-package. This is
+`SnippetProxy` is used internally to alleviate the upfront cost of
+loading snippets from e.g. a SnipMate library or a VSCode package. This is
 achieved by only parsing the snippet on expansion, not immediately after reading
 it from some file.
-`SnippetProxy` may also be used from lua directly, to get the same benefits:
+`SnippetProxy` may also be used from Lua directly to get the same benefits:
 
-This will parse the snippet on startup...
+This will parse the snippet on startup:
 ```lua
 ls.parser.parse_snippet("trig", "a snippet $1!")
 ```
 
-... and this will parse the snippet upon expansion.
+while this will parse the snippet upon expansion:
 ```lua
 local sp = require("luasnip.nodes.snippetProxy")
 sp("trig", "a snippet $1")
@@ -2343,17 +2467,17 @@ sp("trig", "a snippet $1")
 `sp(context, body, opts) -> snippetProxy`
 
 - `context`: exactly the same as the first argument passed to `ls.s`.
-- `body`: the snippet-body.
+- `body`: the snippet body.
 - `opts`: accepts the same `opts` as `ls.s`, with some additions:
   - `parse_fn`: the function for parsing the snippet. Defaults to
-    `ls.parser.parse_snippet` (the parser for lsp-snippets), an alternative is
-    the parser for snipmate-snippets (`ls.parser.parse_snipmate`).
+    `ls.parser.parse_snippet` (the parser for LSP snippets), an alternative is
+    the parser for SnipMate snippets (`ls.parser.parse_snipmate`).
 
-# EXT\_OPTS
+# ext_opts
 
 `ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
-extmarks used for marking node-positions, either globally, per-snippet or
-per-node.
+extmarks used for marking node positions, either globally, per snippet or
+per node.
 This means that they allow highlighting the text inside of nodes, or adding
 virtual text to the line the node begins on.
 
@@ -2403,7 +2527,7 @@ s("trig", {
 
 <!-- panvimdoc-ignore-end -->
 
-In the above example the text inside the insertNodes is higlighted in green if
+In the above example, the text inside the insertNodes is higlighted in green if
 they were not yet visited, in blue once they were, and red while they are.  
 The virtual text "virtual text!!" is visible as long as the snippet is active.
 
@@ -2433,7 +2557,7 @@ default, e.g. to disable highlighting inherited from `passive` when the node is
 ---
 
 As stated earlier, these `ext_opts` can also be applied globally or for an
-entire snippet. For this it's necessary to specify which kind of node a given
+entire snippet. For this, it's necessary to specify which kind of node a given
 set of `ext_opts` should be applied to:
 
 ```lua
@@ -2459,7 +2583,7 @@ ls.setup({
 ```
 
 The above applies the given `ext_opts` to all nodes of these types, in all
-snippets...
+snippets.
 
 ```lua
 local types = require("luasnip.util.types")
@@ -2474,7 +2598,7 @@ s("trig", { i(1, "text1"), i(2, "text2") }, {
 	}
 })
 ```
-... while the `ext_opts` here are only applied to the `insertNodes` inside this
+However, the `ext_opts` here are only applied to the `insertNodes` inside this
 snippet.
 
 ---
@@ -2519,7 +2643,7 @@ s("trig", {
 ---
 
 The `hl_group` of the global `ext_opts` can also be set via standard
-highlight-groups:
+highlight groups:
 
 ```lua
 vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
@@ -2534,8 +2658,8 @@ node in PascalCase (or "Snippet").
 
 ---
 
-One problem that might arise when nested nodes are highlighted, is that the
-highlight of inner nodes should be visible, eg. above that of nodes they are
+One problem that might arise when nested nodes are highlighted is that the
+highlight of inner nodes should be visible, e.g. above that of nodes they are
 nested inside.
 
 This can be controlled using the `priority`-key in `ext_opts`. In
@@ -2570,12 +2694,12 @@ Here the highlight of an insertNode nested directly inside a choiceNode is
 always visible on top of it.
 
 
-# DOCSTRING
+# Docstrings
 
-Snippet-docstrings can be queried using `snippet:get_docstring()`. The function
+Snippet docstrings can be queried using `snippet:get_docstring()`. The function
 evaluates the snippet as if it was expanded regularly, which can be problematic
 if e.g. a dynamicNode in the snippet relies on inputs other than
-the argument-nodes.
+the argument nodes.
 `snip.env` and `snip.captures` are populated with the names of the queried
 variable and the index of the capture respectively
 (`snip.env.TM_SELECTED_TEXT` -> `'$TM_SELECTED_TEXT'`, `snip.captures[1]` ->
@@ -2591,7 +2715,7 @@ s({trig = "(%d)", regTrig = true}, {
 ```
 
 This snippet works fine because	`snippet.captures[1]` is always a number.
-During docstring-generation, however, `snippet.captures[1]` is `'$CAPTURES1'`,
+During docstring generation, however, `snippet.captures[1]` is `'$CAPTURES1'`,
 which will cause an error in the functionNode.
 Issues with `snippet.captures` can be prevented by specifying `docTrig` during
 snippet-definition:
@@ -2618,10 +2742,10 @@ s({trig = "(%d)", regTrig = true, docstring = "repeatmerepeatmerepeatme"}, {
 }),
 ```
 
-A better example to understand `docTrig` and `docstring` can refer to
-[#515](https://github.com/L3MON4D3/LuaSnip/pull/515).
+Refer to [#515](https://github.com/L3MON4D3/LuaSnip/pull/515) for a
+better example to understand `docTrig` and `docstring`.
 
-# DOCSTRING-CACHE
+# Docstring-Cache
 
 Although generation of docstrings is pretty fast, it's preferable to not
 redo it as long as the snippets haven't changed. Using
@@ -2632,16 +2756,16 @@ Both functions accept a table structsured like this: `{ft1={snippets},
 ft2={snippets}}`. Such a table containing all snippets can be obtained via
 `ls.get_snippets()`.
 `load` should be called before any of the `loader`-functions as snippets loaded
-from vscode-style packages already have their `docstring` set (`docstrings`
+from VSCode style packages already have their `docstring` set (`docstrings`
 wouldn't be overwritten, but there'd be unnecessary calls).
 
 The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 `~/.cache/nvim/luasnip/docstrings.json`).
 
-# EVENTS
+# Events
 
 Events can be used to react to some action inside snippets. These callbacks can
-be defined per-snippet (`callbacks`-key in snippet constructor) or globally
+be defined per snippet (`callbacks`-key in snippet constructor) or globally
 (autocommand).
 
 `callbacks`: `fn(node[, event_args]) -> event_res`  
@@ -2690,7 +2814,7 @@ The node and `event_args` can be accessed through `require("luasnip").session`:
     snippet's environment (`snip.env`).
 
 A pretty useless, beyond serving as an example here, application of these would
-be printing e.g. the nodes' text after entering:
+be printing e.g. the node's text after entering:
 
 ```lua
 vim.api.nvim_create_autocmd("User", {
@@ -2702,7 +2826,7 @@ vim.api.nvim_create_autocmd("User", {
 })
 ```
 
-or some information about expansions
+or some information about expansions:
 
 ```lua
 vim.api.nvim_create_autocmd("User", {
@@ -2722,19 +2846,19 @@ vim.api.nvim_create_autocmd("User", {
 })
 ```
 
-# CLEANUP
-The function ls.cleanup()  triggers the `LuasnipCleanup` user-event, that you can listen to do some kind
-of cleaning in your own snippets, by default it will  empty the snippets table and the caches of
-the lazy_load.
+# Cleanup
+The function ls.cleanup()  triggers the `LuasnipCleanup` user event, that you
+can listen to do some kind of cleaning in your own snippets; by default it will
+empty the snippets table and the caches of the lazy_load.
 
 # Logging
-Luasnip uses logging to report unexpected program-states, and information on
+Luasnip uses logging to report unexpected program states, and information on
 what's going on in general. If something does not work as expected, taking a
 look at the log (and potentially increasing the loglevel) might give some good
 hints towards what is going wrong.  
 
 The log is stored in `<vim.fn.stdpath("log")>/luasnip.log`
-(`<vim.fn.stdpath("cache")>/luasnip.log` for neovim-versions where
+(`<vim.fn.stdpath("cache")>/luasnip.log` for Neovim versions where
 `stdpath("log")` does not exist), and can be opened by calling `ls.log.open()`.
 The loglevel (granularity of reported events) can be adjusted by calling
 `ls.log.set_loglevel("error"|"warn"|"info"|"debug")`. `"debug"` has the highest
@@ -2747,7 +2871,78 @@ there already exists a `luasnip.log.old`, it will be deleted.
 `ls.log.ping()` can be used to verify the log is working correctly: it will
 print a short message to the log.
 
-# API-REFERENCE
+# Config-Options
+
+These are the settings you can provide to `luasnip.setup()`:
+
+- `history`: If true, snippets that were exited can still be jumped back into.
+  As snippets are not removed when their text is deleted, they have to be
+  removed manually via `LuasnipUnlinkCurrent` if `delete_check_events` is not
+  enabled (set to eg. `'TextChanged'`).
+- `update_events`: Choose which events trigger an update of the active nodes'
+  dependents. Default is just `'InsertLeave'`, `'TextChanged,TextChangedI'`
+  would update on every change.
+  These, like all other `*_events` are passed to `nvim_create_autocmd` as
+  `events`, so they can be wrapped in a table, like
+  ```lua
+  ls.setup({
+  	update_events = {"TextChanged", "TextChangedI"}
+  })
+  ```
+- `region_check_events`: Events on which to leave the current snippet if the
+  cursor is outside its' 'region'. Disabled by default, `'CursorMoved'`,
+  `'CursorHold'` or `'InsertEnter'` seem reasonable.
+- `delete_check_events`: When to check if the current snippet was deleted, and
+  if so, remove it from the history. Off by default, `'TextChanged'` (perhaps
+  `'InsertLeave'`, to react to changes done in Insert mode) should work just
+  fine (alternatively, this can also be mapped using
+  `<Plug>luasnip-delete-check`). 
+- `store_selection_keys`: Mapping for populating `TM_SELECTED_TEXT` and related
+  variables (not set by default).
+- `enable_autosnippets`: Autosnippets are disabled by default to minimize
+  performance penalty if unused. Set to `true` to enable.
+- `ext_opts`: Additional options passed to extmarks. Can be used to add
+  passive/active highlight on a per-node-basis (more info in DOC.md)
+- `parser_nested_assembler`: Override the default behaviour of inserting a
+  `choiceNode` containing the nested snippet and an empty `insertNode` for
+  nested placeholders (`"${1: ${2: this is nested}}"`). For an example
+  (behaviour more similar to vscode), check
+  [here](https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#imitate-vscodes-behaviour-for-nested-placeholders)
+- `ft_func`: Source of possible filetypes for snippets. Defaults to a function,
+  which returns `vim.split(vim.bo.filetype, ".", true)`, but check
+  [filetype_functions](lua/luasnip/extras/filetype_functions.lua) or the
+  [Extras-Filetype-Functions](#filetype-functions)-section for more options.
+- `load_ft_func`: Function to determine which filetypes belong to a given
+  buffer (used for `lazy_loading`). `fn(bufnr) -> filetypes (string[])`. Again,
+  there are some examples in
+  [filetype_functions](lua/luasnip/extras/filetype_functions.lua).
+- `snip_env`: The best way to author snippets in lua involves the
+  lua-loader (see [Loaders-Lua](#lua)).
+  Unfortunately, this requires that snippets are defined in separate files,
+  which means that common definitions like `s`, `i`, `sn`, `t`, `fmt`, ... have
+  to be repeated in each of them, and that adding more customized functions to
+  ease writing snippets also requires some setup.  
+  `snip_env` can be used to insert variables into exactly the places where
+  lua-snippets are defined (for now only the file loaded by the lua-loader).  
+  Setting `snip_env` to `{ some_global = "a value" }` will add (amongst the
+  defaults stated at the beginning of this documentation) the global variable
+  `some_global` while evaluating these files.  
+  There are special keys which, when set in `snip_env` change the behaviour of
+  this option, and are not passed through to the lua-files:
+  * `__snip_env_behaviour`, string: either `"set"` or `"extend"` (default
+    `"extend"`)  
+    If this is `"extend"`, the variables defined in `snip_env` will complement (and
+    override) the defaults. If this is not desired, `"set"` will not include the
+    defaults, but only the variables set here.
+
+  One side-effect of this is that analysis-tools (most likely
+  `lua-language-server`) for lua will generate diagnostics for the usage of
+  undefined symbols. If you mind the (probably) large number of generated
+  warnings, consider adding the undefined globals to the globals recognized by
+  `lua-language-server` or add `---@diagnostic disable: undefined-global`
+  somewhere in the affected files.
+
+# API
 
 `require("luasnip")`:
 
@@ -2758,21 +2953,20 @@ print a short message to the log.
   `opts` may contain the following keys:
   - `type`: type of `snippets`, `"snippets"` or `"autosnippets"` (ATTENTION:
 	plural form used here). This serves as default value for the `snippetType`
-	key of each snippet added by this call see [SNIPPETS](#SNIPPETS).
-
+	key of each snippet added by this call see [Snippets](#snippets).
   - `key`: Key that identifies snippets added via this call.  
 	If `add_snippets` is called with a key that was already used, the snippets
 	from that previous call will be removed.  
 	This can be used to reload snippets: pass an unique key to each
-	`add_snippets` and just re-do the `add_snippets`-call when the snippets have
+	`add_snippets` and just redo the `add_snippets`-call when the snippets have
 	changed.
   - `override_priority`: set priority for all snippets.
-  - `default_priority`: set priority only for snippets without snippet-priority.
+  - `default_priority`: set priority only for snippets without snippet priority.
 
 - `clean_invalidated(opts: table or nil) -> bool`: clean invalidated snippets
   from internal snippet storage.  
-  Invalidated snippets are still stored, it might be useful to actually remove
-  them, as they still have to be iterated during expansion.
+  Invalidated snippets are still stored; it might be useful to actually remove
+  them as they still have to be iterated during expansion.
 
   `opts` may contain:
 
@@ -2821,12 +3015,12 @@ print a short message to the log.
       this function) as clearing before expansion will populate `TM_CURRENT_LINE`
       and `TM_CURRENT_WORD` with wrong values (they would miss the snippet trigger)
       and clearing after expansion may move the text currently under the cursor
-      and have it end up not at the `i(1)`, but a `#trigger` chars to it's right.
+      and have it end up not at the `i(1)`, but a `#trigger` chars to its right.
       The actual values used for clearing are `from` and `to`, both (0,0)-indexed
       byte-positions.
       If the variables don't have to be populated with the correct values, it's
       safe to remove the text manually.
-    - `expand_params`: table, for overriding the `trigger` used in the snippet
+    - `expand_params`: table for overriding the `trigger` used in the snippet
       and setting the `captures` (useful for pattern-triggered nodes where the
       trigger has to be changed from the pattern to the actual text triggering the
       node).
@@ -2838,14 +3032,14 @@ print a short message to the log.
     - `jump_into_func`: fn(snippet) -> node:
       Callback responsible for jumping into the snippet. The returned node is
       set as the new active node, ie. it is the origin of the next jump.
-      The default is basically this
+      The default is basically this:
       ```lua
       function(snip)
       	-- jump_into set the placeholder of the snippet, 1
       	-- to jump forwards.
       	return snip:jump_into(1)
       ```
-      While this can be used to only insert the snippet
+      while this can be used to only insert the snippet:
       ```lua
       function(snip)
       	return snip.insert_nodes[0]
@@ -2865,7 +3059,7 @@ print a short message to the log.
   if luasnip fails to automatically detect e.g. deletion of a snippet) and
   sets the current node behind the snippet, or, if not possible, before it.
 
-- `lsp_expand(snip_string, opts)`: expand the lsp-syntax-snippet defined via
+- `lsp_expand(snip_string, opts)`: expands the LSP snippet defined via
   `snip_string` at the cursor.
   `opts` can have the same options as `opts` in `snip_expand`.
 
@@ -2873,7 +3067,7 @@ print a short message to the log.
   current node as an argnode (will actually only update them if the text in any
   of the argnodes changed).
 
-- `available(snip_info)`: return a table of all snippets defined for the
+- `available(snip_info)`: returns a table of all snippets defined for the
   current filetypes(s) (`{ft1={snip1, snip2}, ft2={snip3, snip4}}`).
   The structure of the snippet is defined by `snip_info` which is a function
   (`snip_info(snip)`) that takes in a snippet (`snip`), finds the desired
@@ -2883,7 +3077,7 @@ print a short message to the log.
   returned.
 
 - `exit_out_of_region(node)`: checks whether the cursor is still within the
-  range of the snippet `node` belongs to. If yes, no change occurs, if No, the
+  range of the snippet `node` belongs to. If yes, no change occurs; if no, the
   snippet is exited and following snippets' regions are checked and potentially
   exited (the next active node will be the 0-node of the snippet before the one
   the cursor is inside.
@@ -2908,26 +3102,26 @@ print a short message to the log.
 - `load_snippet_docstrings(snippet_table)`: Load docstrings for all snippets
   in `snippet_table` from `stdpath("cache")/luasnip/docstrings.json`.
   The docstrings are stored and restored via trigger, meaning if two
-  snippets for one filetype have the same(very unlikely to happen in actual
+  snippets for one filetype have the same (very unlikely to happen in actual
   usage), bugs could occur.
   `snippet_table` should be laid out as described in `store_snippet_docstrings`.
 
-- `unlink_current_if_deleted()`: Checks if the current snippet was deleted,
+- `unlink_current_if_deleted()`: Checks if the current snippet was deleted;
   if so, it is removed from the jumplist. This is not 100% reliable as
-  luasnip only sees the extmarks and their beginning/end may not be on the same
+  LuaSnip only sees the extmarks and their beginning/end may not be on the same
   position, even if all the text between them was deleted.
 
 - `filetype_extend(filetype:string, extend_filetypes:table of string)`: Tells
   luasnip that for a buffer with `ft=filetype`, snippets from
   `extend_filetypes` should be searched as well. `extend_filetypes` is a
   lua-array (`{ft1, ft2, ft3}`).
-  `luasnip.filetype_extend("lua", {"c", "cpp"})` would search and expand c-and
-  cpp-snippets for lua-files.
+  `luasnip.filetype_extend("lua", {"c", "cpp"})` would search and expand c and
+  cpp snippets for lua files.
 
 - `filetype_set(filetype:string, replace_filetypes:table of string)`: Similar
   to `filetype_extend`, but where _append_ appended filetypes, _set_ sets them:
-  `filetype_set("lua", {"c"})` causes only c-snippets to be expanded in
-  lua-files, lua-snippets aren't even searched.
+  `filetype_set("lua", {"c"})` causes only c snippets to be expanded in
+  lua files; lua snippets aren't even searched.
 
 - `cleanup()`: clears all snippets. Not useful for regular usage, only when
   authoring and testing snippets.
@@ -2950,6 +3144,11 @@ print a short message to the log.
   to the callers environment.
 
 - `get_snip_env()`: Returns `snip_env`.
+
+- `jump_destination(direction)`: Returns the node the next jump in `direction`
+  (either -1 or 1, for backwards, forwards respectively) leads to, or `nil` if
+  the destination could not be determined (most likely because there is no node
+  that can be jumped to in the given direction, or there is no active node).
 
 Not covered in this section are the various node-constructors exposed by
 the module, their usage is shown either previously in this file or in

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,61 +1,64 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 January 27
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 March 28
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
 
-1. BASICS                                                     |luasnip-basics|
-  - Jump-index                                            |luasnip-jump-index|
-  - Adding Snippets                                  |luasnip-adding-snippets|
-2. NODE                                                         |luasnip-node|
-  - Node-Api:                                              |luasnip-node-api:|
-3. SNIPPETS                                                 |luasnip-snippets|
-  - Snippet-Api:                                        |luasnip-snippet-api:|
-4. TEXTNODE                                                 |luasnip-textnode|
-5. INSERTNODE                                             |luasnip-insertnode|
-6. FUNCTIONNODE                                         |luasnip-functionnode|
-  - NODE_REFERENCE                                    |luasnip-node_reference|
-7. CHOICENODE                                             |luasnip-choicenode|
-8. SNIPPETNODE                                           |luasnip-snippetnode|
-9. INDENTSNIPPETNODE                               |luasnip-indentsnippetnode|
-10. DYNAMICNODE                                          |luasnip-dynamicnode|
-11. RESTORENODE                                          |luasnip-restorenode|
-12. ABSOLUTE_INDEXER                                |luasnip-absolute_indexer|
-13. EXTRAS                                                    |luasnip-extras|
-  - Lambda                                                    |luasnip-lambda|
-  - Match                                                      |luasnip-match|
-  - Repeat                                                    |luasnip-repeat|
-  - Partial                                                  |luasnip-partial|
-  - Nonempty                                                |luasnip-nonempty|
-  - Dynamic Lambda                                    |luasnip-dynamic-lambda|
-  - FMT                                                          |luasnip-fmt|
-  - Conditions                                            |luasnip-conditions|
-  - On The Fly snippets                          |luasnip-on-the-fly-snippets|
-  - Select_choice                                      |luasnip-select_choice|
-  - filetype_functions                            |luasnip-filetype_functions|
-  - POSTFIX SNIPPET                                  |luasnip-postfix-snippet|
-  - Snippet List                                        |luasnip-snippet-list|
-14. EXTEND_DECORATOR                                |luasnip-extend_decorator|
-15. LSP-SNIPPETS                                        |luasnip-lsp-snippets|
-  - Snipmate Parser                                  |luasnip-snipmate-parser|
-  - Transformations                                  |luasnip-transformations|
-16. VARIABLES                                              |luasnip-variables|
-  - Environment Namespaces                    |luasnip-environment-namespaces|
-  - LSP-Variables                                      |luasnip-lsp-variables|
-17. LOADERS                                                  |luasnip-loaders|
-  - Troubleshooting                                  |luasnip-troubleshooting|
-  - VSCODE                                                    |luasnip-vscode|
-  - SNIPMATE                                                |luasnip-snipmate|
-  - LUA                                                          |luasnip-lua|
-  - EDIT_SNIPPETS                                      |luasnip-edit_snippets|
-18. SNIPPETPROXY                                        |luasnip-snippetproxy|
-19. EXT_OPTS                                                |luasnip-ext_opts|
-20. DOCSTRING                                              |luasnip-docstring|
-21. DOCSTRING-CACHE                                  |luasnip-docstring-cache|
-22. EVENTS                                                    |luasnip-events|
-23. CLEANUP                                                  |luasnip-cleanup|
-24. Logging                                                  |luasnip-logging|
-25. API-REFERENCE                                      |luasnip-api-reference|
-
+1. Basics                                                     |luasnip-basics|
+  - Jump-Index                                     |luasnip-basics-jump-index|
+  - Adding Snippets                           |luasnip-basics-adding-snippets|
+2. Node                                                         |luasnip-node|
+  - Api                                                     |luasnip-node-api|
+3. Snippets                                                 |luasnip-snippets|
+  - Data                                               |luasnip-snippets-data|
+  - Api                                                 |luasnip-snippets-api|
+4. TextNode                                                 |luasnip-textnode|
+5. InsertNode                                             |luasnip-insertnode|
+6. FunctionNode                                         |luasnip-functionnode|
+7. Node Reference                                     |luasnip-node-reference|
+8. ChoiceNode                                             |luasnip-choicenode|
+9. SnippetNode                                           |luasnip-snippetnode|
+10. IndentSnippetNode                              |luasnip-indentsnippetnode|
+11. DynamicNode                                          |luasnip-dynamicnode|
+12. RestoreNode                                          |luasnip-restorenode|
+13. Absolute Indexer                                |luasnip-absolute-indexer|
+14. MultiSnippet                                        |luasnip-multisnippet|
+15. Extras                                                    |luasnip-extras|
+  - Lambda                                             |luasnip-extras-lambda|
+  - Match                                               |luasnip-extras-match|
+  - Repeat                                             |luasnip-extras-repeat|
+  - Partial                                           |luasnip-extras-partial|
+  - Nonempty                                         |luasnip-extras-nonempty|
+  - Dynamic Lambda                             |luasnip-extras-dynamic-lambda|
+  - FMT                                                   |luasnip-extras-fmt|
+  - Conditions                                     |luasnip-extras-conditions|
+  - On The Fly-Snippets                   |luasnip-extras-on-the-fly-snippets|
+  - select_choice                               |luasnip-extras-select_choice|
+  - Filetype-Functions                     |luasnip-extras-filetype-functions|
+  - Postfix-Snippet                           |luasnip-extras-postfix-snippet|
+  - Snippet List                                 |luasnip-extras-snippet-list|
+16. Extend Decorator                                |luasnip-extend-decorator|
+17. LSP-Snippets                                        |luasnip-lsp-snippets|
+  - Snipmate Parser                     |luasnip-lsp-snippets-snipmate-parser|
+  - Transformations                     |luasnip-lsp-snippets-transformations|
+  - VSCode snippet extra fields|luasnip-lsp-snippets-vscode-snippet-extra-fields|
+18. VARIABLES                                              |luasnip-variables|
+  - Environment Namespaces          |luasnip-variables-environment-namespaces|
+  - LSP-Variables                            |luasnip-variables-lsp-variables|
+19. Loaders                                                  |luasnip-loaders|
+  - Troubleshooting                          |luasnip-loaders-troubleshooting|
+  - VS-Code                                          |luasnip-loaders-vs-code|
+  - SNIPMATE                                        |luasnip-loaders-snipmate|
+  - Lua                                                  |luasnip-loaders-lua|
+  - edit_snippets                              |luasnip-loaders-edit_snippets|
+20. SnippetProxy                                        |luasnip-snippetproxy|
+21. ext_opts                                                |luasnip-ext_opts|
+22. Docstrings                                            |luasnip-docstrings|
+23. Docstring-Cache                                  |luasnip-docstring-cache|
+24. Events                                                    |luasnip-events|
+25. Cleanup                                                  |luasnip-cleanup|
+26. Logging                                                  |luasnip-logging|
+27. Config-Options                                    |luasnip-config-options|
+28. API                                                          |luasnip-api|
 >
                 __                       ____
                /\ \                     /\  _`\           __
@@ -68,16 +71,15 @@ Table of Contents                                  *luasnip-table-of-contents*
                                                                   \/_/
 <
 
-
-Luasnip is a snippet-engine written entirely in lua. It has some great features
+LuaSnip is a snippet engine written entirely in Lua. It has some great features
 like inserting text (`luasnip-function-node`) or nodes (`luasnip-dynamic-node`)
 based on user input, parsing LSP syntax and switching nodes
 (`luasnip-choice-node`). For basic setup like mappings and installing, check
 the README.
 
-All code-snippets in this help assume that
+All code snippets in this help assume the following:
 
->
+>lua
     local ls = require("luasnip")
     local s = ls.snippet
     local sn = ls.snippet_node
@@ -103,23 +105,22 @@ All code-snippets in this help assume that
     local postfix = require("luasnip.extras.postfix").postfix
     local types = require("luasnip.util.types")
     local parse = require("luasnip.util.parser").parse_snippet
+    local ms = ls.multi_snippet
 <
 
-
-As noted in |luasnip-the-lua-section|:
+As noted in the |luasnip-loaders-lua|-section:
 
 
   By default, the names from `luasnip.config.snip_env`
   <https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L147>
   will be used, but it’s possible to customize them by setting `snip_env` in
   `setup`.
-
-
 Furthermore, note that while this document assumes you have defined `ls` to be
 `require("luasnip")`, it is **not** provided in the default set of variables.
 
+
 ==============================================================================
-1. BASICS                                                     *luasnip-basics*
+1. Basics                                                     *luasnip-basics*
 
 In LuaSnip, snippets are made up of `nodes`. These can contain either
 
@@ -133,31 +134,30 @@ In LuaSnip, snippets are made up of `nodes`. These can contain either
     - `restoreNode`: store and restore input to nodes
 - or nodes that can be generated based on input (`dynamicNode`).
 
-
 Snippets are always created using the `s(trigger:string,
 nodes:table)`-function. It is explained in more detail in |luasnip-snippets|,
 but the gist is that it creates a snippet that contains the nodes specified in
 `nodes`, which will be inserted into a buffer if the text before the cursor
 matches `trigger` when `ls.expand` is called.
 
-JUMP-INDEX                                                *luasnip-jump-index*
+
+JUMP-INDEX                                         *luasnip-basics-jump-index*
 
 Nodes that can be jumped to (`insertNode`, `choiceNode`, `dynamicNode`,
 `restoreNode`, `snippetNode`) all require a "jump-index" so luasnip knows the
 order in which these nodes are supposed to be visited ("jumped to").
 
->
+>lua
     s("trig", {
         i(1), t"text", i(2), t"text again", i(3)
     })
 <
 
-
 These indices don’t "run" through the entire snippet, like they do in
 textmate-snippets (`"$1 ${2: $3 $4}"`), they restart at 1 in each nested
 snippetNode:
 
->
+>lua
     s("trig", {
         i(1), t" ", sn(2, {
             t" ", i(1), t" ", i(2)
@@ -165,16 +165,16 @@ snippetNode:
     })
 <
 
-
 (roughly equivalent to the given textmate-snippet).
 
-ADDING SNIPPETS                                      *luasnip-adding-snippets*
+
+ADDING SNIPPETS                               *luasnip-basics-adding-snippets*
 
 The snippets for a given filetype have to be added to luasnip via
 `ls.add_snippets(filetype, snippets)`. Snippets that should be accessible
 globally (in all filetypes) have to be added to the special filetype `all`.
 
->
+>lua
     ls.add_snippets("all", {
         s("ternary", {
             -- equivalent to "${1:cond} ? ${2:then} : ${3:else}"
@@ -183,35 +183,45 @@ globally (in all filetypes) have to be added to the special filetype `all`.
     })
 <
 
-
 It is possible to make snippets from one filetype available to another using
-`ls.filetype_extend`, more info on that |luasnip-here|.
+`ls.filetype_extend`, more info on that in the section |luasnip-api|.
+
 
 ==============================================================================
-2. NODE                                                         *luasnip-node*
+2. Node                                                         *luasnip-node*
 
 Every node accepts, as its last parameter, an optional table of arguments.
-There are some common ones (e.g. |luasnip-`node_ext_opts`|), and some that
-only apply to some nodes (`user_args` for both function and dynamicNode). These
-`opts` are only mentioned if they accept options that are not common to all
-nodes.
+There are some common ones (e.g. `node_ext_opts`, described in
+|luasnip-ext_opts|), and some that only apply to some nodes (`user_args` for
+both function and dynamicNode). These `opts` are only mentioned if they accept
+options that are not common to all nodes.
 
-NODE-API:                                                  *luasnip-node-api:*
+
+API                                                         *luasnip-node-api*
 
 
 - `get_jump_index()`: this method returns the jump-index of a node. If a node
     doesn’t have a jump-index, this method returns `nil` instead.
+- `get_buf_position(opts) -> {from_position, to_position}`:
+    Determines the range of the buffer occupied by this node. `from`- and
+    `to_position` are `row,column`-tuples, `0,0`-indexed (first line is 0, first
+    column is 0) and end-inclusive (see `:h api-indexing`, this is extmarks
+    indexing).
+    - `opts`: `table|nil`, options, valid keys are:
+        - `raw`: `bool`, default `true`. This can be used to switch between
+            byte-columns (`raw=true`) and visual columns (`raw=false`). This makes a
+            difference if the line contains characters represented by multiple bytes
+            in UTF, for example `ÿ`.
 
 
 ==============================================================================
-3. SNIPPETS                                                 *luasnip-snippets*
+3. Snippets                                                 *luasnip-snippets*
 
 The most direct way to define snippets is `s`:
 
->
+>lua
     s({trig="trigger"}, {})
 <
-
 
 (This snippet is useless beyond serving as a minimal example)
 
@@ -219,7 +229,7 @@ The most direct way to define snippets is `s`:
 
 
 - `context`: Either table or a string. Passing a string is equivalent to passing
-    >
+    >lua
         {
           trig = context
         }
@@ -250,8 +260,6 @@ The most direct way to define snippets is `s`:
         `ls.config.setup({ enable_autosnippets = true })` if you want to use this
         feature). If unset it depends on how the snippet is added of which type the
         snippet will be.
-- `nodes`: A single node, or a list of nodes. The nodes that make up the snippet.
-- `opts`: A table, with the following valid keys:
     - `condition`: `fn(line_to_cursor, matched_trigger, captures) -> bool`, where
         - `line_to_cursor`: `string`, the line up to the cursor.
         - `matched_trigger`: `string`, the fully matched trigger (can be retrieved
@@ -259,22 +267,21 @@ The most direct way to define snippets is `s`:
         - `captures`: if the trigger is pattern, this list contains the
             capture-groups. Again, could be computed from `line_to_cursor`, but we
             already did so.
-        The snippet will be expanded only if this function returns true (default is a
-        function that just returns `true`). The function is called before the text on
-        the line is modified in any way.
     - `show_condition`: `f(line_to_cursor) -> bool`.
         - `line_to_cursor`: `string`, the line up to the cursor.
-        This function is (should be) evaluated by completion-engines, indicating
+        This function is (should be) evaluated by completion engines, indicating
         whether the snippet should be included in current completion candidates.
-        Defaults to a function returning `true`. This is different from `condition`
-        because `condition` is evaluated by LuaSnip on snippet expansion (and thus has
-        access to the matched trigger and captures), while `show_condition` is (should
-        be) evaluated by the completion-engine when scanning for available snippet
-        candidates.
+        Defaults to a function returning `true`.
+        This is different from `condition` because `condition` is evaluated by
+        LuaSnip on snippet expansion (and thus has access to the matched trigger and
+        captures), while `show_condition` is (should be) evaluated by the
+        completion engines when scanning for available snippet candidates.
+- `nodes`: A single node or a list of nodes. The nodes that make up the snippet.
+- `opts`: A table with the following valid keys:
     - `callbacks`: Contains functions that are called upon entering/leaving a node of
         this snippet. For example: to print text upon entering the _second_ node of a
         snippet, `callbacks` should be set as follows:
-        >
+        >lua
             {
                 -- position of the node, not the jump-index!!
                 -- s("trig", {t"first node", t"second node", i(1, "third node")}).
@@ -284,29 +291,29 @@ The most direct way to define snippets is `s`:
             }
         <
         To register a callback for the snippets’ own events, the key `[-1]` may be
-        used. More info on events |luasnip-here|
+        used. More info on events in |luasnip-events|
     - `child_ext_opts`, `merge_child_ext_opts`: Control `ext_opts` applied to the
-        children of this snippet. More info on those |luasnip-here|.
+        children of this snippet. More info on those in the |luasnip-ext_opts|-section.
+
+The `opts`-table, as described here, can also be passed to e.g. `snippetNode`
+and `indentSnippetNode`. It is also possible to set `condition` and
+`show_condition` (described in the documentation of the `context`-table) from
+`opts`. They should, however, not be set from both.
 
 
-The `opts`-table can also be passed to e.g. `snippetNode` and
-`indentSnippetNode`, but only `callbacks` and the `ext_opts`-related options
-are used there.
-
-SNIPPET-DATA ~
+DATA                                                   *luasnip-snippets-data*
 
 Snippets contain some interesting tables during runtime:
 
 
 - `snippet.env`: Contains variables used in the LSP-protocol, for example
     `TM_CURRENT_LINE` or `TM_FILENAME`. It’s possible to add customized variables
-    here too, check |luasnip-environment-namespaces|
+    here too, check |luasnip-variables-environment-namespaces|
 - `snippet.captures`: If the snippet was triggered by a pattern (`regTrig`), and
     the pattern contained capture-groups, they can be retrieved here.
 - `snippet.trigger`: The string that triggered this snippet. Again, only
     interesting if the snippet was triggered through `regTrig`, for getting the
     full match.
-
 
 These variables/tables primarily come in handy in `dynamic/functionNodes`,
 where the snippet can be accessed through the immediate parent
@@ -314,7 +321,8 @@ where the snippet can be accessed through the immediate parent
 parent.snippet`, but the `parent` of the dynamicNode is not always the
 surrounding snippet, it could be a `snippetNode`).
 
-SNIPPET-API:                                            *luasnip-snippet-api:*
+
+API                                                     *luasnip-snippets-api*
 
 
 - `invalidate()`: call this method to effectively remove the snippet. The
@@ -325,14 +333,13 @@ SNIPPET-API:                                            *luasnip-snippet-api:*
 
 
 ==============================================================================
-4. TEXTNODE                                                 *luasnip-textnode*
+4. TextNode                                                 *luasnip-textnode*
 
 The most simple kind of node; just text.
 
->
+>lua
     s("trigger", { t("Wow! Text!") })
 <
-
 
 This snippet expands to
 
@@ -340,33 +347,33 @@ This snippet expands to
         Wow! Text!⎵
 <
 
+where ⎵ is the cursor.
 
-Where ⎵ is the cursor. Multiline-strings can be defined by passing a table of
-lines rather than a string:
+Multiline strings can be defined by passing a table of lines rather than a
+string:
 
->
+>lua
     s("trigger", {
         t({"Wow! Text!", "And another line."})
     })
 <
 
-
 `t(text, node_opts)`:
 
 
 - `text`: `string` or `string[]`
-- `node_opts`: `table`, see |luasnip-here|
+- `node_opts`: `table`, see |luasnip-node|
 
 
 ==============================================================================
-5. INSERTNODE                                             *luasnip-insertnode*
+5. InsertNode                                             *luasnip-insertnode*
 
 These Nodes contain editable text and can be jumped to- and from (e.g.
 traditional placeholders and tabstops, like `$1` in textmate-snippets).
 
 The functionality is best demonstrated with an example:
 
->
+>lua
     s("trigger", {
         t({"After expanding, the cursor is here ->"}), i(1),
         t({"", "After jumping forward once, cursor is here ->"}), i(2),
@@ -374,23 +381,19 @@ The functionality is best demonstrated with an example:
     })
 <
 
-
-The InsertNodes are visited in order `1,2,3,..,n,0`. (The jump-index 0 also
+The Insert Nodes are visited in order `1,2,3,..,n,0`. (The jump-index 0 also
 _has_ to belong to an `insertNode`!) So the order of InsertNode-jumps is as
 follows:
 
 
-1. After expansion, the cursor is at InsertNode 1,
-2. after jumping forward once at InsertNode 2,
-3. and after jumping forward again at InsertNode 0.
-
+1. After expansion, the cursor is at InsertNode 1,2. after jumping forward once at InsertNode 2,3. and after jumping forward again at InsertNode 0.
 
 If no 0-th InsertNode is found in a snippet, one is automatically inserted
 after all other nodes.
 
 The jump-order doesn’t have to follow the "textual" order of the nodes:
 
->
+>lua
     s("trigger", {
         t({"After jumping forward once, cursor is here ->"}), i(2),
         t({"", "After expanding, the cursor is here ->"}), i(1),
@@ -398,19 +401,15 @@ The jump-order doesn’t have to follow the "textual" order of the nodes:
     })
 <
 
-
 The above snippet will behave as follows:
 
 
-1. After expansion, we will be at InsertNode 1.
-2. After jumping forward, we will be at InsertNode 2.
-3. After jumping forward again, we will be at InsertNode 0.
+1. After expansion, we will be at InsertNode 1.2. After jumping forward, we will be at InsertNode 2.3. After jumping forward again, we will be at InsertNode 0.
 
-
-An **important** (because here luasnip differs from other snippet-engines)
+An **important** (because here Luasnip differs from other snippet engines)
 detail is that the jump-indices restart at 1 in nested snippets:
 
->
+>lua
     s("trigger", {
         i(1, "First jump"),
         t(" :: "),
@@ -422,13 +421,11 @@ detail is that the jump-indices restart at 1 in nested snippets:
     })
 <
 
+as opposed to e.g. the textmate syntax, where tabstops are snippet-global:
 
-as opposed to e.g. the textmate-syntax, where tabstops are snippet-global:
-
->
+>snippet
     ${1:First jump} :: ${2: ${3:Third jump} : ${4:Fourth jump}}
 <
-
 
 (this is not exactly the same snippet of course, but as close as possible) (the
 restart-rule only applies when defining snippets in lua, the above
@@ -437,23 +434,24 @@ textmate-snippet will expand correctly when parsed).
 `i(jump_index, text, node_opts)`
 
 
-- |luasnip-`jump_index`|: `number`, this determines when this node will be jumped to.
+- `jump_index`: `number`, this determines when this node will be jumped to (see
+    |luasnip-basics-jump-index|).
 - `text`: `string|string[]`, a single string for just one line, a list with >1
     entries for multiple lines.
     This text will be SELECTed when the `insertNode` is jumped into.
-- `node_opts`: `table`, see |luasnip-here|
-
+- `node_opts`: `table`, described in |luasnip-node|
 
 If the `jump_index` is `0`, replacing its’ `text` will leave it outside the
 `insertNode` (for reasons, check out Luasnip#110).
 
+
 ==============================================================================
-6. FUNCTIONNODE                                         *luasnip-functionnode*
+6. FunctionNode                                         *luasnip-functionnode*
 
 Function Nodes insert text based on the content of other nodes using a
 user-defined function:
 
->
+>lua
     local function fn(
       args,     -- text from i(2) in this example i.e. { { "456" } }
       parent,   -- parent snippet or parent node
@@ -472,37 +470,36 @@ user-defined function:
     })
 <
 
-
 `f(fn, argnode_references, node_opts)`: - `fn`: `function(argnode_text, parent,
 user_args1,...,user_argsn) -> text` - `argnode_text`: `string[][]`, the text
 currently contained in the argnodes (e.g. `{{line1}, {line1, line2}}`). The
-snippet-indent will be removed from all lines following the first.
+snippet indent will be removed from all lines following the first.
 
 
 - `parent`: The immediate parent of the `functionNode`. It is included here as it
     allows easy access to some information that could be useful in functionNodes
-    (see |luasnip-here| for some examples). Many snippets access the surrounding
-    snippet just as `parent`, but if the `functionNode` is nested within a
-    `snippetNode`, the immediate parent is a `snippetNode`, not the surrounding
-    snippet (only the surrounding snippet contains data like `env` or `captures`).
+    (see |luasnip-snippets-data| for some examples). Many snippets access the
+    surrounding snippet just as `parent`, but if the `functionNode` is nested
+    within a `snippetNode`, the immediate parent is a `snippetNode`, not the
+    surrounding snippet (only the surrounding snippet contains data like `env` or
+    `captures`).
 - `user_args`: The `user_args` passed in `opts`. Note that there may be multiple
     user_args (e.g. `user_args1, ..., user_argsn`).
 
-
-`fn` shall return a string, which will be inserted as-is, or a table of strings
-for multiline-string, here all lines following the first will be prefixed with
-the snippets’ indentation.
+`fn` shall return a string, which will be inserted as is, or a table of strings
+for multiline strings, where all lines following the first will be prefixed
+with the snippets’ indentation.
 
 
 - `argnode_references`: `node_reference[]|node_refernce|nil`. Either no, a
-    single, or multiple |luasnip-node-references|. Changing any of these will
-    trigger a re-evaluation of `fn`, and insertion of the updated text. If no
-    node-reference is passed, the `functionNode` is evaluated once upon expansion.
-- `node_opts`: `table`, see |luasnip-here|. One additional key is supported:
+    single, or multiple |luasnip-node-reference|s. Changing any of these will
+    trigger a re-evaluation of `fn`, and insertion of the updated text. If no node
+    reference is passed, the `functionNode` is evaluated once upon expansion.
+- `node_opts`: `table`, see |luasnip-node|. One additional key is supported:
     - `user_args`: `any[]`, these will be passed to `fn` as `user_arg1`-`user_argn`.
         These make it easier to reuse similar functions, for example a functionNode
         that wraps some text in different delimiters (`()`, `[]`, …).
-        >
+        >lua
             local function reused_func(_,_, user_arg1)
                 return user_arg1
             end
@@ -517,19 +514,18 @@ the snippets’ indentation.
             })
         <
 
-
 **Examples**:
 
 
-- Use captures from the regex-trigger using a functionNode:
-    >
+- Use captures from the regex trigger using a functionNode:
+    >lua
         s({trig = "b(%d)", regTrig = true},
           f(function(args, snip) return
               "Captured Text: " .. snip.captures[1] .. "." end, {})
         )
     <
-- `argnodes_text` during function-evaluation:
-    >
+- `argnodes_text` during function evaluation:
+    >lua
         s("trig", {
           i(1, "text_of_first"),
           i(2, {"first_line_of_second", "second_line_of_second"}),
@@ -540,14 +536,14 @@ the snippets’ indentation.
     <
     At `--here`, `args` would look as follows (provided no text was changed after
     expansion):
-    >
+    >lua
         args = {
           {"first_line_of_second", "second_line_of_second"},
           {"text_of_first"}
         }
     <
-- |luasnip-`absolute_indexer`|:
-    >
+- |luasnip-absolute-indexer|:
+    >lua
         s("trig", {
           i(1, "text_of_first"),
           i(2, {"first_line_of_second", "second_line_of_second"}),
@@ -557,31 +553,34 @@ the snippets’ indentation.
           end, {ai[2], ai[1]} )})
     <
 
-
 If the function only performs simple operations on text, consider using the
-`lambda` from |luasnip-`luasnip.extras`|
+`lambda` from `luasnip.extras` (See |luasnip-extras-lambda|)
 
-NODE_REFERENCE                                        *luasnip-node_reference*
-
-Node-references are used to refer to other nodes in various parts of
-luasnip’s API. For example, argnodes in functionNode, dynamicNode or lambda
-are node-references. These references can be either of: - `number`: the
-jump-index of the node. This will be resolved relative to the parent of the
-node this is passed to. (So, only nodes with the same parent can be referenced.
-This is very easy to grasp, but also limiting) - |luasnip-`absolute_indexer`|:
-the absolute position of the node. This will come in handy if the referred-to
-node is not in the same snippet/snippetNode as the one this node-reference is
-passed to. - `node`: just the node. Usage of this is discouraged, since it can
-lead to subtle errors (for example if the node passed here is captured in a
-closure and therefore not copied with the remaining tables in the snippet
-(there’s a big comment about just this in commit 8bfbd61)).
 
 ==============================================================================
-7. CHOICENODE                                             *luasnip-choicenode*
+7. Node Reference                                     *luasnip-node-reference*
+
+Node references are used to refer to other nodes in various parts of
+luasnip’s API. For example, argnodes in functionNode, dynamicNode or lambda
+are node references. These references can be either of: - `number`: the
+jump-index of the node. This will be resolved relative to the parent of the
+node this is passed to. (So, only nodes with the same parent can be referenced.
+This is very easy to grasp, but also limiting) - `absolute_indexer`: the
+absolute position of the node. This will come in handy if the node that is
+being referred to is not in the same snippet/snippetNode as the one the node
+reference is passed to (More in |luasnip-absolute-indexer|). - `node`: just the
+node. Usage of this is discouraged since it can lead to subtle errors (for
+example, if the node passed here is captured in a closure and therefore not
+copied with the remaining tables in the snippet; there’s a big comment about
+just this in commit 8bfbd61).
+
+
+==============================================================================
+8. ChoiceNode                                             *luasnip-choicenode*
 
 ChoiceNodes allow choosing between multiple nodes.
 
->
+>lua
      s("trig", c(1, {
         t("Ugh boring, a text node"),
         i(nil, "At least I can edit something now..."),
@@ -589,26 +588,32 @@ ChoiceNodes allow choosing between multiple nodes.
      }))
 <
 
-
 `c(jump_index, choices, node_opts)`
 
 
-- |luasnip-`jump_index`|: `number`, since choiceNodes can be jumped to, they need their
-    jump-indx.
+- `jump_index`: `number`, since choiceNodes can be jumped to, they need a
+    jump-index (Info in |luasnip-basics-jump-index|).
 - `choices`: `node[]|node`, the choices. The first will be initialliy active.
     A list of nodes will be turned into a `snippetNode`.
 - `node_opts`: `table`. `choiceNode` supports the keys common to all nodes
-    described |luasnip-here|, and one additional key:
-    - `restore_cursor`: `false` by default. If it is set, and the node that was
-        being edited also appears in the switched-to choice (can be the case if a
+    described in |luasnip-node|, and one additional key:
+    - `restore_cursor`: `false` by default. If it is set, and the node that was being
+        edited also appears in the switched to choice (can be the case if a
         `restoreNode` is present in both choice) the cursor is restored relative to
-        that node.
-        The default is `false` as enabling might lead to decreased performance. It’s
-        possible to override the default by wrapping the `choiceNode`-constructor
-        in another function that sets `opts.restore_cursor` to `true` and then using
-        that to construct `choiceNode`s:
-        `lua     local function restore_cursor_choice(pos, choices, opts)         if opts then             opts.restore_cursor = true         else             opts = {restore_cursor = true}         end         return c(pos, choices, opts)     end`
-
+        that node. The default is `false` as enabling might lead to decreased
+        performance. It’s possible to override the default by wrapping the
+        `choiceNode` constructor in another function that sets `opts.restore_cursor` to
+        `true` and then using that to construct `choiceNode`s:
+        >lua
+            local function restore_cursor_choice(pos, choices, opts)
+                if opts then
+                    opts.restore_cursor = true
+                else
+                    opts = {restore_cursor = true}
+                end
+                return c(pos, choices, opts)
+            end
+        <
 
 Jumpable nodes that normally expect an index as their first parameter don’t
 need one inside a choiceNode; their jump-index is the same as the
@@ -616,11 +621,12 @@ choiceNodes’.
 
 As it is only possible (for now) to change choices from within the choiceNode,
 make sure that all of the choices have some place for the cursor to stop at!
+
 This means that in `sn(nil, {...nodes...})` `nodes` has to contain e.g. an
 `i(1)`, otherwise luasnip will just "jump through" the nodes, making it
 impossible to change the choice.
 
->
+>lua
     c(1, {
         t"some text", -- textNodes are just stopped at.
         i(nil, "some text"), -- likewise.
@@ -629,13 +635,14 @@ impossible to change the choice.
     })
 <
 
-
 The active choice for a choiceNode can be changed by either calling one of
 `ls.change_choice(1)` (forwards) or `ls.change_choice(-1)` (backwards), or by
-calling `ls.set_choice(choice_indx)`. One way to easily interact with
-choiceNodes is binding `change_choice(1/-1)` to keys:
+calling `ls.set_choice(choice_indx)`.
 
->
+One way to easily interact with choiceNodes is binding `change_choice(1/-1)` to
+keys:
+
+>lua
     -- set keybinds for both INSERT and VISUAL.
     vim.api.nvim_set_keymap("i", "<C-n>", "<Plug>luasnip-next-choice", {})
     vim.api.nvim_set_keymap("s", "<C-n>", "<Plug>luasnip-next-choice", {})
@@ -643,12 +650,13 @@ choiceNodes is binding `change_choice(1/-1)` to keys:
     vim.api.nvim_set_keymap("s", "<C-p>", "<Plug>luasnip-prev-choice", {})
 <
 
+Apart from this, there is also a picker (see |luasnip-select_choice| where no
+cycling is necessary and any choice can be selected right away, via
+`vim.ui.select`.
 
-Apart from this, there is also a |luasnip-picker| where no cycling is necessary
-and any choice can be selected right away, via `vim.ui.select`.
 
 ==============================================================================
-8. SNIPPETNODE                                           *luasnip-snippetnode*
+9. SnippetNode                                           *luasnip-snippetnode*
 
 SnippetNodes directly insert their contents into the surrounding snippet. This
 is useful for `choiceNode`s, which only accept one child, or `dynamicNode`s,
@@ -658,35 +666,35 @@ Their syntax is similar to `s`, however, where snippets require a table
 specifying when to expand, `snippetNode`s, similar to `insertNode`s, expect a
 jump-index.
 
->
+>lua
      s("trig", sn(1, {
         t("basically just text "),
         i(1, "And an insertNode.")
      }))
 <
 
-
 `sn(jump_index, nodes, node_opts)`
 
 
-- |luasnip-`jump_index`|: `number`, the usual.
+- `jump_index`: `number`, the usual |luasnip-jump-index|.
 - `nodes`: `node[]|node`, just like for `s`.
     Note that `snippetNode`s don’t accept an `i(0)`, so the jump-indices of the nodes
     inside them have to be in `1,2,...,n`.
-- `node_opts`: `table`: again, all |luasnip-common| keys are supported, but also
+- `node_opts`: `table`: again, the keys common to all nodes (documented in
+    |luasnip-node|) are supported, but also
     - `callbacks`,
     - `child_ext_opts` and
     - `merge_child_ext_opts`,
-    which are further explained in |luasnip-`snippets`|.
+    which are further explained in |luasnip-snippets|.
 
 
 ==============================================================================
-9. INDENTSNIPPETNODE                               *luasnip-indentsnippetnode*
+10. IndentSnippetNode                              *luasnip-indentsnippetnode*
 
 By default, all nodes are indented at least as deep as the trigger. With these
 nodes it’s possible to override that behaviour:
 
->
+>lua
     s("isn", {
         isn(1, {
             t({"This is indented as deep as the trigger",
@@ -695,32 +703,32 @@ nodes it’s possible to override that behaviour:
     })
 <
 
-
 (Note the empty string passed to isn).
 
 Indent is only applied after linebreaks, so it’s not possible to remove
 indent on the line where the snippet was triggered using `ISN` (That is
-possible via regex-triggers where the entire line before the trigger is
+possible via regex triggers where the entire line before the trigger is
 matched).
 
-Another nice usecase for `ISN` is inserting text, e.g. `//` or some other
-comment- string before the nodes of the snippet:
+Another nice use case for `ISN` is inserting text, e.g. `//` or some other
+comment string before the nodes of the snippet:
 
->
+>lua
     s("isn2", {
         isn(1, t({"//This is", "A multiline", "comment"}), "$PARENT_INDENT//")
     })
 <
 
-
 Here the `//` before `This is` is important, once again, because indent is only
-applied after linebreaks. To enable such usage, `$PARENT_INDENT` in the
-indentstring is replaced by the parent’s indent (duh).
+applied after linebreaks.
+
+To enable such usage, `$PARENT_INDENT` in the indentstring is replaced by the
+parent’s indent.
 
 `isn(jump_index, nodes, indentstring, node_opts)`
 
-All of these except `indentstring` are exactly the same as
-|luasnip-`snippetnode`|.
+All of these parameters except `indentstring` are exactly the same as in
+|luasnip-snippetnode|.
 
 
 - `indentstring`: `string`, will be used to indent the nodes inside this
@@ -730,50 +738,50 @@ All of these except `indentstring` are exactly the same as
 
 
 ==============================================================================
-10. DYNAMICNODE                                          *luasnip-dynamicnode*
+11. DynamicNode                                          *luasnip-dynamicnode*
 
 Very similar to functionNode, but returns a snippetNode instead of just text,
 which makes them very powerful as parts of the snippet can be changed based on
-user-input.
+user input.
 
 `d(jump_index, function, node-references, opts)`:
 
 
-- |luasnip-`jump_index`|: `number`, just like all jumpable nodes, its’ position
-    in the jump-list.
+- `jump_index`: `number`, just like all jumpable nodes, its’ position in the
+    jump-list (|luasnip-basics-jump-index|).
 - `function`: `fn(args, parent, old_state, user_args) -> snippetNode` This
     function is called when the argnodes’ text changes. It should generate and
-    returns (wrapped inside a `snippetNode`) nodes, these will be inserted at the
-    dynamicNodes place. `args`, `parent` and `user_args` are also explained in
+    return (wrapped inside a `snippetNode`) nodes, which will be inserted at the
+    dynamicNode’s place. `args`, `parent` and `user_args` are also explained in
     |luasnip-functionnode|
     - `args`: `table of text` (`{{"node1line1", "node1line2"}, {"node2line1"}}`)
         from nodes the `dynamicNode` depends on.
     - `parent`: the immediate parent of the `dynamicNode`.
-    - `old_state`: a user-defined table. This table may contain anything, its
+    - `old_state`: a user-defined table. This table may contain anything; its
         intended usage is to preserve information from the previously generated
-        `snippetNode`: If the `dynamicNode` depends on other nodes it may be
+        `snippetNode`. If the `dynamicNode` depends on other nodes, it may be
         reconstructed, which means all user input (text inserted in `insertNodes`,
-        changed choices) to the previous dynamicNode is lost.
+        changed choices) to the previous `dynamicNode` is lost.
         The `old_state` table must be stored in `snippetNode` returned by
         the function (`snippetNode.old_state`).
         The second example below illustrates the usage of `old_state`.
-    - `user_args`: passed through from `dynamicNode`-opts, may be more than one
+    - `user_args`: passed through from `dynamicNode`-opts; may have more than one
         argument.
-- `node_references`: `node_reference[]|node_references|nil`, |luasnip-references|
-    to the nodes the dynamicNode depends on: if any of these trigger an update (for
-    example if the text inside them changes), the `dynamicNode`s’ function will
-    be executed, and the result inserted at the `dynamicNodes` place.
-    (`dynamicNode` behaves exactly the same as `functionNode` in this regard).
-- `opts`: In addition to the |luasnip-usual| keys, there is, again,
+- `node_references`: `node_reference[]|node_references|nil`,
+    |luasnip-node-references| to the nodes the dynamicNode depends on: if any of
+    these trigger an update (for example, if the text inside them changes), the
+    `dynamicNode`s’ function will be executed, and the result inserted at the
+    `dynamicNode`s place. (`dynamicNode` behaves exactly the same as `functionNode`
+    in this regard).
+- `opts`: In addition to the common |luasnip-node|-keys, there is, again,
     - `user_args`, which is described in |luasnip-functionnode|.
-
 
 **Examples**:
 
 This `dynamicNode` inserts an `insertNode` which copies the text inside the
 first `insertNode`.
 
->
+>lua
     s("trig", {
         t"text: ", i(1), t{"", "copy: "},
         d(2, function(args)
@@ -788,13 +796,13 @@ first `insertNode`.
     })
 <
 
+This snippet makes use of `old_state` to count the number of updates.
 
-This snippet makes use of `old_state` to count the number of updates. To
-store/restore values generated by the `dynamicNode` or entered into
+To store/restore values generated by the `dynamicNode` or entered into
 `insert/choiceNode`, consider using the shortly-introduced `restoreNode`
 instead of `old_state`.
 
->
+>lua
     local function count(_, _, old_state)
         old_state = old_state or {
             updates = 0
@@ -820,17 +828,17 @@ instead of `old_state`.
     )
 <
 
-
 As with `functionNode`, `user_args` can be used to reuse similar `dynamicNode`-
 functions.
 
-==============================================================================
-11. RESTORENODE                                          *luasnip-restorenode*
 
-This node can store and restore a snippetNode as-is. This includes changed
+==============================================================================
+12. RestoreNode                                          *luasnip-restorenode*
+
+This node can store and restore a snippetNode as is. This includes changed
 choices and changed text. Its’ usage is best demonstrated by an example:
 
->
+>lua
     s("paren_change", {
         c(1, {
             sn(nil, { t("("), r(1, "user_text"), t(")") }),
@@ -845,13 +853,12 @@ choices and changed text. Its’ usage is best demonstrated by an example:
     })
 <
 
-
 Here the text entered into `user_text` is preserved upon changing choice.
 
 `r(jump_index, key, nodes, node_opts)`:
 
 
-- |luasnip-`jump_index`|, when to jump to this node.
+- `jump_index`, when to jump to this node.
 - `key`, `string`: `restoreNode`s with the same key share their content.
 - `nodes`, `node[]|node`: the content of the `restoreNode`.
     Can either be a single node, or a table of nodes (both of which will be
@@ -863,7 +870,6 @@ Here the text entered into `user_text` is preserved upon changing choice.
     used for `restoreNodes` outside that `dynamicNode`. A way around this
     limitation is defining the content in the `restoreNode` outside the
     `dynamicNode`.
-
 
 The content for a key may also be defined in the `opts`-parameter of the
 snippet-constructor, as seen in the example above. The `stored`-table accepts
@@ -877,7 +883,7 @@ one may be visible at a time. See this issue
 The `restoreNode` is especially useful for storing input across updates of a
 `dynamicNode`. Consider this:
 
->
+>lua
     local function simple_restore(args, _)
         return sn(nil, {i(1, args[1]), i(2, "user_text")})
     end
@@ -888,12 +894,11 @@ The `restoreNode` is especially useful for storing input across updates of a
     }),
 <
 
-
 Every time the `i(1)` in the outer snippet is changed, the text inside the
 `dynamicNode` is reset to `"user_text"`. This can be prevented by using a
 `restoreNode`:
 
->
+>lua
     local function simple_restore(args, _)
         return sn(nil, {i(1, args[1]), r(2, "dyn", i(nil, "user_text"))})
     end
@@ -904,24 +909,24 @@ Every time the `i(1)` in the outer snippet is changed, the text inside the
     }),
 <
 
-
 Now the entered text is stored.
 
-`RestoreNode`s indent is not influenced by `indentSnippetNodes` right now. If
+`restoreNode`s indent is not influenced by `indentSnippetNodes` right now. If
 that really bothers you feel free to open an issue.
 
-==============================================================================
-12. ABSOLUTE_INDEXER                                *luasnip-absolute_indexer*
 
-A more capable way of |luasnip-referencing-nodes|! Using only
-|luasnip-`jump-indices`|, accessing an outer `i(1)` isn’t possible from
+==============================================================================
+13. Absolute Indexer                                *luasnip-absolute-indexer*
+
+The most capable way of referencing nodes (|luasnip-node-reference|). Using
+only a |luasnip-jump-index|, accessing an outer `i(1)` isn’t possible from
 inside e.g. a snippetNode, since only nodes with the same parent can be
 referenced (jump indices are interpreted relative to the parent of the node
 that’s passed the reference). The `absolute_indexer` can be used to reference
 nodes based on their absolute position in the snippet, which lifts this
 restriction.
 
->
+>lua
     s("trig", {
         i(1), c(2, {
             sn(nil, {
@@ -932,10 +937,9 @@ restriction.
     })
 <
 
-
 Using `absolute_indexer`, it’s possible to do so:
 
->
+>lua
     s("trig", {
         i(1), c(2, {
             sn(nil, { i(1),
@@ -946,10 +950,9 @@ Using `absolute_indexer`, it’s possible to do so:
     })
 <
 
-
 There are some quirks in addressing nodes:
 
->
+>lua
     s("trig", {
         i(2), -- ai[2]: indices based on jump-index, not position.
         sn(1, { -- ai[1]
@@ -979,7 +982,6 @@ There are some quirks in addressing nodes:
     })
 <
 
-
 Note specifically that the index of a dynamicNode differs from that of the
 generated snippetNode, and that restoreNodes (internally) always store a
 snippetNode, so even if the restoreNode only contains one node, that node has
@@ -987,17 +989,85 @@ to be accessed as `ai[restoreNodeIndx][0][1]`.
 
 `absolute_indexer`s’ can be constructed in different ways:
 
->
+>lua
     ai[1][2][3] == ai(1, 2, 3) == ai{1, 2, 3}
 <
 
 
 ==============================================================================
-13. EXTRAS                                                    *luasnip-extras*
+14. MultiSnippet                                        *luasnip-multisnippet*
 
-LAMBDA                                                        *luasnip-lambda*
+There are situations where it might be comfortable to access a snippet in
+different ways. For example, one might want to enable auto-triggering in
+regions where the snippets usage is common, while leaving it manual-only in
+others. This is where `ms` should be used: A single snippet can be associated
+with multiple `context`s (the `context`-table determines the conditions under
+which a snippet may be triggered). This has the advantage (compared with just
+registering copies) that all `context`s are backed by a single snippet, and not
+multiple, and it’s (at least should be :D) more comfortable to use.
 
-A shortcut for `functionNode`s that only do very basic string- manipulation.
+`ms(contexts, nodes, opts) -> addable`:
+
+
+- `contexts`: table containing list of `contexts`, and some keywords.
+    `context` are described in |luasnip-snippets|, here they may also be tables
+    or strings.
+    So far, there is only one valid keyword:
+    - `common`: Accepts yet another context.
+        The options in `common` are applied to (but don’t override) the other
+        contexts specified in `contexts`.
+- `nodes`: List of nodes, exactly like in |luasnip-snippets|.
+- `opts`: Table, options for this function:
+    - `common_opts`: The snippet-options (see also |luasnip-snippets|) applied
+        to the snippet generated from `nodes`.
+
+The returned object is an `addable`, something which can be passed to
+`add_snippets`, or returned from the lua-loader.
+
+**Examples**:
+
+>lua
+    ls.add_snippets("all", {
+        ms({"a", "b"}, {t"a or b"})
+    })
+<
+
+>lua
+    ls.add_snippets("all", {
+        ms({
+            common = {snippetType = "autosnippet"},
+            "a",
+            "b"
+        }, {
+            t"a or b (but autotriggered!!)"
+        })
+    })
+<
+
+>lua
+    ls.add_snippets("all", {
+        ms({
+            common = {snippetType = "autosnippet"},
+            {trig = "a", snippetType = "snippet"},
+            "b",
+            {trig = "c", condition = function(line_to_cursor)
+                return line_to_cursor == ""
+            end}
+        }, {
+            t"a or b (but autotriggered!!)"
+        })
+    })
+<
+
+
+==============================================================================
+15. Extras                                                    *luasnip-extras*
+
+
+LAMBDA                                                 *luasnip-extras-lambda*
+
+A shortcut for `functionNode`s that only do very basic string manipulation.
+
 `l(lambda, argnodes)`:
 
 
@@ -1006,38 +1076,37 @@ A shortcut for `functionNode`s that only do very basic string- manipulation.
     For example:
     - `l._1:gsub("a", "e")` replaces all occurences of "a" in the text of the
         first argnode with "e", or
-    - `l._1 .. l._2` concats text of the first and second argnode.
+    - `l._1 .. l._2` concatenates text of the first and second argnode.
         If an argnode contains multiple lines of text, they are concatenated with
         `"\n"` prior to any operation.
-- `argnodes`, |luasnip-`node-references`|, just like in function- and
+- `argnodes`, a |luasnip-node-reference|, just like in function- and
     dynamicNode.
-
 
 There are many examples for `lambda` in `Examples/snippets.lua`
 
-MATCH                                                          *luasnip-match*
+
+MATCH                                                   *luasnip-extras-match*
 
 `match` can insert text based on a predicate (again, a shorthand for
 `functionNode`).
 
-`match(argnodes, condition, then, else)`, where
+`match(argnodes, condition, then, else)`:
 
 
-- `argnode`: A single |luasnip-`node-reference`|. May not be nil, or
+- `argnode`: A single |luasnip-node-reference|. May not be nil, or
     a table.
 - `condition` may be either of
-    - `string`: interpreted as a lua-pattern. Matched on the `\n`-joined (in case
+    - `string`: interpreted as a lua pattern. Matched on the `\n`-joined (in case
         it’s multiline) text of the first argnode (`args[1]:match(condition)`).
     - `function`: `fn(args, snip) -> bool`: takes the same parameters as the
         `functionNode`-function, any value other than nil or false is interpreted
         as a match.
     - `lambda`: `l._n` is the `\n`-joined text of the nth argnode.
-        Useful if string-manipulations have to be performed before the string is matched.
+        Useful if string manipulations have to be performed before the string is matched.
         Should end with `match`, but any other truthy result will be interpreted
         as matching.
 - `then` is inserted if the condition matches,
 - `else` if it does not.
-
 
 Both `then` and `else` can be either text, lambda or function (with the same
 parameters as specified above). `then`’s default-value depends on the
@@ -1051,33 +1120,32 @@ parameters as specified above). `then`’s default-value depends on the
     something other than strings).
 - `lambda`: Simply the first value returned by the lambda.
 
-
 Examples:
 
 
 - `match(n, "^ABC$", "A")`.
 - `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")`
-    >
+    >lua
         s("trig", {
           i(1), t":",
           i(2), t"::",
           m({1, 2}, l._1:match("^"..l._2.."$"), l._1:gsub("a", "e"))
         })
     <
-- >
+- >lua
             s("extras1", {
               i(1), t { "", "" }, m(1, "^ABC$", "A")
             }),
     <
     Inserts "A" if the node with jump-index `n` matches "ABC" exactly, nothing
     otherwise.
-- >
+- >lua
           s("extras2", {
             i(1, "INPUT"), t { "", "" }, m(1, l._1:match(l._1:reverse()), "PALINDROME")
           }),
     <
     Inserts `"PALINDROME"` if i(1) contains a palindrome.
-- >
+- >lua
           s("extras3", {
             i(1), t { "", "" }, i(2), t { "", "" },
             m({ 1, 2 }, l._1:match("^" .. l._2 .. "$"), l._1:gsub("a", "e"))
@@ -1087,46 +1155,50 @@ Examples:
     replaced with `e`, if the second insertNode matches the first exactly.
 
 
-REPEAT                                                        *luasnip-repeat*
+REPEAT                                                 *luasnip-extras-repeat*
 
 Inserts the text of the passed node.
 
-`rep(node_reference)` - `node_reference`, a single |luasnip-`node-reference`|.
+`rep(node_reference)` - `node_reference`, a single |luasnip-node-reference|.
 
->
+>lua
     s("extras4", { i(1), t { "", "" }, extras.rep(1) }),
 <
 
 
-PARTIAL                                                      *luasnip-partial*
+PARTIAL                                               *luasnip-extras-partial*
 
-Evaluates a function on expand and inserts its’ value.
+Evaluates a function on expand and inserts its value.
 
 `partial(fn, params...)` - `fn`: any function - `params`: varargs, any, will be
 passed to `fn`.
 
 For example `partial(os.date, "%Y")` inserts the current year on expansion.
 
->
+>lua
     s("extras5", { extras.partial(os.date, "%Y") }),
 <
 
 
-NONEMPTY                                                    *luasnip-nonempty*
+NONEMPTY                                             *luasnip-extras-nonempty*
 
 Inserts text if the referenced node doesn’t contain any text.
-`nonempty(node_reference, not_empty, empty)` - `node_reference`, a single
-|luasnip-node-reference|. - `not_empty`, `string`: inserted if the node is not
-empty. - `empty`, `string`: inserted if the node is empty.
 
->
+`nonempty(node_reference, not_empty, empty)`:
+
+
+- `node_reference`, a single |luasnip-node-reference|.
+- `not_empty`, `string`: inserted if the node is not empty.
+- `empty`, `string`: inserted if the node is empty.
+
+>lua
     s("extras6", { i(1, ""), t { "", "" }, extras.nonempty(1, "not empty!", "empty!") }),
 <
 
 
-DYNAMIC LAMBDA                                        *luasnip-dynamic-lambda*
+DYNAMIC LAMBDA                                 *luasnip-extras-dynamic-lambda*
 
-Pretty much the same as lambda, it just inserts the resulting text as an
+Pretty much the same as lambda, but it inserts the resulting text as an
 insertNode, and, as such, it can be quickly overridden.
 
 `dynamic_lambda(jump_indx, lambda, node_references)` - `jump_indx`, as usual,
@@ -1134,26 +1206,29 @@ the jump-indx.
 
 The remaining arguments carry over from lambda.
 
->
+>lua
     s("extras7", { i(1), t { "", "" }, extras.dynamic_lambda(2, l._1 .. l._1, 1) }),
 <
 
 
-FMT                                                              *luasnip-fmt*
+FMT                                                       *luasnip-extras-fmt*
 
 Authoring snippets can be quite clunky, especially since every second node is
 probably a `textNode`, inserting a small number of characters between two more
-complicated nodes. `fmt` can be used to define snippets in a much more readable
-way. This is achieved by borrowing (as the name implies) from
-`format`-functionality (our syntax is very similar to python’s
-<https://docs.python.org/3/library/stdtypes.html#str.format>). `fmt` accepts a
-string and a table of nodes. Each occurrence of a delimiter-pair in the string
-is replaced by one node from the table, while text outside the delimiters is
-turned into textNodes.
+complicated nodes.
+
+`fmt` can be used to define snippets in a much more readable way. This is
+achieved by borrowing (as the name implies) from `format`-functionality (our
+syntax is very similar to python’s
+<https://docs.python.org/3/library/stdtypes.html#str.format>).
+
+`fmt` accepts a string and a table of nodes. Each occurrence of a delimiter
+pair in the string is replaced by one node from the table, while text outside
+the delimiters is turned into textNodes.
 
 Simple example:
 
->
+>lua
     ls.add_snippets("all", {
       -- important! fmt does not return a snippet, it returns a table of nodes.
       s("example1", fmt("just an {iNode1}", {
@@ -1187,14 +1262,13 @@ Simple example:
     })
 <
 
-
 One important detail here is that the position of the delimiters does not, in
 any way, correspond to the jump-index of the nodes!
 
 `fmt(format:string, nodes:table of nodes, opts:table|nil) -> table of nodes`
 
 
-- `format`: a string. Occurences of `{<somekey>}` ( `{,}` are customizable, more
+- `format`: a string. Occurences of `{<somekey>}` ( `{}` are customizable; more
     on that later) are replaced with `content[<somekey>]` (which should be a
     node), while surrounding text becomes `textNode`s.
     To escape a delimiter, repeat it (`"{{"`).
@@ -1207,7 +1281,7 @@ any way, correspond to the jump-index of the nodes!
     subsequent occurences.
 - `nodes`: just a table of nodes.
 - `opts`: optional arguments:
-    - `delimiters`: string, two characters. Change `{,}` to some other pair, e.g.
+    - `delimiters`: string, two characters. Change `{}` to some other pair, e.g.
         `"<>"`.
     - `strict`: Warn about unused nodes (default true).
     - `trim_empty`: remove empty (`"%s*"`) first and last line in `format`. Useful
@@ -1215,29 +1289,30 @@ any way, correspond to the jump-index of the nodes!
     - `dedent`: remove indent common to all lines in `format`. Again, makes
         passing multiline-strings a bit nicer (default true).
     - `repeat_duplicates`: repeat nodes when a key is reused instead of copying
-        the node if it has a jump-index, refer to |luasnip-jump-index| to
+        the node if it has a jump-index, refer to |luasnip-basics-jump-index| to
         know which nodes have a jump-index (default false).
 
-
 There is also `require("luasnip.extras.fmt").fmta`. This only differs from
-`fmt` by using angle-brackets (`<>`) as the default-delimiter.
+`fmt` by using angle brackets (`<>`) as the default delimiter.
 
-CONDITIONS                                                *luasnip-conditions*
 
-This module (`luasnip.extras.condition`) contains function that can be passed
+CONDITIONS                                         *luasnip-extras-conditions*
+
+This module (`luasnip.extras.condition`) contains functions that can be passed
 to a snippet’s `condition` or `show_condition`. These are grouped accordingly
 into `luasnip.extras.conditions.expand` and `luasnip.extras.conditions.show`:
 
-**`expand`**: - `line_begin`: only expand if the cursor is at the beginning of
+**expand**: - `line_begin`: only expand if the cursor is at the beginning of
 the line.
 
-**`show`**: - `line_end`: only expand at the end of the line.
+**show**: - `line_end`: only expand at the end of the line.
 
-`expand` contains, additionally, all conditions provided by `show`.
+Additionally, `expand` contains all conditions provided by `show`.
 
-CONDITION-OBJECTS ~
 
-`luasnip.extras.conditions` also contains condition-objects. These can, just
+CONDITION OBJECTS ~
+
+`luasnip.extras.conditions` also contains condition objects. These can, just
 like functions, be passed to `condition` or `show_condition`, but can also be
 combined with each other into logical expressions:
 
@@ -1253,34 +1328,33 @@ combined with each other into logical expressions:
     so we decided to make use of a more obscure symbol (which will hopefully avoid
     false assumptions about its meaning).
 
-
 This makes logical combinations of conditions very readable. Compare
 
->
+>lua
     condition = conditions.expand.line_end + conditions.expand.line_begin
 <
 
-
 with the more verbose
 
->
+>lua
     condition = function(...) return conditions.expand.line_end(...) or conditions.expand.line_begin(...) end
 <
 
-
-The conditions provided in `show` and `expand` are already condition-objects.
+The conditions provided in `show` and `expand` are already condition objects.
 To create new ones, use
 `require("luasnip.extras.conditions").make_condition(condition_fn)`
 
-ON THE FLY SNIPPETS                              *luasnip-on-the-fly-snippets*
+
+ON THE FLY-SNIPPETS                       *luasnip-extras-on-the-fly-snippets*
 
 Sometimes it’s desirable to create snippets tailored for exactly the current
 situation. For example inserting repetitive, but just slightly different
-invocations of some function, or supplying data in some schema. On The
-Fly-snippets enable exactly this usecase: they can be quickly created and
-expanded, with as little disruption as possible.
+invocations of some function, or supplying data in some schema.
 
-Since they should mainly fast to write, and don’t necessarily need all bells
+On-the-fly snippets enable exactly this use case: they can be quickly created
+and expanded with as little disruption as possible.
+
+Since they should mainly fast to write and don’t necessarily need all bells
 and whistles, they don’t make use of lsp/textmate-syntax, but a more
 simplistic one:
 
@@ -1291,8 +1365,7 @@ simplistic one:
 - … That’s it. `$` can be escaped by preceding it with a second `$`, all other
     symbols will be interpreted literally.
 
-
-There is currently only one way to expand On The Fly-snippets:
+There is currently only one way to expand on-the-fly snippets:
 `require('luasnip.extras.otf').on_the_fly("<some-register>")` will interpret
 whatever text is in the register `<some-register>` as a snippet, and expand it
 immediately. The idea behind this mechanism is that it enables a very immediate
@@ -1300,9 +1373,9 @@ way of supplying and retrieving (expanding) the snippet: write the snippet-body
 into the buffer, cut/yank it into some register, and call
 `on_the_fly("<register>")` to expand the snippet.
 
-Here’s one set of example-keybindings:
+Here’s one set of example keybindings:
 
->
+>vim
     " in the first call: passing the register is optional since `on_the_fly`
     " defaults to the unnamed register, which will always contain the previously cut
     " text.
@@ -1310,12 +1383,11 @@ Here’s one set of example-keybindings:
     inoremap <c-f>  <cmd>lua require('luasnip.extras.otf').on_the_fly("e")<cr>
 <
 
+Obviously, `<c-f>` is arbritary and can be changed to any other key combo.
+Another interesting application is allowing multiple on-the-fly snippets at the
+same time by retrieving snippets from multiple registers:
 
-Obviously, `<c-f>` is arbritary, and can be changed to any other key-combo.
-Another interesting application is allowing multiple on the fly-snippets at the
-same time, by retrieving snippets from multiple registers:
-
->
+>vim
     " For register a
     vnoremap <c-f>a  "ac<cmd>lua require('luasnip.extras.otf').on_the_fly()<cr>
     inoremap <c-f>a  <cmd>lua require('luasnip.extras.otf').on_the_fly("a")<cr>
@@ -1327,24 +1399,24 @@ same time, by retrieving snippets from multiple registers:
 <
 
 
-SELECT_CHOICE                                          *luasnip-select_choice*
+SELECT_CHOICE                                   *luasnip-extras-select_choice*
 
 It’s possible to leverage `vim.ui.select` for selecting a choice directly,
 without cycling through the available choices. All that is needed for this is
 calling `require("luasnip.extras.select_choice")`, most likely via some
 keybind, e.g.
 
->
+>vim
     inoremap <c-u> <cmd>lua require("luasnip.extras.select_choice")()<cr>
 <
-
 
 while inside a choiceNode. The `opts.kind` hint for `vim.ui.select` will be set
 to `luasnip`.
 
-FILETYPE_FUNCTIONS                                *luasnip-filetype_functions*
 
-Contains some utility-functions that can be passed to the `ft_func` or
+FILETYPE-FUNCTIONS                         *luasnip-extras-filetype-functions*
+
+Contains some utility functions that can be passed to the `ft_func` or
 `load_ft_func`-settings.
 
 
@@ -1352,17 +1424,17 @@ Contains some utility-functions that can be passed to the `ft_func` or
     the buffer.
 - `from_cursor_pos`: uses treesitter to determine the filetype at the cursor.
     With that, it’s possible to expand snippets in injected regions, as long as
-    the treesitter-parser supports them. If this is used in conjuction with
+    the treesitter parser supports them. If this is used in conjuction with
     `lazy_load`, extra care must be taken that all the filetypes that can be
     expanded in a given buffer are also returned by `load_ft_func` (otherwise their
     snippets may not be loaded). This can easily be achieved with `extend_load_ft`.
 - `extend_load_ft`: `fn(extend_ft:map) -> fn` A simple solution to the problem
-    described above is loading more filetypes than just that of the target-buffer
+    described above is loading more filetypes than just that of the target buffer
     when `lazy_load`ing. This can be done ergonomically via `extend_load_ft`:
     calling it with a table where the keys are filetypes, and the values are the
     filetypes that should be loaded additionaly returns a function that can be
     passed to `load_ft_func` and takes care of extending the filetypes properly.
-    >
+    >lua
         ls.setup({
           load_ft_func =
               -- Also load both lua and json when a markdown-file is opened,
@@ -1376,25 +1448,24 @@ Contains some utility-functions that can be passed to the `ft_func` or
     <
 
 
-POSTFIX SNIPPET                                      *luasnip-postfix-snippet*
+POSTFIX-SNIPPET                               *luasnip-extras-postfix-snippet*
 
 Postfix snippets, famously used in rust analyzer
-<https://rust-analyzer.github.io/> and various IDEs, are a type of snippet,
-which alters text before the snippets trigger. While these can be implemented
-using regTrig snippets, this helper makes the process easier in most cases.
+<https://rust-analyzer.github.io/> and various IDEs, are a type of snippet
+which alters text before the snippet’s trigger. While these can be
+implemented using regTrig snippets, this helper makes the process easier in
+most cases.
 
 The simplest example, which surrounds the text preceeding the `.br` with
 brackets `[]`, looks like:
 
->
-    
-          postfix(".br", {
-                  f(function(_, parent)
-                        return "[" .. parent.snippet.env.POSTFIX_MATCH .. "]"
-                  end, {}),
-          })
+>lua
+    postfix(".br", {
+        f(function(_, parent)
+            return "[" .. parent.snippet.env.POSTFIX_MATCH .. "]"
+        end, {}),
+    })
 <
-
 
 and is triggered with `xxx.br` and expands to `[xxx]`.
 
@@ -1406,21 +1477,19 @@ is also usable within dynamic nodes.
 
 This field can also be used within lambdas and dynamic nodes.
 
->
-          postfix(".br", {
-                  l("[" .. l.POSTFIX_MATCH .. "]"),
-          })
+>lua
+    postfix(".br", {
+        l("[" .. l.POSTFIX_MATCH .. "]"),
+    })
 <
 
-
->
-        postfix(".brd", {
-          d(1, function (_, parent)
+>lua
+    postfix(".brd", {
+        d(1, function (_, parent)
             return sn(nil, {t("[" .. parent.env.POSTFIX_MATCH .. "]")})
-          end)
-        }),
+        end)
+    }),
 <
-
 
 The arguments to `postfix` are identical to the arguments to `s` but with a few
 extra options.
@@ -1438,14 +1507,12 @@ as the table in the same position for `s` except:
     matched against the pattern, which makes the character immediately
     preceeding the trigger match as the end of the string.
 
-
 Some other match strings, including the default, are available from the postfix
 module. `require("luasnip.extras.postfix).matches`:
 
 
 - `default`: [%w%.%_%-%“%’]+$
 - 'line': `^.+$`
-
 
 The second argument is identical to the second argument for `s`, that is, a
 table of nodes.
@@ -1458,27 +1525,25 @@ snippet. If you pass a callback on the pre_expand event (structure example
 below) it will get run after the builtin callback. This means that your
 callback will have access to the `POSTFIX_MATCH` field as well.
 
->
-    
-          {
-            callbacks = {
-                  [-1] = {
-                          [events.pre_expand] = function(snippet, event_args)
-                              -- function body to match before the dot
-                              -- goes here
-                           end
-                          }
-                        }
+>lua
+    {
+        callbacks = {
+        [-1] = {
+            [events.pre_expand] = function(snippet, event_args)
+            -- function body to match before the dot
+            -- goes here
+            end
             }
+        }
+    }
 <
 
 
-SNIPPET LIST                                            *luasnip-snippet-list*
+SNIPPET LIST                                     *luasnip-extras-snippet-list*
 
->
+>lua
     local sl = require("luasnip.extras.snippet_list")
 <
-
 
 Makes an `open` function available to use to open currently available snippets
 in a different buffer/window/tab.
@@ -1491,19 +1556,17 @@ in a different buffer/window/tab.
     - `printer`: `printer(snippets:table) -> any`
     - `display`: `display(snippets:any)`
 
-
 Benefits include: syntax highlighting, searching, and customizability.
 
 Simple Example:
 
->
+>lua
     sl.open()
 <
 
-
 Customization Examples:
 
->
+>lua
     -- making our own snip_info
     local function snip_info(snippet)
         return { name = snippet.name }
@@ -1513,8 +1576,7 @@ Customization Examples:
     sl.open({snip_info = snip_info})
 <
 
-
->
+>lua
     -- making our own printer
     local function printer(snippets)
         local res = ""
@@ -1537,8 +1599,7 @@ Customization Examples:
     sl.open({printer = printer})
 <
 
-
->
+>lua
     -- making our own display
     local function display(printer_result)
         -- right vertical split
@@ -1567,25 +1628,23 @@ Customization Examples:
     sl.open({display = display})
 <
 
-
 There is a **caveat** with implementing your own printer and/or display
 function. The **default** behavior for the printer function is to return a
 string representation of the snippets. The display function uses the results
 from the printer function, therefore by **default** the display function is
 expecting that result to be a string.
 
-This doesn’t have to be the case however. You can for example implement your
-own printer function that returns a table representation of the snippets
+However, this doesn’t have to be the case. For example, you can implement
+your own printer function that returns a table representation of the snippets
 **but** you would have to then implement your own display function or some
-other function in order to stringify this result.
+other function in order to return the result as a string.
 
-An `options` table is available which has functionality in it that can be used
-to customize 'common' settings.
+An `options` table, which has some core functionality that can be used to
+customize 'common' settings, is provided.
 
 
 - `sl.options`: options table:
     - `display`: `display(opts:table|nil) -> function(printer_result:string)`
-
 
 You can see from the example above that making a custom display is a fairly
 involved process. What if you just wanted to change a buffer option like the
@@ -1601,10 +1660,9 @@ behavior.
     - `buf_opts`: `table which has a {buffer_option = value} form`
     - `get_name`: `get_name(buf) -> string`
 
-
 Let’s recreate the custom display example above:
 
->
+>lua
     -- keeping the default display behavior but modifying window/buffer
     local modified_default_display = sl.options.display({
             buf_opts = {filetype = "javascript"},
@@ -1618,7 +1676,7 @@ Let’s recreate the custom display example above:
 
 
 ==============================================================================
-14. EXTEND_DECORATOR                                *luasnip-extend_decorator*
+16. Extend Decorator                                *luasnip-extend-decorator*
 
 Most of luasnip’s functions have some arguments to control their behaviour.
 Examples include `s`, where `wordTrig`, `regTrig`, … can be set in the first
@@ -1626,11 +1684,13 @@ argument to the function, or `fmt`, where the delimiter can be set in the third
 argument. This is all good and well, but if these functions are often used with
 non-default settings, it can become cumbersome to always explicitly set them.
 
-This is where the `extend_decorator` comes in: It can be used to create
+This is where the `extend_decorator` comes in: it can be used to create
 decorated functions which always extend the arguments passed directly with
-other, previously defined ones. An example:
+other previously defined ones.
 
->
+An example:
+
+>lua
     local fmt = require("luasnip.extras.fmt").fmt
     
     fmt("{}", {i(1)}) -- -> list of nodes, containing just the i(1).
@@ -1651,10 +1711,9 @@ other, previously defined ones. An example:
     -- node/snippet-constructors and `parse_snippet`.
 <
 
-
 `extend_decorator.apply(fn, ...)` requires that `fn` is previously registered
-via `extend_decorator.register`. (This is not limited to luasnip’s
-functions!) (although, for usage outside of luasnip, best copy the source-file
+via `extend_decorator.register`. (This is not limited to LuaSnip’s functions;
+although, for usage outside of LuaSnip, best copy the source file:
 `/lua/luasnip/util/extend_decorator.lua`).
 
 `register(fn, ...)`:
@@ -1667,10 +1726,9 @@ functions!) (although, for usage outside of luasnip, best copy the source-file
     - extend, `fn(arg, extend_value) -> effective_arg` (optional): this function
         is used to extend the args passed to the decorated function.
         It defaults to a function which just extends the the arg-table with the
-        extend-table (accepts `nil`).
-        This extend-behaviour is adaptable to accomodate `s`, where the first
+        extend table (accepts `nil`).
+        This extend behaviour is adaptable to accomodate `s`, where the first
         argument may be string or table.
-
 
 `apply(fn, ...) -> decorated_fn`:
 
@@ -1680,10 +1738,9 @@ functions!) (although, for usage outside of luasnip, best copy the source-file
     in `register` (the argument first passed to `register` will be extended with
     the first value passed here).
 
-
 One more example for registering a new function:
 
->
+>lua
     local function somefn(arg1, arg2, opts1, opts2)
         ... -- not important
     end
@@ -1698,15 +1755,14 @@ One more example for registering a new function:
 
 
 ==============================================================================
-15. LSP-SNIPPETS                                        *luasnip-lsp-snippets*
+17. LSP-Snippets                                        *luasnip-lsp-snippets*
 
-Luasnip is capable of parsing lsp-style snippets using
+LuaSnip is capable of parsing LSP-style snippets using
 `ls.parser.parse_snippet(context, snippet_string, opts)`:
 
->
+>lua
     ls.parser.parse_snippet({trig = "lsp"}, "$1 is ${2|hard,easy,challenging|}")
 <
-
 
 `context` can be: - `string|table`: treated like the first argument to `ls.s`,
 `parse_snippet` returns a snippet. - `number`: `parse_snippet` returns a
@@ -1714,13 +1770,13 @@ snippetNode, with the position `context`. - `nil`: `parse_snippet` returns a
 flat table of nodes. This can be used like `fmt`.
 
 Nested placeholders(`"${1:this is ${2:nested}}"`) will be turned into
-choiceNode’s with: - the given snippet(`"this is ${1:nested}"`) and - an
-empty insertNode
+choiceNodes with: - the given snippet(`"this is ${1:nested}"`) and - an empty
+insertNode
 
 This behaviour can be modified by changing `parser_nested_assembler` in
 `ls.setup()`.
 
-Luasnip will also modify some snippets it’s incapable of representing
+LuaSnip will also modify some snippets that it is incapable of representing
 accurately: - if the `$0` is a placeholder with something other than just text
 inside - if the `$0` is a choice - if the `$0` is not an immediate child of the
 snippet (it could be inside a placeholder: `"${1: $0 }"`)
@@ -1737,33 +1793,38 @@ from the snippet’s lines. Default true.
 Both `trim_empty` and `dedent` will be disabled for snippets parsed via
 `ls.lsp_expand`: it might prevent correct expansion of snippets sent by lsp.
 
-SNIPMATE PARSER                                      *luasnip-snipmate-parser*
 
-It is furthermore possible to parse snipmate-snippets (this includes support
-for vimscript-evaluation!!) Snipmate-snippets have to be parsed with a
-different function, `ls.parser.parse_snipmate`:
+SNIPMATE PARSER                         *luasnip-lsp-snippets-snipmate-parser*
 
->
+It is furthermore possible to parse SnipMate snippets (this includes support
+for vimscript-evaluation!!)
+
+SnipMate snippets need to be parsed with a different function,
+`ls.parser.parse_snipmate`:
+
+>lua
     ls.parser.parse_snipmate("year", "The year is `strftime('%Y')`")
 <
 
-
 `parse_snipmate` accepts the same arguments as `parse_snippet`, only the
-snippet-body is parsed differently.
+snippet body is parsed differently.
 
-TRANSFORMATIONS                                      *luasnip-transformations*
+
+TRANSFORMATIONS                         *luasnip-lsp-snippets-transformations*
 
 To apply Variable/Placeholder-transformations
 <https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variable-transforms>,
 luasnip needs to apply ECMAScript regexes. This is implemented by relying on
-`jsregexp` <https://github.com/kmarius/jsregexp>. The easiest, but potentially
-error-prone way to install it is by calling `make install_jsregexp` in the
-repo-root. This process can be automated by `packer.nvim`:
+`jsregexp` <https://github.com/kmarius/jsregexp>.
 
->
+The easiest (but potentially error-prone) way to install it is by calling `make
+install_jsregexp` in the repo root.
+
+This process can be automated by `packer.nvim`:
+
+>lua
     use { "L3MON4D3/LuaSnip", run = "make install_jsregexp" }
 <
-
 
 If this fails, first open an issue :P, and then try installing the
 `jsregexp`-luarock. This is also possible via `packer.nvim`, although actual
@@ -1775,14 +1836,41 @@ Alternatively, `jsregexp` can be cloned locally, `make`d, and the resulting
 `jsregexp.so` placed in some place where nvim can find it (probably
 `~/.config/nvim/lua/`).
 
-If `jsregexp` is not available, transformation are replaced by a simple copy.
+If `jsregexp` is not available, transformations are replaced by a simple copy.
+
+
+VSCODE SNIPPET EXTRA FIELDS *luasnip-lsp-snippets-vscode-snippet-extra-fields*
+
+
+  **Note** See also this Issue 705
+  <https://github.com/L3MON4D3/LuaSnip/issues/705> for more info
+>json
+        
+        {
+            "prefix": ...
+            "scope": "javascript,typescript",
+            "body": ...
+        }
+<
+
+The `"scope":`
+<https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-scope>
+field is honored when loaded into the LuaSnip engine. If it isn’t part of the
+current buffer (editor) language, then it’s not imported. Let’s say you
+have `shared.json` that has snippets for different languages specified via
+`scope`. When specific language mapped to a `.code-snippets` (or `.json`) file
+by a `package.json` then only snippets `scope`-ed to the same language are
+loaded. The rest is ignored.
+
+`"isFileTemplate" :` field isn’t handled in anyway.
+
 
 ==============================================================================
-16. VARIABLES                                              *luasnip-variables*
+18. VARIABLES                                              *luasnip-variables*
 
 All `TM_something`-variables are supported with two additions: `LS_SELECT_RAW`
 and `LS_SELECT_DEDENT`. These were introduced because `TM_SELECTED_TEXT` is
-designed to be compatible with vscodes’ behavior, which can be
+designed to be compatible with VSCode’s behavior, which can be
 counterintuitive when the snippet can be expanded at places other than the
 point where selection started (or when doing transformations on selected text).
 Besides those we also provide `LS_TRIGGER` which contains the trigger of the
@@ -1793,7 +1881,7 @@ definition.
 All variables can be used outside of lsp-parsed snippets as their values are
 stored in a snippets’ `snip.env`-table:
 
->
+>lua
     s("selected_text", f(function(args, snip)
       local res, env = {}, snip.env
       table.insert(res, "Selected Text (current line is " .. env.TM_LINE_NUMBER .. "):")
@@ -1802,13 +1890,13 @@ stored in a snippets’ `snip.env`-table:
     end, {}))
 <
 
-
 To use any `*SELECT*` variable, the `store_selection_keys` must be set via
 `require("luasnip").config.setup({store_selection_keys="<Tab>"})`. In this
-case, hitting `<Tab>` while in Visualmode will populate the `*SELECT*`-vars for
-the next snippet and then clear them.
+case, hitting `<Tab>` while in visual mode will populate the `*SELECT*`-vars
+for the next snippet and then clear them.
 
-ENVIRONMENT NAMESPACES                        *luasnip-environment-namespaces*
+
+ENVIRONMENT NAMESPACES              *luasnip-variables-environment-namespaces*
 
 You can also add your own variables by using the `ls.env_namespace(name, opts)`
 where:
@@ -1831,14 +1919,13 @@ where:
         a list of vars that are tables or a boolean for the full namespace, it’s false by default. Refer to
         issue#510 <https://github.com/L3MON4D3/LuaSnip/issues/510#issuecomment-1209333698> for more information.
 
-
 The four fields of `opts` are optional but you need to provide either `init` or
-`vars`, and `eager` can’t be without `vars`. Also you can’t use namespaces
+`vars`, and `eager` can’t be without `vars`. Also, you can’t use namespaces
 that override default vars.
 
 A simple example to make it more clear:
 
->
+>lua
     local function random_lang()
         return ({"LUA", "VIML", "VIML9"})[math.floor(math.random()/2 + 1.5)]
     end
@@ -1868,43 +1955,41 @@ A simple example to make it more clear:
 <
 
 
-LSP-VARIABLES                                          *luasnip-lsp-variables*
+LSP-VARIABLES                                *luasnip-variables-lsp-variables*
 
-All variables, even ones added via `env_namespace`, can be accessed in
-lsp-snippets as `$VAR_NAME`.
+All variables, even ones added via `env_namespace`, can be accessed in LSP
+snippets as `$VAR_NAME`.
 
 The lsp-spec states:
 
 ------------------------------------------------------------------------------
-
 With `$name` or `${name:default}` you can insert the value of a variable. When
 a variable isn’t set, its default or the empty string is inserted. When a
 variable is unknown (that is, its name isn’t defined) the name of the
 variable is inserted and it is transformed into a placeholder.
 
 ------------------------------------------------------------------------------
-
 The above necessiates a differentiation between `unknown` and `unset`
 variables:
 
-For Luasnip, a variable `VARNAME` is `unknown` when `env.VARNAME` returns `nil`
+For LuaSnip, a variable `VARNAME` is `unknown` when `env.VARNAME` returns `nil`
 and `unset` if it returns an empty string.
 
-Consider this when adding env-variables which might be used in lsp-snippets.
+Consider this when adding env-variables which might be used in LSP snippets.
+
 
 ==============================================================================
-17. LOADERS                                                  *luasnip-loaders*
+19. Loaders                                                  *luasnip-loaders*
 
 Luasnip is capable of loading snippets from different formats, including both
-the well-established vscode- and snipmate-format, as well as plain lua-files
-for snippets written in lua
+the well-established VSCode and SnipMate format, as well as plain Lua files for
+snippets written in Lua.
 
 All loaders share a similar interface:
 
->
+>lua
     require("luasnip.loaders.from_{vscode,snipmate,lua}").{lazy_,}load(opts:table|nil)
 <
-
 
 where `opts` can contain the following keys:
 
@@ -1925,10 +2010,9 @@ where `opts` can contain the following keys:
 - `exclude`: List of languages to exclude, empty by default.
 - `include`: List of languages to include, includes everything by default.
 - `{override,default}_priority`: These keys are passed straight to the
-    |luasnip-`add_snippets`|-calls and can therefore change the priority
-    of snippets loaded from some colletion (or, in combination with
+    `add_snippets`-calls (documented in |luasnip-api|) and can therefore change the
+    priority of snippets loaded from some colletion (or, in combination with
     `{in,ex}clude`, only some of its snippets).
-
 
 While `load` will immediately load the snippets, `lazy_load` will defer loading
 until the snippets are actually needed (whenever a new buffer is created, or
@@ -1939,50 +2023,51 @@ a `bufnr`, returns the filetypes that should be loaded (`fn(bufnr) -> filetypes
 (string[])`)).
 
 All of the loaders support reloading, so simply editing any file contributing
-snippets will reload its snippets (only in the session the file was edited in,
+snippets will reload its snippets (only in the session the file was edited in;
 we use `BufWritePost` for reloading, not some lower-level mechanism).
 
-For easy editing of these files, Luasnip provides a
-|luasnip-`vim.ui.select`-based-dialog| where first the filetype, and then the
+For easy editing of these files, LuaSnip provides a `vim.ui.select`-based
+dialog (|luasnip-loaders-edit_snippets|) where first the filetype, and then the
 file can be selected.
 
-TROUBLESHOOTING                                      *luasnip-troubleshooting*
+
+TROUBLESHOOTING                              *luasnip-loaders-troubleshooting*
 
 
-- Luasnip uses `all` as the global filetype. As most snippet collections don’t
-    explicitly target luasnip, they may not provide global snippets for this
+- LuaSnip uses `all` as the global filetype. As most snippet collections don’t
+    explicitly target LuaSnip, they may not provide global snippets for this
     filetype, but another, like `_` (`honza/vim-snippets`). In these cases, it’s
-    necessary to extend luasnip’s global filetype with the collection’s global
+    necessary to extend LuaSnip’s global filetype with the collection’s global
     filetype:
-    >
+    >lua
         ls.filetype_extend("all", { "_" })
     <
     In general, if some snippets don’t show up when loading a collection, a good
-    first step is checking the filetype luasnip is actually looking into (print
+    first step is checking the filetype LuaSnip is actually looking into (print
     them for the current buffer via `:lua
     print(vim.inspect(require("luasnip").get_snippet_filetypes()))`), against the
     one the missing snippet is provided for (in the collection). If there is indeed
     a mismatch, `filetype_extend` can be used to also search the collection’s
     filetype:
-    >
+    >lua
         ls.filetype_extend("<luasnip-filetype>", { "<collection-filetype>" })
     <
-- As we only load `lazy_load`ed snippet on some events, `lazy_load` will probably
-    not play nice when a non-default `ft_func` is used: if it depends on e.g. the
-    cursor-position, only the filetypes for the cursor-position when the
-    `lazy_load`-events are triggered will be loaded. Check
-    |luasnip-filetype_function’s-`extend_load_ft`| for a solution.
+- As we only load `lazy_load`ed snippets on some events, `lazy_load` will
+    probably not play nice when a non-default `ft_func` is used: if it depends on
+    e.g. the cursor position, only the filetypes for the cursor position when the
+    `lazy_load` events are triggered will be loaded. Check
+    |luasnip-extras-filetype-function|’s `extend_load_ft` for a solution.
 
 
-VSCODE                                                        *luasnip-vscode*
+VS-CODE                                              *luasnip-loaders-vs-code*
 
-As a reference on the structure of these snippet-libraries, see
+As a reference on the structure of these snippet libraries, see
 `friendly-snippets` <https://github.com/rafamadriz/friendly-snippets>.
 
-We support a small extension: snippets can contain luasnip-specific options in
+We support a small extension: snippets can contain LuaSnip-specific options in
 the `luasnip`-table:
 
->
+>json
     "example1": {
         "prefix": "options",
         "body": [
@@ -1996,12 +2081,17 @@ the `luasnip`-table:
     }
 <
 
+Files with the extension `jsonc` will be parsed as `jsonc`, json with comments
+<https://code.visualstudio.com/docs/languages/json#_json-with-comments>, while
+`*.json` are parsed with a regular `json` parser, where comments are
+disallowed. (the json-parser is a bit faster, so don’t default to `jsonc` if
+it’s not necessary).
 
 **Example**:
 
 `~/.config/nvim/my_snippets/package.json`:
 
->
+>json
     {
         "name": "example-snippets",
         "contributes": {
@@ -2023,10 +2113,9 @@ the `luasnip`-table:
     }
 <
 
-
 `~/.config/nvim/my_snippets/snippets/all.json`:
 
->
+>json
     {
         "snip1": {
             "prefix": "all1",
@@ -2045,10 +2134,9 @@ the `luasnip`-table:
     }
 <
 
-
 `~/.config/nvim/my_snippets/lua.json`:
 
->
+>json
     {
         "snip1": {
             "prefix": "lua",
@@ -2059,10 +2147,9 @@ the `luasnip`-table:
     }
 <
 
-
 This collection can be loaded with any of
 
->
+>lua
     -- don't pass any arguments, luasnip will find the collection because it is
     -- (probably) in rtp.
     require("luasnip.loaders.from_vscode").lazy_load()
@@ -2073,46 +2160,43 @@ This collection can be loaded with any of
 <
 
 
-SNIPMATE                                                    *luasnip-snipmate*
+SNIPMATE                                            *luasnip-loaders-snipmate*
 
 Luasnip does not support the full snipmate format: Only `./{ft}.snippets` and
 `./{ft}/*.snippets` will be loaded. See honza/vim-snippets
 <https://github.com/honza/vim-snippets> for lots of examples.
 
-Like vscode, the snipmate-format is also extended to make use of some of
-luasnips more advanced capabilities:
+Like VSCode, the SnipMate format is also extended to make use of some of
+LuaSnip’s more advanced capabilities:
 
->
+>snippets
     priority 2000
     autosnippet options
         whoa :O
 <
 
-
 **Example**:
 
 `~/.config/nvim/snippets/c.snippets`:
 
->
+>snippets
     # this is a comment
     snippet c c-snippet
         c!
 <
 
-
 `~/.config/nvim/snippets/cpp.snippets`:
 
->
+>snippets
     extends c
     
     snippet cpp cpp-snippet
         cpp!
 <
 
-
 This can, again, be loaded with any of
 
->
+>lua
     require("luasnip.loaders.from_snipmate").load()
     -- specify the full path...
     require("luasnip.loaders.from_snipmate").lazy_load({paths = "~/.config/nvim/snippets"})
@@ -2120,19 +2204,18 @@ This can, again, be loaded with any of
     require("luasnip.loaders.from_snipmate").lazy_load({paths = "./snippets"})
 <
 
-
 Stuff to watch out for:
 
 
 - Using both `extends <ft2>` in `<ft1>.snippets` and
     `ls.filetype_extend("<ft1>", {"<ft2>"})` leads to duplicate snippets.
 - `${VISUAL}` will be replaced by `$TM_SELECTED_TEXT` to make the snippets
-    compatible with luasnip
+    compatible with LuaSnip
 - We do not implement eval using ` (backtick). This may be implemented in the
     future.
 
 
-LUA                                                              *luasnip-lua*
+LUA                                                      *luasnip-loaders-lua*
 
 Instead of adding all snippets via `add_snippets`, it’s possible to store
 them in separate files and load all of those. The file-structure here is
@@ -2146,11 +2229,11 @@ There are two ways to add snippets:
     added as regular snippets, while the snippets in the second will be added as
     autosnippets (both are the defaults, if a snippet defines a different
     `snippetType`, that will have preference)
-- snippets can also be appended to the global (only for these files! They are not
-    visible anywhere else) tables `ls_file_snippets` and `ls_file_autosnippets`.
-    This can be combined with a custom `snip_env` to define and add snippets with
-    one function-call:
-    >
+- snippets can also be appended to the global (only for these files - they are
+    not visible anywhere else) tables `ls_file_snippets` and
+    `ls_file_autosnippets`. This can be combined with a custom `snip_env` to define
+    and add snippets with one function call:
+    >lua
         ls.setup({
           snip_env = {
               s = function(...)
@@ -2170,12 +2253,11 @@ There are two ways to add snippets:
         })
     <
     This is more flexible than the previous approach since the snippets don’t
-    have to be collected, they just have to be defined using the above `s` and
+    have to be collected; they just have to be defined using the above `s` and
     `parse`.
 
-
-As defining all of the snippet-constructors (`s`, `c`, `t`, …) in every file
-is rather cumbersome, luasnip will bring some globals into scope for executing
+As defining all of the snippet constructors (`s`, `c`, `t`, …) in every file
+is rather cumbersome, LuaSnip will bring some globals into scope for executing
 these files. By default, the names from `luasnip.config.snip_env`
 <https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/config.lua#L122-L147>
 will be used, but it’s possible to customize them by setting `snip_env` in
@@ -2185,16 +2267,15 @@ will be used, but it’s possible to customize them by setting `snip_env` in
 
 `~/snippets/all.lua`:
 
->
+>lua
     return {
         s("trig", t("loaded!!"))
     }
 <
 
-
 `~/snippets/c.lua`:
 
->
+>lua
     return {
         s("ctrig", t("also loaded!!"))
     }, {
@@ -2202,25 +2283,28 @@ will be used, but it’s possible to customize them by setting `snip_env` in
     }
 <
 
-
 Load via
 
->
+>lua
     require("luasnip.loaders.from_lua").load({paths = "~/snippets"})
 <
 
 
-EDIT_SNIPPETS                                          *luasnip-edit_snippets*
+EDIT_SNIPPETS                                  *luasnip-loaders-edit_snippets*
 
 To easily edit snippets for the current session, the files loaded by any loader
 can be quickly edited via
-`require("luasnip.loaders").edit_snippet_files(opts:table|nil)` When called, it
-will open a `vim.ui.select`-dialog to select first a filetype, and then (if
-there are multiple) the associated file to edit.
+`require("luasnip.loaders").edit_snippet_files(opts:table|nil)`
 
-`opts` contains three settings:
+When called, it will open a `vim.ui.select`-dialog to select first a filetype,
+and then (if there are multiple) the associated file to edit.
+
+`opts` contains four settings:
 
 
+- `ft_filter`: `fn(filetype:string) -> bool` Optionally filter initially listed
+    filetypes. `true` -> filetype will be listed, `false` -> not listed. Accepts
+    all filetypes by default.
 - `format`: `fn(file:string, source_name:string) -> string|nil` `file` is simply
     the path to the file, `source_name` is one of `"lua"`, `"snipmate"` or
     `"vscode"`. If a string is returned, it is used as the title of the item, `nil`
@@ -2231,7 +2315,7 @@ there are multiple) the associated file to edit.
     - more aggressively shorten paths using symbolic names, e.g.
         `"$FRIENDLY_SNIPPETS"`. Example: hide the `*.lua` snippet files, and shorten
         the path with `$LuaSnip`:
-        >
+        >lua
             require "luasnip.loaders" .edit_snippet_files {
               format = function(file, source_name)
                 if source_name == "lua" then return nil
@@ -2252,8 +2336,8 @@ there are multiple) the associated file to edit.
     each pair is the label that will appear in the selection-prompt, and the second
     is the path that will be passed to the `edit()` function if that item was
     selected.
-    This can be used to create a new snippet-file for the current filetype:
-    >
+    This can be used to create a new snippet file for the current filetype:
+    >lua
         require("luasnip.loaders").edit_snippet_files {
         extend = function(ft, paths)
           if #paths == 0 then
@@ -2268,61 +2352,58 @@ there are multiple) the associated file to edit.
         }
     <
 
-
 One comfortable way to call this function is registering it as a command:
 
->
+>vim
     command! LuaSnipEdit :lua require("luasnip.loaders").edit_snippet_files()
 <
 
 
 ==============================================================================
-18. SNIPPETPROXY                                        *luasnip-snippetproxy*
+20. SnippetProxy                                        *luasnip-snippetproxy*
 
-`SnippetProxy` is used internally to alleviate the upfront-cost of loading
-snippets from e.g. a snipmate-library or a vscode-package. This is achieved by
+`SnippetProxy` is used internally to alleviate the upfront cost of loading
+snippets from e.g. a SnipMate library or a VSCode package. This is achieved by
 only parsing the snippet on expansion, not immediately after reading it from
-some file. `SnippetProxy` may also be used from lua directly, to get the same
+some file. `SnippetProxy` may also be used from Lua directly to get the same
 benefits:
 
-This will parse the snippet on startup…
+This will parse the snippet on startup:
 
->
+>lua
     ls.parser.parse_snippet("trig", "a snippet $1!")
 <
 
+while this will parse the snippet upon expansion:
 
-… and this will parse the snippet upon expansion.
-
->
+>lua
     local sp = require("luasnip.nodes.snippetProxy")
     sp("trig", "a snippet $1")
 <
-
 
 `sp(context, body, opts) -> snippetProxy`
 
 
 - `context`: exactly the same as the first argument passed to `ls.s`.
-- `body`: the snippet-body.
+- `body`: the snippet body.
 - `opts`: accepts the same `opts` as `ls.s`, with some additions:
     - `parse_fn`: the function for parsing the snippet. Defaults to
-        `ls.parser.parse_snippet` (the parser for lsp-snippets), an alternative is
-        the parser for snipmate-snippets (`ls.parser.parse_snipmate`).
+        `ls.parser.parse_snippet` (the parser for LSP snippets), an alternative is
+        the parser for SnipMate snippets (`ls.parser.parse_snipmate`).
 
 
 ==============================================================================
-19. EXT_OPTS                                                *luasnip-ext_opts*
+21. ext_opts                                                *luasnip-ext_opts*
 
 `ext_opts` can be used to set the `opts` (see `nvim_buf_set_extmark`) of the
-extmarks used for marking node-positions, either globally, per-snippet or
-per-node. This means that they allow highlighting the text inside of nodes, or
+extmarks used for marking node positions, either globally, per snippet or per
+node. This means that they allow highlighting the text inside of nodes, or
 adding virtual text to the line the node begins on.
 
 This is an example for the `node_ext_opts` used to set `ext_opts` of single
 nodes:
 
->
+>lua
     local ext_opts = {
         -- these ext_opts are applied when the node is active (e.g. it has been
         -- jumped into, and not out yet).
@@ -2361,8 +2442,7 @@ nodes:
     })
 <
 
-
-In the above example the text inside the insertNodes is higlighted in green if
+In the above example, the text inside the insertNodes is higlighted in green if
 they were not yet visited, in blue once they were, and red while they are. The
 virtual text "virtual text!!" is visible as long as the snippet is active.
 
@@ -2374,18 +2454,16 @@ less specific ones:
 - `visited` and `unvisited` from `passive`
 - `active` from `visited`
 
-
 To disable a key from a less specific state, it has to be explicitly set to its
 default, e.g. to disable highlighting inherited from `passive` when the node
 is `active`, `hl_group` should be set to `None`.
 
 ------------------------------------------------------------------------------
-
 As stated earlier, these `ext_opts` can also be applied globally or for an
-entire snippet. For this it’s necessary to specify which kind of node a given
-set of `ext_opts` should be applied to:
+entire snippet. For this, it’s necessary to specify which kind of node a
+given set of `ext_opts` should be applied to:
 
->
+>lua
     local types = require("luasnip.util.types")
     
     ls.setup({
@@ -2407,11 +2485,10 @@ set of `ext_opts` should be applied to:
     })
 <
 
-
 The above applies the given `ext_opts` to all nodes of these types, in all
-snippets…
+snippets.
 
->
+>lua
     local types = require("luasnip.util.types")
     
     s("trig", { i(1, "text1"), i(2, "text2") }, {
@@ -2425,12 +2502,10 @@ snippets…
     })
 <
 
-
-… while the `ext_opts` here are only applied to the `insertNodes` inside this
+However, the `ext_opts` here are only applied to the `insertNodes` inside this
 snippet.
 
 ------------------------------------------------------------------------------
-
 By default, the `ext_opts` actually used for a node are created by extending
 the `node_ext_opts` with the `effective_child_ext_opts[node.type]` of the
 parent, which are in turn the parent’s `child_ext_opts` extended with the
@@ -2439,7 +2514,7 @@ global `ext_opts` (those set `ls.setup`).
 It’s possible to prevent both of these merges by passing
 `merge_node/child_ext_opts=false` to the snippet/node-opts:
 
->
+>lua
     ls.setup({
         ext_opts = {
             [types.insertNode] = {
@@ -2468,13 +2543,11 @@ It’s possible to prevent both of these merges by passing
     })
 <
 
-
 ------------------------------------------------------------------------------
+The `hl_group` of the global `ext_opts` can also be set via standard highlight
+groups:
 
-The `hl_group` of the global `ext_opts` can also be set via standard
-highlight-groups:
-
->
+>lua
     vim.cmd("hi link LuasnipInsertNodePassive GruvboxRed")
     vim.cmd("hi link LuasnipSnippetPassive GruvboxBlue")
     
@@ -2482,15 +2555,13 @@ highlight-groups:
     ls.setup({})
 <
 
-
 The names for the used highlight groups are
 `"Luasnip<node>{Passive,Active,SnippetPassive}"`, where `<node>` can be any
 kind of node in PascalCase (or "Snippet").
 
 ------------------------------------------------------------------------------
-
-One problem that might arise when nested nodes are highlighted, is that the
-highlight of inner nodes should be visible, eg. above that of nodes they are
+One problem that might arise when nested nodes are highlighted is that the
+highlight of inner nodes should be visible, e.g. above that of nodes they are
 nested inside.
 
 This can be controlled using the `priority`-key in `ext_opts`. In
@@ -2501,7 +2572,7 @@ snippet(Nodes)s.
 Both the initial base-priority and its’ increase and can be controlled using
 `ext_base_prio` and `ext_prio_increase`:
 
->
+>lua
     ls.setup({
         ext_opts = {
             [types.insertNode] = {
@@ -2523,23 +2594,23 @@ Both the initial base-priority and its’ increase and can be controlled using
     })
 <
 
-
 Here the highlight of an insertNode nested directly inside a choiceNode is
 always visible on top of it.
 
-==============================================================================
-20. DOCSTRING                                              *luasnip-docstring*
 
-Snippet-docstrings can be queried using `snippet:get_docstring()`. The function
+==============================================================================
+22. Docstrings                                            *luasnip-docstrings*
+
+Snippet docstrings can be queried using `snippet:get_docstring()`. The function
 evaluates the snippet as if it was expanded regularly, which can be problematic
-if e.g. a dynamicNode in the snippet relies on inputs other than the
-argument-nodes. `snip.env` and `snip.captures` are populated with the names of
-the queried variable and the index of the capture respectively
+if e.g. a dynamicNode in the snippet relies on inputs other than the argument
+nodes. `snip.env` and `snip.captures` are populated with the names of the
+queried variable and the index of the capture respectively
 (`snip.env.TM_SELECTED_TEXT` -> `'$TM_SELECTED_TEXT'`, `snip.captures[1]` ->
 `'$CAPTURES1'`). Although this leads to more expressive docstrings, it can
 cause errors in functions that e.g. rely on a capture being a number:
 
->
+>lua
     s({trig = "(%d)", regTrig = true}, {
         f(function(args, snip)
             return string.rep("repeatme ", tonumber(snip.captures[1]))
@@ -2547,13 +2618,12 @@ cause errors in functions that e.g. rely on a capture being a number:
     }),
 <
 
-
 This snippet works fine because `snippet.captures[1]` is always a number.
-During docstring-generation, however, `snippet.captures[1]` is `'$CAPTURES1'`,
+During docstring generation, however, `snippet.captures[1]` is `'$CAPTURES1'`,
 which will cause an error in the functionNode. Issues with `snippet.captures`
 can be prevented by specifying `docTrig` during snippet-definition:
 
->
+>lua
     s({trig = "(%d)", regTrig = true, docTrig = "3"}, {
         f(function(args, snip)
             return string.rep("repeatme ", tonumber(snip.captures[1]))
@@ -2561,14 +2631,13 @@ can be prevented by specifying `docTrig` during snippet-definition:
     }),
 <
 
-
 `snippet.captures` and `snippet.trigger` will be populated as if actually
 triggered with `3`.
 
 Other issues will have to be handled manually by checking the contents of e.g.
 `snip.env` or predefining the docstring for the snippet:
 
->
+>lua
     s({trig = "(%d)", regTrig = true, docstring = "repeatmerepeatmerepeatme"}, {
         f(function(args, snip)
             return string.rep("repeatme ", tonumber(snip.captures[1]))
@@ -2576,12 +2645,12 @@ Other issues will have to be handled manually by checking the contents of e.g.
     }),
 <
 
+Refer to #515 <https://github.com/L3MON4D3/LuaSnip/pull/515> for a better
+example to understand `docTrig` and `docstring`.
 
-A better example to understand `docTrig` and `docstring` can refer to #515
-<https://github.com/L3MON4D3/LuaSnip/pull/515>.
 
 ==============================================================================
-21. DOCSTRING-CACHE                                  *luasnip-docstring-cache*
+23. Docstring-Cache                                  *luasnip-docstring-cache*
 
 Although generation of docstrings is pretty fast, it’s preferable to not redo
 it as long as the snippets haven’t changed. Using
@@ -2590,18 +2659,19 @@ it as long as the snippets haven’t changed. Using
 deserialized into the snippets. Both functions accept a table structsured like
 this: `{ft1={snippets}, ft2={snippets}}`. Such a table containing all snippets
 can be obtained via `ls.get_snippets()`. `load` should be called before any of
-the `loader`-functions as snippets loaded from vscode-style packages already
+the `loader`-functions as snippets loaded from VSCode style packages already
 have their `docstring` set (`docstrings` wouldn’t be overwritten, but
 there’d be unnecessary calls).
 
 The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 `~/.cache/nvim/luasnip/docstrings.json`).
 
+
 ==============================================================================
-22. EVENTS                                                    *luasnip-events*
+24. Events                                                    *luasnip-events*
 
 Events can be used to react to some action inside snippets. These callbacks can
-be defined per-snippet (`callbacks`-key in snippet constructor) or globally
+be defined per snippet (`callbacks`-key in snippet constructor) or globally
 (autocommand).
 
 `callbacks`: `fn(node[, event_args]) -> event_res` All callbacks get the `node`
@@ -2612,27 +2682,24 @@ the snippet can be changed.
 `autocommand`: Luasnip uses `User`-events. Autocommands for these can be
 registered using
 
->
+>vim
     au User SomeUserEvent echom "SomeUserEvent was triggered"
 <
 
-
 or
 
->
+>lua
     vim.api.nvim_create_autocommand("User", {
         patter = "SomeUserEvent",
         command = "echom SomeUserEvent was triggered"
     })
 <
 
-
 The node and `event_args` can be accessed through `require("luasnip").session`:
 
 
 - `node`: `session.event_node`
 - `event_args`: `session.event_args`
-
 
 **Events**:
 
@@ -2656,11 +2723,10 @@ The node and `event_args` can be accessed through `require("luasnip").session`:
     - `env_override`: `map string->(string[]|string)`, override or extend the
         snippet’s environment (`snip.env`).
 
-
 A pretty useless, beyond serving as an example here, application of these would
-be printing e.g. the nodes’ text after entering:
+be printing e.g. the node’s text after entering:
 
->
+>lua
     vim.api.nvim_create_autocmd("User", {
         pattern = "LuasnipInsertNodeEnter",
         callback = function()
@@ -2670,10 +2736,9 @@ be printing e.g. the nodes’ text after entering:
     })
 <
 
+or some information about expansions:
 
-or some information about expansions
-
->
+>lua
     vim.api.nvim_create_autocmd("User", {
         pattern = "LuasnipPreExpand",
         callback = function()
@@ -2693,22 +2758,23 @@ or some information about expansions
 
 
 ==============================================================================
-23. CLEANUP                                                  *luasnip-cleanup*
+25. Cleanup                                                  *luasnip-cleanup*
 
-The function ls.cleanup() triggers the `LuasnipCleanup` user-event, that you
-can listen to do some kind of cleaning in your own snippets, by default it will
+The function ls.cleanup() triggers the `LuasnipCleanup` user event, that you
+can listen to do some kind of cleaning in your own snippets; by default it will
 empty the snippets table and the caches of the lazy_load.
 
-==============================================================================
-24. Logging                                                  *luasnip-logging*
 
-Luasnip uses logging to report unexpected program-states, and information on
+==============================================================================
+26. Logging                                                  *luasnip-logging*
+
+Luasnip uses logging to report unexpected program states, and information on
 what’s going on in general. If something does not work as expected, taking a
 look at the log (and potentially increasing the loglevel) might give some good
 hints towards what is going wrong.
 
 The log is stored in `<vim.fn.stdpath("log")>/luasnip.log`
-(`<vim.fn.stdpath("cache")>/luasnip.log` for neovim-versions where
+(`<vim.fn.stdpath("cache")>/luasnip.log` for Neovim versions where
 `stdpath("log")` does not exist), and can be opened by calling `ls.log.open()`.
 The loglevel (granularity of reported events) can be adjusted by calling
 `ls.log.set_loglevel("error"|"warn"|"info"|"debug")`. `"debug"` has the highest
@@ -2721,8 +2787,79 @@ there already exists a `luasnip.log.old`, it will be deleted.
 `ls.log.ping()` can be used to verify the log is working correctly: it will
 print a short message to the log.
 
+
 ==============================================================================
-25. API-REFERENCE                                      *luasnip-api-reference*
+27. Config-Options                                    *luasnip-config-options*
+
+These are the settings you can provide to `luasnip.setup()`:
+
+
+- `history`: If true, snippets that were exited can still be jumped back into. As
+    snippets are not removed when their text is deleted, they have to be removed
+    manually via `LuasnipUnlinkCurrent` if `delete_check_events` is not enabled
+    (set to eg. `'TextChanged'`).
+- `update_events`: Choose which events trigger an update of the active nodes’
+    dependents. Default is just `'InsertLeave'`, `'TextChanged,TextChangedI'` would
+    update on every change. These, like all other `*_events` are passed to
+    `nvim_create_autocmd` as `events`, so they can be wrapped in a table, like
+    >lua
+        ls.setup({
+          update_events = {"TextChanged", "TextChangedI"}
+        })
+    <
+- `region_check_events`: Events on which to leave the current snippet if the
+    cursor is outside its’ 'region'. Disabled by default, `'CursorMoved'`,
+    `'CursorHold'` or `'InsertEnter'` seem reasonable.
+- `delete_check_events`: When to check if the current snippet was deleted, and if
+    so, remove it from the history. Off by default, `'TextChanged'` (perhaps
+    `'InsertLeave'`, to react to changes done in Insert mode) should work just fine
+    (alternatively, this can also be mapped using `<Plug>luasnip-delete-check`).
+- `store_selection_keys`: Mapping for populating `TM_SELECTED_TEXT` and related
+    variables (not set by default).
+- `enable_autosnippets`: Autosnippets are disabled by default to minimize
+    performance penalty if unused. Set to `true` to enable.
+- `ext_opts`: Additional options passed to extmarks. Can be used to add
+    passive/active highlight on a per-node-basis (more info in DOC.md)
+- `parser_nested_assembler`: Override the default behaviour of inserting a
+    `choiceNode` containing the nested snippet and an empty `insertNode` for nested
+    placeholders (`"${1: ${2: this is nested}}"`). For an example (behaviour more
+    similar to vscode), check here
+    <https://github.com/L3MON4D3/LuaSnip/wiki/Nice-Configs#imitate-vscodes-behaviour-for-nested-placeholders>
+- `ft_func`: Source of possible filetypes for snippets. Defaults to a function,
+    which returns `vim.split(vim.bo.filetype, ".", true)`, but check
+    filetype_functions <lua/luasnip/extras/filetype_functions.lua> or the
+    |luasnip-extras-filetype-functions|-section for more options.
+- `load_ft_func`: Function to determine which filetypes belong to a given buffer
+    (used for `lazy_loading`). `fn(bufnr) -> filetypes (string[])`. Again, there
+    are some examples in filetype_functions
+    <lua/luasnip/extras/filetype_functions.lua>.
+- `snip_env`: The best way to author snippets in lua involves the lua-loader (see
+    |luasnip-loaders-lua|). Unfortunately, this requires that snippets are defined
+    in separate files, which means that common definitions like `s`, `i`, `sn`,
+    `t`, `fmt`, … have to be repeated in each of them, and that adding more
+    customized functions to ease writing snippets also requires some setup.
+    `snip_env` can be used to insert variables into exactly the places where
+    lua-snippets are defined (for now only the file loaded by the lua-loader).
+    Setting `snip_env` to `{ some_global = "a value" }` will add (amongst the
+    defaults stated at the beginning of this documentation) the global variable
+    `some_global` while evaluating these files. There are special keys which, when
+    set in `snip_env` change the behaviour of this option, and are not passed
+    through to the lua-files:
+    - `__snip_env_behaviour`, string: either `"set"` or `"extend"` (default
+        `"extend"`)
+        If this is `"extend"`, the variables defined in `snip_env` will complement (and
+        override) the defaults. If this is not desired, `"set"` will not include the
+        defaults, but only the variables set here.
+    One side-effect of this is that analysis-tools (most likely
+    `lua-language-server`) for lua will generate diagnostics for the usage of
+    undefined symbols. If you mind the (probably) large number of generated
+    warnings, consider adding the undefined globals to the globals recognized by
+    `lua-language-server` or add `---@diagnostic disable: undefined-global`
+    somewhere in the affected files.
+
+
+==============================================================================
+28. API                                                          *luasnip-api*
 
 `require("luasnip")`:
 
@@ -2731,19 +2868,20 @@ print a short message to the log.
     Makes `snippets` (list of snippets) available in `ft`. If `ft` is `nil`,
     `snippets` should be a table containing lists of snippets, the keys are
     corresponding filetypes. `opts` may contain the following keys:
-    - `type`: type of `snippets`, `"snippets"` or `"autosnippets"` (ATTENTION: plural
-        form used here). This serves as default value for the `snippetType` key of each
-        snippet added by this call see |luasnip-snippets|.
-    - `key`: Key that identifies snippets added via this call. If `add_snippets` is
-        called with a key that was already used, the snippets from that previous call
-        will be removed. This can be used to reload snippets: pass an unique key to
-        each `add_snippets` and just re-do the `add_snippets`-call when the snippets
-        have changed.
+    - `type`: type of `snippets`, `"snippets"` or `"autosnippets"` (ATTENTION:
+        plural form used here). This serves as default value for the `snippetType`
+        key of each snippet added by this call see |luasnip-snippets|.
+    - `key`: Key that identifies snippets added via this call.
+        If `add_snippets` is called with a key that was already used, the snippets
+        from that previous call will be removed.
+        This can be used to reload snippets: pass an unique key to each
+        `add_snippets` and just redo the `add_snippets`-call when the snippets have
+        changed.
     - `override_priority`: set priority for all snippets.
-    - `default_priority`: set priority only for snippets without snippet-priority.
+    - `default_priority`: set priority only for snippets without snippet priority.
 - `clean_invalidated(opts: table or nil) -> bool`: clean invalidated snippets
-    from internal snippet storage. Invalidated snippets are still stored, it might
-    be useful to actually remove them, as they still have to be iterated during
+    from internal snippet storage. Invalidated snippets are still stored; it might
+    be useful to actually remove them as they still have to be iterated during
     expansion.
     `opts` may contain:
     - `inv_limit`: how many invalidated snippets are allowed. If the number of
@@ -2778,12 +2916,12 @@ print a short message to the log.
         this function) as clearing before expansion will populate `TM_CURRENT_LINE`
         and `TM_CURRENT_WORD` with wrong values (they would miss the snippet trigger)
         and clearing after expansion may move the text currently under the cursor
-        and have it end up not at the `i(1)`, but a `#trigger` chars to it’s right.
+        and have it end up not at the `i(1)`, but a `#trigger` chars to its right.
         The actual values used for clearing are `from` and `to`, both (0,0)-indexed
         byte-positions.
         If the variables don’t have to be populated with the correct values, it’s
         safe to remove the text manually.
-    - `expand_params`: table, for overriding the `trigger` used in the snippet
+    - `expand_params`: table for overriding the `trigger` used in the snippet
         and setting the `captures` (useful for pattern-triggered nodes where the
         trigger has to be changed from the pattern to the actual text triggering the
         node).
@@ -2795,9 +2933,9 @@ print a short message to the log.
     - `jump_into_func`: fn(snippet) -> node:
         Callback responsible for jumping into the snippet. The returned node is
         set as the new active node, ie. it is the origin of the next jump.
-        The default is basically this
+        The default is basically this:
         `lua     function(snip)       -- jump_into set the placeholder of the snippet, 1       -- to jump forwards.       return snip:jump_into(1)`
-        While this can be used to only insert the snippet
+        while this can be used to only insert the snippet:
         `lua     function(snip)       return snip.insert_nodes[0]     end`
     `opts` and any of its parameters may be nil.
 - `get_active_snip()`: returns the currently active snippet (not node!).
@@ -2807,13 +2945,13 @@ print a short message to the log.
 - `unlink_current()`: removes the current snippet from the jumplist (useful if
     luasnip fails to automatically detect e.g. deletion of a snippet) and sets the
     current node behind the snippet, or, if not possible, before it.
-- `lsp_expand(snip_string, opts)`: expand the lsp-syntax-snippet defined via
+- `lsp_expand(snip_string, opts)`: expands the LSP snippet defined via
     `snip_string` at the cursor. `opts` can have the same options as `opts` in
     `snip_expand`.
 - `active_update_dependents()`: update all function/dynamicNodes that have the
     current node as an argnode (will actually only update them if the text in any
     of the argnodes changed).
-- `available(snip_info)`: return a table of all snippets defined for the current
+- `available(snip_info)`: returns a table of all snippets defined for the current
     filetypes(s) (`{ft1={snip1, snip2}, ft2={snip3, snip4}}`). The structure of the
     snippet is defined by `snip_info` which is a function (`snip_info(snip)`) that
     takes in a snippet (`snip`), finds the desired information on it, and returns
@@ -2821,7 +2959,7 @@ print a short message to the log.
     You can use it for more granular control over the table of snippets that is
     returned.
 - `exit_out_of_region(node)`: checks whether the cursor is still within the range
-    of the snippet `node` belongs to. If yes, no change occurs, if No, the snippet
+    of the snippet `node` belongs to. If yes, no change occurs; if no, the snippet
     is exited and following snippets’ regions are checked and potentially exited
     (the next active node will be the 0-node of the snippet before the one the
     cursor is inside. If the cursor isn’t inside any snippet, the active node
@@ -2841,21 +2979,21 @@ print a short message to the log.
 - `load_snippet_docstrings(snippet_table)`: Load docstrings for all snippets in
     `snippet_table` from `stdpath("cache")/luasnip/docstrings.json`. The docstrings
     are stored and restored via trigger, meaning if two snippets for one filetype
-    have the same(very unlikely to happen in actual usage), bugs could occur.
+    have the same (very unlikely to happen in actual usage), bugs could occur.
     `snippet_table` should be laid out as described in `store_snippet_docstrings`.
-- `unlink_current_if_deleted()`: Checks if the current snippet was deleted, if
-    so, it is removed from the jumplist. This is not 100% reliable as luasnip only
+- `unlink_current_if_deleted()`: Checks if the current snippet was deleted; if
+    so, it is removed from the jumplist. This is not 100% reliable as LuaSnip only
     sees the extmarks and their beginning/end may not be on the same position, even
     if all the text between them was deleted.
 - `filetype_extend(filetype:string, extend_filetypes:table of string)`: Tells
     luasnip that for a buffer with `ft=filetype`, snippets from `extend_filetypes`
     should be searched as well. `extend_filetypes` is a lua-array (`{ft1, ft2,
     ft3}`). `luasnip.filetype_extend("lua", {"c", "cpp"})` would search and expand
-    c-and cpp-snippets for lua-files.
+    c and cpp snippets for lua files.
 - `filetype_set(filetype:string, replace_filetypes:table of string)`: Similar to
     `filetype_extend`, but where _append_ appended filetypes, _set_ sets them:
-    `filetype_set("lua", {"c"})` causes only c-snippets to be expanded in
-    lua-files, lua-snippets aren’t even searched.
+    `filetype_set("lua", {"c"})` causes only c snippets to be expanded in lua
+    files; lua snippets aren’t even searched.
 - `cleanup()`: clears all snippets. Not useful for regular usage, only when
     authoring and testing snippets.
 - `refresh_notify(ft:string)`: Triggers an autocmd that other plugins can hook
@@ -2871,7 +3009,10 @@ print a short message to the log.
 - `setup_snip_env()`: Adds the variables defined (during `setup`) in `snip_env`
     to the callers environment.
 - `get_snip_env()`: Returns `snip_env`.
-
+- `jump_destination(direction)`: Returns the node the next jump in `direction`
+    (either -1 or 1, for backwards, forwards respectively) leads to, or `nil` if
+    the destination could not be determined (most likely because there is no node
+    that can be jumped to in the given direction, or there is no active node).
 
 Not covered in this section are the various node-constructors exposed by the
 module, their usage is shown either previously in this file or in

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -34,13 +34,13 @@ local function get_file_snippets(lang, file)
 		local body = type(parts.body) == "string" and parts.body
 			or table.concat(parts.body, "\n")
 
-			-- Skip entire snippet if entry has `scope` field mismatching lang
-			-- This prevents snippets mapped by package.json to one language
-			-- to be used for another. This is not part of LSP Snippets! See:
-			-- https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-scope
-			if type(parts.scope) == "string" and not parts.scope:match(lang) then
-				goto continue
-			end
+		-- Skip entire snippet if entry has `scope` field mismatching lang
+		-- This prevents snippets mapped by package.json to one language
+		-- to be used for another. This is not part of LSP Snippets! See:
+		-- https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-scope
+		if type(parts.scope) == "string" and not parts.scope:match(lang) then
+			goto continue
+		end
 
 		-- There are still some snippets that fail while loading
 		pcall(function()


### PR DESCRIPTION
```json
{
    "prefix"     : "...",
    "body"       : "var ${1:name} = ${2:value}",
    "scope"      : "javascript, typescript"
    "description": "My snippet"
}
```
The above give you an idea how you can specify language scope in which snippet should appear. This is primarily intended to be used inside `*.code-snippets` files. If you import scoped snippets by your `package.json` you may get duplicates, this PR prevents this.

See: 
https://github.com/L3MON4D3/LuaSnip/issues/705#issuecomment-1419284976