### PR TITLE
refactor: remove deprecated function

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 April 23
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2023 April 28
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/plugin/luasnip.lua
+++ b/plugin/luasnip.lua
@@ -62,7 +62,7 @@ vim.api.nvim_create_user_command("LuaSnipUnlinkCurrent", function()
 	require("luasnip").unlink_current()
 end, { force = true })
 vim.api.nvim_create_user_command("LuaSnipListAvailable", function()
-	vim.pretty_print(require("luasnip").available())
+	vim.print(require("luasnip").available())
 end, { force = true })
 
 require("luasnip.config")._setup()


### PR DESCRIPTION
hi @L3MON4D3,

vim.pretty_print is deprecated so I have changed it to vim.print