### PR TITLE
fix: merge opts with context

### DIFF
--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -159,6 +159,8 @@ end
 
 -- context, opts non-nil tables.
 local function init_snippet_context(context, opts)
+	context = opts and vim.tbl_extend("error", context, opts) or context
+
 	local effective_context = {}
 
 	-- trig is set by user, trigger is used internally.
@@ -205,12 +207,8 @@ local function init_snippet_context(context, opts)
 	effective_context.regTrig =
 		util.ternary(context.regTrig ~= nil, context.regTrig, false)
 
-	effective_context.condition = context.condition
-		or opts.condition
-		or true_func
-	effective_context.show_condition = context.show_condition
-		or opts.show_condition
-		or true_func
+	effective_context.condition = context.condition or true_func
+	effective_context.show_condition = context.show_condition or true_func
 
 	-- init invalidated here.
 	-- This is because invalidated is a key that can be populated without any


### PR DESCRIPTION
```lua
local increment = postfix("++", {
  f(function(_, parent)
    return string.format("%s = %s + 1", parent.snippet.env.POSTFIX_MATCH, parent.snippet.env.POSTFIX_MATCH)
  end, {}),
}, {
  hidden = true,
  condition = has_word_before,
})
```

^ `hidden = true` in this example was not working as expected.