### PR TITLE
fix: `expand_or_locally_jumpable()` checks the next node

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 March 27
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 April 09
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -187,7 +187,7 @@ local function in_snippet()
 end
 
 local function expand_or_locally_jumpable()
-	return expandable() or (in_snippet() and jumpable())
+	return expandable() or (in_snippet() and jumpable(1))
 end
 
 local function locally_jumpable(dir)


### PR DESCRIPTION
`expand_or_locally_jumpable()` should always check whether the next node is jumpable.