### PR TITLE
Support `.code-snippets`.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2154,10 +2154,8 @@ Luasnip is capable of loading snippets from different formats, including both
 the well-established VSCode and SnipMate format, as well as plain Lua files for
 snippets written in Lua.
 
-All loaders share a similar interface:
-```lua
-require("luasnip.loaders.from_{vscode,snipmate,lua}").{lazy_,}load(opts:table|nil)
-```
+All loaders (except the vscode-standalone-loader) share a similar interface:
+`require("luasnip.loaders.from_{vscode,snipmate,lua}").{lazy_,}load(opts:table|nil)`
 
 where `opts` can contain the following keys:
 
@@ -2318,6 +2316,65 @@ require("luasnip.loaders.from_vscode").lazy_load({paths = "~/.config/nvim/my_sni
 -- or relative to the directory of $MYVIMRC
 require("luasnip.loaders.from_vscode").load({paths = "./my_snippets"})
 ```
+
+### Standalone
+Beside snippet-libraries provided by packages, vscode also supports another
+format which can be used for project-local snippets, or user-defined snippets,
+`.code-snippets`.  
+
+The layout of these files is almost identical to that of the package-provided
+snippets, but there is one additional field supported in the
+snippet-definitions, `scope`, with which the filetype of the snippet can be set.
+If `scope` is not set, the snippet will be added to the global filetype (`all`).
+
+`require("luasnip.loaders.from_vscode").load_standalone(opts)`
+
+- `opts`: `table`, can contain the following keys:
+  - `path`: `string`, Path to the `*.code-snippets`-file that should be loaded.
+    Just like the paths in `load`, this one can begin with a `"~/"` to be
+    relative to `$HOME`, and a `"./"` to be relative to the
+    neovim-config-directory.
+  - `{override,default}_priority`: These keys are passed straight to the
+    `add_snippets`-calls (documented in [API](#api)) and can be used to change
+    the priority of the loaded snippets.
+
+**Example**:
+`a.code-snippets`:
+```jsonc
+{
+    // a comment, since `.code-snippets` may contain jsonc.
+    "c/cpp-snippet": {
+        "prefix": [
+            "trigger1",
+            "trigger2"
+        ],
+        "body": [
+            "this is $1",
+            "my snippet $2"
+        ],
+        "description": "A description of the snippet.",
+        "scope": "c,cpp"
+    },
+    "python-snippet": {
+        "prefix": "trig",
+        "body": [
+            "this is $1",
+            "a different snippet $2"
+        ],
+        "description": "Another snippet-description.",
+        "scope": "python"
+    },
+    "global snippet": {
+        "prefix": "trigg",
+        "body": [
+            "this is $1",
+            "the last snippet $2"
+        ],
+        "description": "One last snippet-description.",
+    }
+}
+```
+This file can be loaded by calling
 
 ## SNIPMATE
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2023 May 25
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2023 May 28
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -2023,11 +2023,8 @@ Luasnip is capable of loading snippets from different formats, including both
 the well-established VSCode and SnipMate format, as well as plain Lua files for
 snippets written in Lua.
 
-All loaders share a similar interface:
-
->lua
-    require("luasnip.loaders.from_{vscode,snipmate,lua}").{lazy_,}load(opts:table|nil)
-<
+All loaders (except the vscode-standalone-loader) share a similar interface:
+`require("luasnip.loaders.from_{vscode,snipmate,lua}").{lazy_,}load(opts:table|nil)`
 
 where `opts` can contain the following keys:
 
@@ -2194,6 +2191,69 @@ This collection can be loaded with any of
     -- or relative to the directory of $MYVIMRC
     require("luasnip.loaders.from_vscode").load({paths = "./my_snippets"})
 <
+
+
+STANDALONE ~
+
+Beside snippet-libraries provided by packages, vscode also supports another
+format which can be used for project-local snippets, or user-defined snippets,
+`.code-snippets`.
+
+The layout of these files is almost identical to that of the package-provided
+snippets, but there is one additional field supported in the
+snippet-definitions, `scope`, with which the filetype of the snippet can be
+set. If `scope` is not set, the snippet will be added to the global filetype
+(`all`).
+
+`require("luasnip.loaders.from_vscode").load_standalone(opts)`
+
+- `opts`: `table`, can contain the following keys:
+    - `path`: `string`, Path to the `*.code-snippets`-file that should be loaded.
+        Just like the paths in `load`, this one can begin with a `"~/"` to be
+        relative to `$HOME`, and a `"./"` to be relative to the
+        neovim-config-directory.
+    - `{override,default}_priority`: These keys are passed straight to the
+        `add_snippets`-calls (documented in |luasnip-api|) and can be used to change
+        the priority of the loaded snippets.
+
+**Example**: `a.code-snippets`:
+
+>jsonc
+    {
+        // a comment, since `.code-snippets` may contain jsonc.
+        "c/cpp-snippet": {
+            "prefix": [
+                "trigger1",
+                "trigger2"
+            ],
+            "body": [
+                "this is $1",
+                "my snippet $2"
+            ],
+            "description": "A description of the snippet.",
+            "scope": "c,cpp"
+        },
+        "python-snippet": {
+            "prefix": "trig",
+            "body": [
+                "this is $1",
+                "a different snippet $2"
+            ],
+            "description": "Another snippet-description.",
+            "scope": "python"
+        },
+        "global snippet": {
+            "prefix": "trigg",
+            "body": [
+                "this is $1",
+                "the last snippet $2"
+            ],
+            "description": "One last snippet-description.",
+        }
+    }
+<
+
+This file can be loaded by calling
 
 
 SNIPMATE                                            *luasnip-loaders-snipmate*

--- a/lua/luasnip/extras/snip_location.lua
+++ b/lua/luasnip/extras/snip_location.lua
@@ -114,7 +114,11 @@ function M.jump_to_snippet(snip, opts)
 	end
 
 	local fcall_range
-	local ft = util.ternary(vim.bo[0].filetype ~= "", vim.bo[0].filetype, vim.api.nvim_buf_get_name(0):match("%.([^%.]+)$"))
+	local ft = util.ternary(
+		vim.bo[0].filetype ~= "",
+		vim.bo[0].filetype,
+		vim.api.nvim_buf_get_name(0):match("%.([^%.]+)$")
+	)
 	if ft == "lua" then
 		if source.line then
 			-- in lua-file, can get region of definition via treesitter.
@@ -137,8 +141,7 @@ function M.jump_to_snippet(snip, opts)
 	-- matches *.json or *.jsonc.
 	elseif ft == "json" or ft == "jsonc" then
 		local ok
-		ok, fcall_range =
-			pcall(json_find_snippet_definition, 0, ft, snip.name)
+		ok, fcall_range = pcall(json_find_snippet_definition, 0, ft, snip.name)
 		if not ok then
 			print(
 				"Could not determine range of snippet-definition: "

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -52,13 +52,13 @@ local function new_cache()
 end
 
 local M = {
-	vscode = new_cache(),
+	vscode_packages = new_cache(),
 	snipmate = new_cache(),
 	lua = new_cache(),
 }
 
 function M.cleanup()
-	M.vscode:clean()
+	M.vscode_packages:clean()
 	M.snipmate:clean()
 	M.lua:clean()
 end

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -53,12 +53,14 @@ end
 
 local M = {
 	vscode_packages = new_cache(),
+	vscode_standalone = new_cache(),
 	snipmate = new_cache(),
 	lua = new_cache(),
 }
 
 function M.cleanup()
 	M.vscode_packages:clean()
+	M.vscode_standalone:clean()
 	M.snipmate:clean()
 	M.lua:clean()
 end

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -132,7 +132,8 @@ local function load_snippet_files(lang, files, add_opts)
 				-- only load snippets matching the language set in `package.json`.
 				file_lang_snippets,
 				vim.tbl_extend("keep", {
-					-- again, include filetype, same reasoning as with augroup.
+					-- provide key s.t. snippets will be replaced if the file
+					-- is reloaded.
 					key = string.format("__%s_package_snippets_%s", lang, file),
 					refresh_notify = false,
 				}, add_opts)
@@ -336,7 +337,11 @@ function M.edit_snippet_files()
 end
 
 local function standalone_add(path, add_opts)
+	-- by default, put snippets into global scope.
 	local file_snippets = get_file_snippets(path, "all")
+
+	-- store add_opts for this file: file might be edited, and then we want to
+	-- reload it with these same add_opts.
 	standalone_cache.path_snippets[path] = {
 		add_opts = add_opts
 	}
@@ -346,6 +351,8 @@ local function standalone_add(path, add_opts)
 		nil,
 		file_snippets,
 		vim.tbl_extend("keep", {
+			-- provide key s.t. snippets will be replaced if the file is
+			-- reloaded.
 			key = string.format("__standalone_snippets_%s", path),
 		}, add_opts)
 	)
@@ -375,6 +382,7 @@ function M._reload_file(filename)
 		end
 		ls.clean_invalidated({ inv_limit = 100 })
 	end
+
 	local standalone_cached_data = standalone_cache.path_snippets[filename]
 	if standalone_cached_data then
 		log.info("Re-loading snippets contributed by %s", filename)

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -338,7 +338,6 @@ end
 local function standalone_add(path, add_opts)
 	local file_snippets = get_file_snippets(path, "all")
 	standalone_cache.path_snippets[path] = {
-		snippets = vim.deepcopy(file_snippets),
 		add_opts = add_opts
 	}
 
@@ -379,8 +378,9 @@ function M._reload_file(filename)
 	local standalone_cached_data = standalone_cache.path_snippets[filename]
 	if standalone_cached_data then
 		log.info("Re-loading snippets contributed by %s", filename)
-		package_cache.path_snippets[filename] = nil
-		local add_opts = package_cached_data.add_opts
+
+		standalone_cache.path_snippets[filename] = nil
+		local add_opts = standalone_cached_data.add_opts
 
 		standalone_add(filename, add_opts)
 		ls.clean_invalidated({ inv_limit = 100 })

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -133,7 +133,7 @@ local function load_snippet_files(lang, files, add_opts)
 				file_lang_snippets,
 				vim.tbl_extend("keep", {
 					-- again, include filetype, same reasoning as with augroup.
-					key = string.format("__%s_snippets_%s", lang, file),
+					key = string.format("__%s_package_snippets_%s", lang, file),
 					refresh_notify = false,
 				}, add_opts)
 			)
@@ -346,7 +346,7 @@ local function standalone_add(path, add_opts)
 		nil,
 		file_snippets,
 		vim.tbl_extend("keep", {
-			key = string.format("__snippets_%s", path),
+			key = string.format("__standalone_snippets_%s", path),
 		}, add_opts)
 	)
 end

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -12,7 +12,7 @@ local source = require("luasnip.session.snippet_collection.source")
 local json_decoders = {
 	json = util.json_decode,
 	jsonc = require("luasnip.util.jsonc").decode,
-	["code-snippets"] = require("luasnip.util.jsonc").decode
+	["code-snippets"] = require("luasnip.util.jsonc").decode,
 }
 
 local function read_json(fname)
@@ -46,10 +46,11 @@ end
 -- set opts.ignore_scope to add all snippets to default_filetype, regardless of scope.
 local function get_file_snippets(file, default_filetype, opts)
 	opts = opts or {}
-	local ignore_scope = util.ternary(opts.ignore_scope, opts.ignore_scope, false)
+	local ignore_scope =
+		util.ternary(opts.ignore_scope, opts.ignore_scope, false)
 
 	-- since most snippets we load don't have a scope-field, we just insert this here by default.
-	local snippets_by_ft = {[default_filetype] = {}}
+	local snippets_by_ft = { [default_filetype] = {} }
 
 	local snippet_set_data = read_json(file)
 	if snippet_set_data == nil then
@@ -75,7 +76,8 @@ local function get_file_snippets(file, default_filetype, opts)
 					dscr = parts.description or name,
 					wordTrig = ls_conf.wordTrig,
 					priority = ls_conf.priority,
-					snippetType = ls_conf.autotrigger and "autosnippet" or "snippet"
+					snippetType = ls_conf.autotrigger and "autosnippet"
+						or "snippet",
 				}, body)
 
 				if session.config.loaders_store_source then
@@ -86,7 +88,9 @@ local function get_file_snippets(file, default_filetype, opts)
 				-- https://code.visualstudio.com/docs/editor/userdefinedsnippets#_language-snippet-scope
 				-- scope can have multiple components.
 				if parts.scope and not ignore_scope then
-					for _, scope in ipairs(vim.split(parts.scope, ",", { plain = true })) do
+					for _, scope in
+						ipairs(vim.split(parts.scope, ",", { plain = true }))
+					do
 						-- set table in case it does not exist yet.
 						snippets_by_ft[scope] = snippets_by_ft[scope] or {}
 
@@ -113,7 +117,8 @@ local function load_snippet_files(lang, files, add_opts)
 				cached_path.fts[lang] = true
 			else
 				-- get all snippets from file, regardless of scope.
-				file_lang_snippets = get_file_snippets(file, lang, {ignore_scope = true})[lang]
+				file_lang_snippets =
+					get_file_snippets(file, lang, { ignore_scope = true })[lang]
 				-- store snippets to prevent parsing the same file more than once.
 				package_cache.path_snippets[file] = {
 					snippets = vim.deepcopy(file_lang_snippets),
@@ -338,7 +343,7 @@ local function standalone_add(path, add_opts)
 	-- store add_opts for this file: file might be edited, and then we want to
 	-- reload it with these same add_opts.
 	standalone_cache.path_snippets[path] = {
-		add_opts = add_opts
+		add_opts = add_opts,
 	}
 
 	ls.add_snippets(
@@ -373,7 +378,6 @@ function M._reload_file(filename)
 		-- reload file for all filetypes it occurs in.
 		for ft, _ in pairs(package_cached_data.fts) do
 			load_snippet_files(ft, { filename }, add_opts)
-
 		end
 		ls.clean_invalidated({ inv_limit = 100 })
 	end

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -83,9 +83,6 @@ local function get_file_snippets(file, default_filetype, opts)
 					snip._source = source.from_location(file)
 				end
 
-				-- snippet can be provided to multiple filetypes via scope.
-				local ft_tables = {}
-
 				-- https://code.visualstudio.com/docs/editor/userdefinedsnippets#_language-snippet-scope
 				-- scope can have multiple components.
 				if parts.scope and not ignore_scope then

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -93,7 +93,7 @@ local function get_file_snippets(file, default_filetype, opts)
 						-- set table in case it does not exist yet.
 						snippets_by_ft[scope] = snippets_by_ft[scope] or {}
 
-						table.insert(snippets_by_ft[scope], snip)
+						table.insert(snippets_by_ft[scope], snip:copy())
 					end
 				else
 					table.insert(snippets_by_ft[default_filetype], snip)

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -11,6 +11,7 @@ local source = require("luasnip.session.snippet_collection.source")
 local json_decoders = {
 	json = util.json_decode,
 	jsonc = require("luasnip.util.jsonc").decode,
+	["code-snippets"] = require("luasnip.util.jsonc").decode
 }
 
 local function read_json(fname)
@@ -21,9 +22,9 @@ local function read_json(fname)
 	end
 
 	local fname_extension = Path.extension(fname)
-	if fname_extension ~= "json" and fname_extension ~= "jsonc" then
+	if json_decoders[fname_extension] == nil then
 		log.error(
-			"`%s` was expected to have file-extension either `json` or `jsonc`, but doesn't.",
+			"`%s` was expected to have file-extension either `json`, `jsonc` or `code-snippets`, but doesn't.",
 			fname
 		)
 		return nil

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -361,7 +361,7 @@ end
 function M.load_standalone(opts)
 	opts = opts or {}
 	local add_opts = loader_util.add_opts(opts)
-	local path = opts.path
+	local path = Path.expand(opts.path)
 
 	standalone_add(path, add_opts)
 end

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -90,15 +90,13 @@ local function get_file_snippets(file, default_filetype, opts)
 				-- scope can have multiple components.
 				if parts.scope and not ignore_scope then
 					for _, scope in ipairs(vim.split(parts.scope, ",", { plain = true })) do
+						-- set table in case it does not exist yet.
 						snippets_by_ft[scope] = snippets_by_ft[scope] or {}
-						table.insert(ft_tables, snippets_by_ft[scope])
+
+						table.insert(snippets_by_ft[scope], snip)
 					end
 				else
-					table.insert(ft_tables, snippets_by_ft[default_filetype])
-				end
-
-				for _, t in ipairs(ft_tables) do
-					table.insert(t, snip)
+					table.insert(snippets_by_ft[default_filetype], snip)
 				end
 			end
 		end)

--- a/tests/data/vscode-snippets/package.json
+++ b/tests/data/vscode-snippets/package.json
@@ -31,6 +31,12 @@
 					"all"
 				],
 				"path": "snippets/all.jsonc"
+			},
+			{
+				"language": [
+					"all"
+				],
+				"path": "./snippets/all.code-snippets"
 			}
 		]
 	}

--- a/tests/data/vscode-snippets/snippets/all.code-snippets
+++ b/tests/data/vscode-snippets/snippets/all.code-snippets
@@ -1,0 +1,10 @@
+// uh oh, a comment.
+{
+	"a": {
+		"prefix": "codesnippets",
+		"body": [
+			"code-snippets!!!"
+		]
+	}
+	/* oh no a block comment */
+}

--- a/tests/data/vscode-standalone.code-snippets
+++ b/tests/data/vscode-standalone.code-snippets
@@ -1,0 +1,36 @@
+{
+	"snip1": {
+		"prefix": "vscode_lua1",
+		"body": [
+			"vscode$1lualualua"
+		],
+		"scope": "lua"
+	},
+	"snip1": {
+		"prefix": "all1",
+		"body": [
+			"expands? jumps? $1 $2 !"
+		],
+		"scope": "all"
+	},
+	"snip2": {
+		"prefix": "all2",
+		"body": [
+			"multi $1",
+			"line $2",
+			"#not removed??",
+			"snippet$0"
+		],
+		// empty scope should be all
+	},
+	"snip2": {
+		"prefix": "vscode_lua2",
+		"body": [
+			"vscode$1lualualua"
+		],
+		"luasnip": {
+			"autotrigger": true
+		},
+		"scope": "all"
+	}
+}

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -154,6 +154,14 @@ M.loaders = {
 			)
 		)
 	end,
+	["vscode(standalone)"] = function()
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_vscode").load_standalone({path="%s"})]],
+				os.getenv("LUASNIP_SOURCE") .. "/tests/data/vscode-standalone.code-snippets"
+			)
+		)
+	end,
 
 	["snipmate(rtp)"] = function()
 		exec(

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -158,7 +158,8 @@ M.loaders = {
 		exec_lua(
 			string.format(
 				[[require("luasnip.loaders.from_vscode").load_standalone({path="%s"})]],
-				os.getenv("LUASNIP_SOURCE") .. "/tests/data/vscode-standalone.code-snippets"
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/vscode-standalone.code-snippets"
 			)
 		)
 	end,

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -496,11 +496,13 @@ describe("loaders:", function()
 
 		feed("icodesnippets")
 		exec_lua("ls.expand()")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			code-snippets!!!^                                  |
 			{0:~                                                 }|
 			{0:~                                                 }|
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 	end)
 end)

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -388,6 +388,12 @@ describe("loaders:", function()
 		"/tests/data/vscode-snippets/snippets/all.json",
 		"<Esc>4jwlcereplaces<Esc>:w<Cr><C-O>ccall1"
 	)
+	reload_test(
+		"vscode-standalone-reload works",
+		ls_helpers.loaders["vscode(standalone)"],
+		"/tests/data/vscode-standalone.code-snippets",
+		"<Esc>11jwlcereplaces<Esc>:w<Cr><C-O>ccall1"
+	)
 
 	reload_test(
 		"lua-reload works",

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -484,4 +484,17 @@ describe("loaders:", function()
 		"/tests/symlinked_data/lua-snippets/luasnippets/all.lua",
 		"<Esc>jfecereplaces<Esc>:w<Cr><C-O>ccall1"
 	)
+
+	it("Can load files with `code-snippets`-extension.", function()
+		ls_helpers.loaders["vscode(rtp)"]()
+
+		feed("icodesnippets")
+		exec_lua("ls.expand()")
+		screen:expect{grid=[[
+			code-snippets!!!^                                  |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]}
+	end)
 end)


### PR DESCRIPTION
Both in `package.json`-style snippet-packages and as standalone files, where snippet-filetypes have to be set via `scope`.