### PR TITLE
fix: vim.pretty_print is deprecated (^neovim-0.9.0)

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2023 May 01
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2023 May 05
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/plugin/luasnip.lua
+++ b/plugin/luasnip.lua
@@ -61,8 +61,19 @@ end)
 vim.api.nvim_create_user_command("LuaSnipUnlinkCurrent", function()
 	require("luasnip").unlink_current()
 end, { force = true })
+
+--stylua: ignore
 vim.api.nvim_create_user_command("LuaSnipListAvailable", function()
-	vim.pretty_print(require("luasnip").available())
+	(
+		(
+			vim.version
+			and type(vim.version) == "table"
+			and (
+				((vim.version().major == 0) and (vim.version().minor >= 9))
+				or (vim.version().major > 0) )
+		) and vim.print
+		  or vim.pretty_print
+	)(require("luasnip").available())
 end, { force = true })
 
 require("luasnip.config")._setup()

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -768,4 +768,71 @@ describe("snippets_basic", function()
 			end
 		end
 	)
+
+	it("LuaSnipListAvailable works", function()
+		helpers.clear()
+		ls_helpers.session_setup_luasnip()
+
+		screen = Screen.new(50, 40)
+		screen:attach()
+		screen:set_default_attr_ids({
+			[0] = {bold = true, foreground = Screen.colors.Blue1};
+			[1] = {bold = true, foreground = Screen.colors.Brown};
+			[2] = {bold = true};
+			[3] = {background = Screen.colors.LightGrey};
+			[4] = {bold = true, reverse = true};
+			[5] = {bold = true, foreground = Screen.colors.SeaGreen4};
+			[6] = {foreground = Screen.colors.Red1};
+		})
+		exec_lua([[
+			ls.add_snippets("all", {
+				s({trig="a"}, { t"justsometexta" }),
+				s({trig="b"}, { t"justsometextb" }),
+				s({trig="c"}, { t"justsometextc" }),
+			})
+		]])
+		feed(":LuaSnipListAvailable<Cr>")
+		screen:expect{grid=[[
+			                                                  |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{4:                                                  }|
+			{                                                 |
+			  [""] = {},                                      |
+			  all = { {                                       |
+			      description = { "a" },                      |
+			      name = "a",                                 |
+			      regTrig = false,                            |
+			      trigger = "a",                              |
+			      wordTrig = true                             |
+			    }, {                                          |
+			      description = { "b" },                      |
+			      name = "b",                                 |
+			      regTrig = false,                            |
+			      trigger = "b",                              |
+			      wordTrig = true                             |
+			    }, {                                          |
+			      description = { "c" },                      |
+			      name = "c",                                 |
+			      regTrig = false,                            |
+			      trigger = "c",                              |
+			      wordTrig = true                             |
+			    } }                                           |
+			}                                                 |
+			{5:Press ENTER or type command to continue}^           |]]}
+		feed("<Cr>")
+	end)
 end)

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -776,13 +776,13 @@ describe("snippets_basic", function()
 		screen = Screen.new(50, 40)
 		screen:attach()
 		screen:set_default_attr_ids({
-			[0] = {bold = true, foreground = Screen.colors.Blue1};
-			[1] = {bold = true, foreground = Screen.colors.Brown};
-			[2] = {bold = true};
-			[3] = {background = Screen.colors.LightGrey};
-			[4] = {bold = true, reverse = true};
-			[5] = {bold = true, foreground = Screen.colors.SeaGreen4};
-			[6] = {foreground = Screen.colors.Red1};
+			[0] = { bold = true, foreground = Screen.colors.Blue1 },
+			[1] = { bold = true, foreground = Screen.colors.Brown },
+			[2] = { bold = true },
+			[3] = { background = Screen.colors.LightGrey },
+			[4] = { bold = true, reverse = true },
+			[5] = { bold = true, foreground = Screen.colors.SeaGreen4 },
+			[6] = { foreground = Screen.colors.Red1 },
 		})
 		exec_lua([[
 			ls.add_snippets("all", {
@@ -792,7 +792,8 @@ describe("snippets_basic", function()
 			})
 		]])
 		feed(":LuaSnipListAvailable<Cr>")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			                                                  |
 			{0:~                                                 }|
 			{0:~                                                 }|
@@ -832,7 +833,8 @@ describe("snippets_basic", function()
 			      wordTrig = true                             |
 			    } }                                           |
 			}                                                 |
-			{5:Press ENTER or type command to continue}^           |]]}
+			{5:Press ENTER or type command to continue}^           |]],
+		})
 		feed("<Cr>")
 	end)
 end)


### PR DESCRIPTION
see:
https://github.com/neovim/neovim/blob/040f1459849ab05b04f6bb1e77b3def16b4c2f2b/runtime/doc/news.txt#LL321C3-L321C3

vim.pretty_print is removed in development (prerelease) build: https://github.com/neovim/neovim/releases/tag/nightly

This commit should guarantee backwards compatibility.

Related pull request:
https://github.com/L3MON4D3/LuaSnip/pull/876