### PR TITLE
doc: mention MacOS Makefile variable for jsregexp

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1922,6 +1922,16 @@ This process can be automated by `packer.nvim`:
 ```lua
 use { "L3MON4D3/LuaSnip", run = "make install_jsregexp" }
 ```
+
+If you are on MacOS and not using Homebrew then you will need to specify the
+location of your LuaJIT dylib via the `LUAJIT_OSX_PATH` variable without adding */lib/*
+at the end. So `/opt/local/lib/` becomes `/opt/local`.
+
+When using MacPorts for example:
+```lua
+use { "L3MON4D3/LuaSnip", run = "make install_jsregexp LUAJIT_OSX_PATH=/opt/local" }
+```
+
 If this fails, first open an issue :P, and then try installing the
 `jsregexp`-luarock. This is also possible via 
 `packer.nvim`, although actual usage may require a small workaround, see

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 April 12
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 April 13
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -1825,6 +1825,16 @@ This process can be automated by `packer.nvim`:
 
 >lua
     use { "L3MON4D3/LuaSnip", run = "make install_jsregexp" }
+<
+
+If you are on MacOS and not using Homebrew then you will need to specify the
+location of your LuaJIT dylib via the `LUAJIT_OSX_PATH` variable without adding
+_/lib/_ at the end. So `/opt/local/lib/` becomes `/opt/local`.
+
+When using MacPorts for example:
+
+>lua
+    use { "L3MON4D3/LuaSnip", run = "make install_jsregexp LUAJIT_OSX_PATH=/opt/local" }
 <
 
 If this fails, first open an issue :P, and then try installing the


### PR DESCRIPTION
The LUAJIT_OSX_PATH variable which allows MacOS users to specify the location of their lib directory was added in a835e3d680c5940b61780c6af07885db95382478
and needed to be documented.