### PR TITLE
feat (ffmt): introduce `ffmt` to read format string from separate file

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 April 14
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 April 16
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*


### PR DESCRIPTION
Hi, thanks a lot for the amazing plugin!

I would like to add a functionality to define the format string in a different file and use the content to expand a snippet.
I believe this would be useful to define a template file.

I have implemented a function `file_format_nodes`, aliased to `ffmt` that is kind of a wrapper around `fmt` node.

So the usage is very simple.

### Old way: Using `fmt` node

```lua
snippets[#snippets + 1] = s(
  e("journal", "template for journal page"),
  fmt(
    [[
* {title}
  {{:{yesterday}:}}[Yesterday] - {{:{tomorrow}:}}[Tomorrow]

** Daily Review
   - {}

** Today's Checklist
   - ( ) Write my daily review

** Achievements
   -
    ]],
    {
      title = f(function(_, _)
        return parse_date(0, file_title())
      end),
      yesterday = f(function(_, _)
        return parse_date(-1, file_title())
      end),
      tomorrow = f(function(_, _)
        return parse_date(1, file_title())
      end),
      i(0),
    }
  )
)
```

### Instead, using `ffmt`

- `~/norg-template/journal.norg`
```txt
* {title}
  {{:{yesterday}:}}[Yesterday] - {{:{tomorrow}:}}[Tomorrow]

** Daily Review
   - {}

** Today's Checklist
   - ( ) Write my daily review

** Achievements
   -
```

```lua
snippets[#snippets + 1] = s(
  e("journal", "template for journal page"),
  ffmt("~/norg-template/journal.norg", {
    title = f(function(_, _)
      return parse_date(0, file_title())
    end),
    yesterday = f(function(_, _)
      return parse_date(-1, file_title())
    end),
    tomorrow = f(function(_, _)
      return parse_date(1, file_title())
    end),
    i(0),
  }
)
```