### PR TITLE
Several improvements.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -2152,7 +2152,7 @@ Luasnip is capable of loading snippets from different formats, including both
 the well-established VSCode and SnipMate format, as well as plain Lua files for
 snippets written in Lua.
 
-All loaders share a similar interface:
+All loaders (except the vscode-standalone-loader) share a similar interface:
 `require("luasnip.loaders.from_{vscode,snipmate,lua}").{lazy_,}load(opts:table|nil)`
 
 where `opts` can contain the following keys:
@@ -2353,6 +2353,69 @@ require("luasnip.loaders.from_vscode").lazy_load()
 require("luasnip.loaders.from_vscode").lazy_load({paths = "~/.config/nvim/my_snippets"})
 -- or relative to the directory of $MYVIMRC
 require("luasnip.loaders.from_vscode").load({paths = "./my_snippets"})
+```
+
+### Standalone
+Beside snippet-libraries provided by packages, vscode also supports another
+format which can be used for project-local snippets, or user-defined snippets,
+`.code-snippets`.  
+
+The layout of these files is almost identical to that of the package-provided
+snippets, but there is one additional field supported in the
+snippet-definitions, `scope`, with which the filetype of the snippet can be set.
+If `scope` is not set, the snippet will be added to the global filetype (`all`).
+
+`require("luasnip.loaders.from_vscode").load_standalone(opts)`
+
+- `opts`: `table`, can contain the following keys:
+  - `path`: `string`, Path to the `*.code-snippets`-file that should be loaded.
+    Just like the paths in `load`, this one can begin with a `"~/"` to be
+    relative to `$HOME`, and a `"./"` to be relative to the
+    neovim-config-directory.
+  - `{override,default}_priority`: These keys are passed straight to the
+    `add_snippets`-calls (documented in [API](#api)) and can be used to change
+    the priority of the loaded snippets.
+
+**Example**:
+`a.code-snippets`:
+```jsonc
+{
+    // a comment, since `.code-snippets` may contain jsonc.
+    "c/cpp-snippet": {
+        "prefix": [
+            "trigger1",
+            "trigger2"
+        ],
+        "body": [
+            "this is $1",
+            "my snippet $2"
+        ],
+        "description": "A description of the snippet.",
+        "scope": "c,cpp"
+    },
+    "python-snippet": {
+        "prefix": "trig",
+        "body": [
+            "this is $1",
+            "a different snippet $2"
+        ],
+        "description": "Another snippet-description.",
+        "scope": "python"
+    },
+    "global snippet": {
+        "prefix": "trigg",
+        "body": [
+            "this is $1",
+            "the last snippet $2"
+        ],
+        "description": "One last snippet-description.",
+    }
+}
+```
+
+This file can be loaded by calling
+```lua
+require("luasnip.loaders.from_vscode").load_standalone({path = "a.code-snippets"})
 ```
 
 ## SNIPMATE

--- a/DOC.md
+++ b/DOC.md
@@ -212,6 +212,8 @@ s({trig="trigger"}, {})
     LuaSnip on snippet expansion (and thus has access to the matched trigger and
 	captures), while `show_condition` is (should be) evaluated by the
 	completion engines when scanning for available snippet candidates.
+  - `filetype`: `string`, the filetype of the snippet.
+    This overrides the filetype the snippet is added (via `add_snippet`) as.
 
 - `nodes`: A single node or a list of nodes. The nodes that make up the
   snippet.

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2023 May 26
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2023 May 31
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -284,6 +284,8 @@ The most direct way to define snippets is `s`:
         LuaSnip on snippet expansion (and thus has access to the matched trigger and
         captures), while `show_condition` is (should be) evaluated by the
         completion engines when scanning for available snippet candidates.
+    - `filetype`: `string`, the filetype of the snippet.
+        This overrides the filetype the snippet is added (via `add_snippet`) as.
 - `nodes`: A single node or a list of nodes. The nodes that make up the snippet.
 - `opts`: A table with the following valid keys:
     - `callbacks`: Contains functions that are called upon entering/leaving a node of
@@ -2015,7 +2017,7 @@ Luasnip is capable of loading snippets from different formats, including both
 the well-established VSCode and SnipMate format, as well as plain Lua files for
 snippets written in Lua.
 
-All loaders share a similar interface:
+All loaders (except the vscode-standalone-loader) share a similar interface:
 `require("luasnip.loaders.from_{vscode,snipmate,lua}").{lazy_,}load(opts:table|nil)`
 
 where `opts` can contain the following keys:
@@ -2055,6 +2057,47 @@ we use `BufWritePost` for reloading, not some lower-level mechanism).
 For easy editing of these files, LuaSnip provides a `vim.ui.select`-based
 dialog (|luasnip-loaders-edit_snippets|) where first the filetype, and then the
 file can be selected.
+
+
+SNIPPET-SPECIFIC FILETYPES ~
+
+Some loaders (vscode,lua) support giving snippets generated in some file their
+own filetype (vscode via `scope`, lua via the underlying `filetype`-option for
+snippets). These snippet-specific filetypes are not considered when determining
+which files to `lazy_load` for some filetype, this is exclusively determined by
+the `language` associated with a file in vscodes’ `package.json`, and the
+file/directory-name in lua. This can be resolved relatively easily in vscode,
+where the `language` advertised in `package.json` can just be a superset of the
+`scope`s in the file. Another simplistic solution is to set the language to
+`all` (in lua, it might make sense to create a directory
+`luasnippets/all/*.lua` to group these files together). Another approach is to
+modify `load_ft_func` to load a custom filetype if the snippets should be
+activated, and store the snippets in a file for that filetype. This can be used
+to group snippets by e.g. framework, and load them once a file belonging to
+such a framework is edited.
+
+**Example**: `react.lua`
+
+>lua
+    return {
+        s({filetype = "css", trig = ...}, ...),
+        s({filetype = "html", trig = ...}, ...),
+        s({filetype = "js", trig = ...}, ...),
+    }
+<
+
+`luasnip_config.lua`
+
+>lua
+    load_ft_func = function(bufnr)
+        if "<bufnr-in-react-framework>" then
+            -- will load `react.lua` for this buffer
+            return {"react"}
+        else
+            return require("luasnip.extras.filetype_functions").from_filetype_load
+        end
+    end
+<
 
 
 TROUBLESHOOTING                              *luasnip-loaders-troubleshooting*
@@ -2182,6 +2225,73 @@ This collection can be loaded with any of
     require("luasnip.loaders.from_vscode").lazy_load({paths = "~/.config/nvim/my_snippets"})
     -- or relative to the directory of $MYVIMRC
     require("luasnip.loaders.from_vscode").load({paths = "./my_snippets"})
+<
+
+
+STANDALONE ~
+
+Beside snippet-libraries provided by packages, vscode also supports another
+format which can be used for project-local snippets, or user-defined snippets,
+`.code-snippets`.
+
+The layout of these files is almost identical to that of the package-provided
+snippets, but there is one additional field supported in the
+snippet-definitions, `scope`, with which the filetype of the snippet can be
+set. If `scope` is not set, the snippet will be added to the global filetype
+(`all`).
+
+`require("luasnip.loaders.from_vscode").load_standalone(opts)`
+
+- `opts`: `table`, can contain the following keys:
+    - `path`: `string`, Path to the `*.code-snippets`-file that should be loaded.
+        Just like the paths in `load`, this one can begin with a `"~/"` to be
+        relative to `$HOME`, and a `"./"` to be relative to the
+        neovim-config-directory.
+    - `{override,default}_priority`: These keys are passed straight to the
+        `add_snippets`-calls (documented in |luasnip-api|) and can be used to change
+        the priority of the loaded snippets.
+
+**Example**: `a.code-snippets`:
+
+>jsonc
+    {
+        // a comment, since `.code-snippets` may contain jsonc.
+        "c/cpp-snippet": {
+            "prefix": [
+                "trigger1",
+                "trigger2"
+            ],
+            "body": [
+                "this is $1",
+                "my snippet $2"
+            ],
+            "description": "A description of the snippet.",
+            "scope": "c,cpp"
+        },
+        "python-snippet": {
+            "prefix": "trig",
+            "body": [
+                "this is $1",
+                "a different snippet $2"
+            ],
+            "description": "Another snippet-description.",
+            "scope": "python"
+        },
+        "global snippet": {
+            "prefix": "trigg",
+            "body": [
+                "this is $1",
+                "the last snippet $2"
+            ],
+            "description": "One last snippet-description.",
+        }
+    }
+<
+
+This file can be loaded by calling
+
+>lua
+    require("luasnip.loaders.from_vscode").load_standalone({path = "a.code-snippets"})
 <
 
 

--- a/lua/luasnip/extras/snip_location.lua
+++ b/lua/luasnip/extras/snip_location.lua
@@ -114,7 +114,11 @@ function M.jump_to_snippet(snip, opts)
 	end
 
 	local fcall_range
-	local ft = util.ternary(vim.bo[0].filetype ~= "", vim.bo[0].filetype, vim.api.nvim_buf_get_name(0):match("%.([^%.]+)$"))
+	local ft = util.ternary(
+		vim.bo[0].filetype ~= "",
+		vim.bo[0].filetype,
+		vim.api.nvim_buf_get_name(0):match("%.([^%.]+)$")
+	)
 	if ft == "lua" then
 		if source.line then
 			-- in lua-file, can get region of definition via treesitter.
@@ -137,8 +141,7 @@ function M.jump_to_snippet(snip, opts)
 	-- matches *.json or *.jsonc.
 	elseif ft == "json" or ft == "jsonc" then
 		local ok
-		ok, fcall_range =
-			pcall(json_find_snippet_definition, 0, ft, snip.name)
+		ok, fcall_range = pcall(json_find_snippet_definition, 0, ft, snip.name)
 		if not ok then
 			print(
 				"Could not determine range of snippet-definition: "

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -52,13 +52,13 @@ local function new_cache()
 end
 
 local M = {
-	vscode = new_cache(),
+	vscode_packages = new_cache(),
 	snipmate = new_cache(),
 	lua = new_cache(),
 }
 
 function M.cleanup()
-	M.vscode:clean()
+	M.vscode_packages:clean()
 	M.snipmate:clean()
 	M.lua:clean()
 end

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -62,12 +62,14 @@ end
 
 local M = {
 	vscode_packages = new_cache(),
+	vscode_standalone = new_cache(),
 	snipmate = new_cache(),
 	lua = new_cache(),
 }
 
 function M.cleanup()
 	M.vscode_packages:clean()
+	M.vscode_standalone:clean()
 	M.snipmate:clean()
 	M.lua:clean()
 end

--- a/lua/luasnip/loaders/_caches.lua
+++ b/lua/luasnip/loaders/_caches.lua
@@ -40,11 +40,20 @@ local function new_cache()
 		lazy_loaded_ft = { all = true },
 
 		-- key is file type, value are normalized!! paths of .snippets files.
+		-- shall contain all files loaded by any loader.
 		ft_paths = {},
 
 		-- key is _normalized!!!!_ file path, value are loader-specific.
 		-- Might contain the snippets from the file, or the filetype(s) it
 		-- contributes to.
+		--
+		-- for vscode:
+		-- stores {
+		-- 	 snippets, -- the snippets provided by the file
+		--   filetype_add_opts, -- add_opts for some filetype
+		--   filetypes -- filetypes for which this file is active (important for
+		--   reload).
+		-- }
 		path_snippets = {},
 	}, {
 		__index = Cache,

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -14,7 +14,7 @@ local duplicate = require("luasnip.nodes.duplicate")
 local json_decoders = {
 	json = util.json_decode,
 	jsonc = require("luasnip.util.jsonc").decode,
-	["code-snippets"] = require("luasnip.util.jsonc").decode
+	["code-snippets"] = require("luasnip.util.jsonc").decode,
 }
 
 local function read_json(fname)
@@ -69,7 +69,7 @@ local function get_file_snippets(file)
 			dscr = parts.description or name,
 			wordTrig = ls_conf.wordTrig,
 			priority = ls_conf.priority,
-			snippetType = ls_conf.autotrigger and "autosnippet" or "snippet"
+			snippetType = ls_conf.autotrigger and "autosnippet" or "snippet",
 		}
 
 		-- Sometimes it's a list of prefixes instead of a single one
@@ -78,12 +78,16 @@ local function get_file_snippets(file)
 
 		-- vscode documents `,`, but `.` also works.
 		-- an entry `false` in this list will cause a `ft=nil` for the snippet.
-		local filetypes = parts.scope and vim.split(parts.scope, "[.,]") or {false}
+		local filetypes = parts.scope and vim.split(parts.scope, "[.,]")
+			or { false }
 
 		local contexts = {}
 		for _, prefix in ipairs(prefixes) do
 			for _, filetype in ipairs(filetypes) do
-				table.insert(contexts, {filetype = filetype or nil, trig = prefix})
+				table.insert(
+					contexts,
+					{ filetype = filetype or nil, trig = prefix }
+				)
 			end
 		end
 
@@ -117,12 +121,15 @@ end
 -- `force_reload`: don't use cache when reloading, default false
 local function load_snippet_file(file, filetype, add_opts, opts)
 	opts = opts or {}
-	local refresh_notify = util.ternary(opts.refresh_notify ~= nil, opts.refresh_notify, false)
-	local force_reload = util.ternary(opts.force_reload ~= nil, opts.force_reload, false)
+	local refresh_notify =
+		util.ternary(opts.refresh_notify ~= nil, opts.refresh_notify, false)
+	local force_reload =
+		util.ternary(opts.force_reload ~= nil, opts.force_reload, false)
 
 	if not Path.exists(file) then
 		log.error(
-			"Trying to read snippets from file %s, but it does not exist.", file
+			"Trying to read snippets from file %s, but it does not exist.",
+			file
 		)
 		return
 	end
@@ -151,11 +158,7 @@ local function load_snippet_file(file, filetype, add_opts, opts)
 			refresh_notify = refresh_notify,
 		}, add_opts)
 	)
-	log.info(
-		"Adding %s snippets from %s",
-		#file_snippets,
-		file
-	)
+	log.info("Adding %s snippets from %s", #file_snippets, file)
 end
 
 --- Find all files+associated filetypes in a package.
@@ -274,7 +277,7 @@ local function update_cache(cache, file, filetype, add_opts)
 	if not filecache then
 		filecache = {
 			filetype_add_opts = {},
-			filetypes = {}
+			filetypes = {},
 		}
 		cache.path_snippets[file] = filecache
 	end
@@ -299,7 +302,7 @@ function M.load(opts)
 			update_cache(package_cache, file, ft, add_opts)
 
 			-- `false`: don't refresh while adding.
-			load_snippet_file(file, ft, add_opts, {refresh_notify = false})
+			load_snippet_file(file, ft, add_opts, { refresh_notify = false })
 		end
 		ls.refresh_notify(ft)
 	end
@@ -311,7 +314,7 @@ function M._load_lazy_loaded_ft(ft)
 			file,
 			ft,
 			package_cache.path_snippets[file].filetype_add_opts[ft],
-			{refresh_notify = false}
+			{ refresh_notify = false }
 		)
 	end
 	ls.refresh_notify(ft)
@@ -352,7 +355,12 @@ function M.lazy_load(opts)
 		if package_cache.lazy_loaded_ft[ft] then
 			for _, file in ipairs(files) do
 				-- instantly load snippets if they were already loaded...
-				load_snippet_file(file, ft, add_opts, {refresh_notify = false})
+				load_snippet_file(
+					file,
+					ft,
+					add_opts,
+					{ refresh_notify = false }
+				)
 				log.info(
 					"Immediately loading lazy-load-snippets for already-active filetype %s from files:\n%s",
 					ft,
@@ -426,7 +434,12 @@ function M._reload_file(filename)
 		-- just use its snippets.
 		local force_reload = true
 		for ft, _ in pairs(package_cached_data.filetypes) do
-			load_snippet_file(filename, ft, package_cached_data.filetype_add_opts[ft], {force_reload = force_reload})
+			load_snippet_file(
+				filename,
+				ft,
+				package_cached_data.filetype_add_opts[ft],
+				{ force_reload = force_reload }
+			)
 			-- only force-reload once, then reuse updated snippets.
 			force_reload = false
 		end

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -11,6 +11,7 @@ local source = require("luasnip.session.snippet_collection.source")
 local json_decoders = {
 	json = util.json_decode,
 	jsonc = require("luasnip.util.jsonc").decode,
+	["code-snippets"] = require("luasnip.util.jsonc").decode
 }
 
 local function read_json(fname)
@@ -21,9 +22,9 @@ local function read_json(fname)
 	end
 
 	local fname_extension = Path.extension(fname)
-	if fname_extension ~= "json" and fname_extension ~= "jsonc" then
+	if json_decoders[fname_extension] == nil then
 		log.error(
-			"`%s` was expected to have file-extension either `json` or `jsonc`, but doesn't.",
+			"`%s` was expected to have file-extension either `json`, `jsonc` or `code-snippets`, but doesn't.",
 			fname
 		)
 		return nil

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -4,6 +4,12 @@ local Path = require("luasnip.util.path")
 
 local M = {}
 
+-- used to map cache-name to name passed to format.
+local clean_name = {
+	vscode_packages = "vscode",
+	snipmate = "snipmate",
+	lua = "lua"
+}
 local function default_format(path, _)
 	path = path:gsub(
 		vim.pesc(vim.fn.stdpath("data") .. "/site/pack/packer/start"),
@@ -48,9 +54,9 @@ function M.edit_snippet_files(opts)
 			local items = {}
 
 			-- concat files from all loaders for the selected filetype ft.
-			for _, cache_name in ipairs({ "vscode", "snipmate", "lua" }) do
+			for _, cache_name in ipairs({ "vscode_packages", "snipmate", "lua" }) do
 				for _, path in ipairs(Cache[cache_name].ft_paths[ft] or {}) do
-					local fmt_name = format(path, cache_name)
+					local fmt_name = format(path, clean_name[cache_name])
 					if fmt_name then
 						table.insert(ft_paths, path)
 						table.insert(items, fmt_name)

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -10,7 +10,7 @@ local clean_name = {
 	vscode_packages = "vscode",
 	vscode_standalone = "vscode-standalone",
 	snipmate = "snipmate",
-	lua = "lua"
+	lua = "lua",
 }
 local function default_format(path, _)
 	path = path:gsub(
@@ -46,7 +46,7 @@ function M.edit_snippet_files(opts)
 	opts = opts or {}
 	local format = opts.format or default_format
 	local edit = opts.edit or default_edit
-	local extend = opts.extend or function(_,_)
+	local extend = opts.extend or function(_, _)
 		return {}
 	end
 
@@ -56,7 +56,12 @@ function M.edit_snippet_files(opts)
 			local items = {}
 
 			-- concat files from all loaders for the selected filetype ft.
-			for _, cache_name in ipairs({ "vscode_packages", "vscode_standalone", "snipmate", "lua" }) do
+			for _, cache_name in ipairs({
+				"vscode_packages",
+				"vscode_standalone",
+				"snipmate",
+				"lua",
+			}) do
 				for _, path in ipairs(Cache[cache_name].ft_paths[ft] or {}) do
 					local fmt_name = format(path, clean_name[cache_name])
 					if fmt_name then
@@ -96,7 +101,10 @@ function M.edit_snippet_files(opts)
 
 	local all_fts = {}
 	vim.list_extend(all_fts, util.get_snippet_filetypes())
-	vim.list_extend(all_fts, loader_util.get_load_fts(vim.api.nvim_get_current_buf()))
+	vim.list_extend(
+		all_fts,
+		loader_util.get_load_fts(vim.api.nvim_get_current_buf())
+	)
 	all_fts = util.deduplicate(all_fts)
 
 	local filtered_fts = {}

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -1,5 +1,6 @@
 local Cache = require("luasnip.loaders._caches")
 local util = require("luasnip.util.util")
+local loader_util = require("luasnip.loaders.util")
 local Path = require("luasnip.util.path")
 
 local M = {}
@@ -93,8 +94,13 @@ function M.edit_snippet_files(opts)
 
 	local ft_filter = opts.ft_filter or util.yes
 
+	local all_fts = {}
+	vim.list_extend(all_fts, util.get_snippet_filetypes())
+	vim.list_extend(all_fts, loader_util.get_load_fts(vim.api.nvim_get_current_buf()))
+	all_fts = util.deduplicate(all_fts)
+
 	local filtered_fts = {}
-	for _, ft in ipairs(util.get_snippet_filetypes()) do
+	for _, ft in ipairs(all_fts) do
 		if ft_filter(ft) then
 			table.insert(filtered_fts, ft)
 		end

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -7,6 +7,7 @@ local M = {}
 -- used to map cache-name to name passed to format.
 local clean_name = {
 	vscode_packages = "vscode",
+	vscode_standalone = "vscode-standalone",
 	snipmate = "snipmate",
 	lua = "lua"
 }
@@ -44,7 +45,7 @@ function M.edit_snippet_files(opts)
 	opts = opts or {}
 	local format = opts.format or default_format
 	local edit = opts.edit or default_edit
-	local extend = opts.extend or function()
+	local extend = opts.extend or function(_,_)
 		return {}
 	end
 
@@ -54,7 +55,7 @@ function M.edit_snippet_files(opts)
 			local items = {}
 
 			-- concat files from all loaders for the selected filetype ft.
-			for _, cache_name in ipairs({ "vscode_packages", "snipmate", "lua" }) do
+			for _, cache_name in ipairs({ "vscode_packages", "vscode_standalone", "snipmate", "lua" }) do
 				for _, path in ipairs(Cache[cache_name].ft_paths[ft] or {}) do
 					local fmt_name = format(path, clean_name[cache_name])
 					if fmt_name then

--- a/lua/luasnip/nodes/duplicate.lua
+++ b/lua/luasnip/nodes/duplicate.lua
@@ -5,7 +5,9 @@ local M = {}
 local DupExpandable = {}
 
 -- just pass these through to _expandable.
-function DupExpandable:get_docstring() return self._expandable:get_docstring() end
+function DupExpandable:get_docstring()
+	return self._expandable:get_docstring()
+end
 function DupExpandable:copy()
 	local copy = self._expandable:copy()
 	copy.id = self.id
@@ -23,18 +25,20 @@ function DupExpandable:matches(...)
 end
 
 -- invalidate has to be called on this snippet itself.
-function DupExpandable:invalidate() snip_mod.Snippet.invalidate(self) end
+function DupExpandable:invalidate()
+	snip_mod.Snippet.invalidate(self)
+end
 
 local dup_mt = {
 	-- index DupExpandable for own functions, and then the expandable stored in
 	-- self/t.
-	__index = function(t,k)
+	__index = function(t, k)
 		if DupExpandable[k] then
 			return DupExpandable[k]
 		end
 
 		return t._expandable[k]
-	end
+	end,
 }
 
 function M.duplicate_expandable(expandable)
@@ -48,19 +52,18 @@ function M.duplicate_expandable(expandable)
 	}, dup_mt)
 end
 
-
 local DupAddable = {}
 
 function DupAddable:retrieve_all()
 	return vim.tbl_map(M.duplicate_expandable, self.addable:retrieve_all())
 end
 local DupAddable_mt = {
-	__index = DupAddable
+	__index = DupAddable,
 }
 
 function M.duplicate_addable(addable)
 	return setmetatable({
-		addable = addable
+		addable = addable,
 	}, DupAddable_mt)
 end
 

--- a/lua/luasnip/nodes/duplicate.lua
+++ b/lua/luasnip/nodes/duplicate.lua
@@ -1,0 +1,67 @@
+local snip_mod = require("luasnip.nodes.snippet")
+
+local M = {}
+
+local DupExpandable = {}
+
+-- just pass these through to _expandable.
+function DupExpandable:get_docstring() return self._expandable:get_docstring() end
+function DupExpandable:copy()
+	local copy = self._expandable:copy()
+	copy.id = self.id
+
+	return copy
+end
+
+-- this is modified in `self:invalidate` _and_ needs to be called on _expandable.
+function DupExpandable:matches(...)
+	-- use snippet-module matches, self._expandable might have had its match
+	-- overwritten by invalidate.
+	-- (if there are more issues with this, consider some other mechanism for
+	-- invalidating)
+	return snip_mod.Snippet.matches(self._expandable, ...)
+end
+
+-- invalidate has to be called on this snippet itself.
+function DupExpandable:invalidate() snip_mod.Snippet.invalidate(self) end
+
+local dup_mt = {
+	-- index DupExpandable for own functions, and then the expandable stored in
+	-- self/t.
+	__index = function(t,k)
+		if DupExpandable[k] then
+			return DupExpandable[k]
+		end
+
+		return t._expandable[k]
+	end
+}
+
+function M.duplicate_expandable(expandable)
+	return setmetatable({
+		_expandable = expandable,
+		-- copy these!
+		-- if `expandable` is invalidated, we don't necessarily want this
+		-- expandable to be invalidated as well.
+		hidden = expandable.hidden,
+		invalidated = expandable.invalidated,
+	}, dup_mt)
+end
+
+
+local DupAddable = {}
+
+function DupAddable:retrieve_all()
+	return vim.tbl_map(M.duplicate_expandable, self.addable:retrieve_all())
+end
+local DupAddable_mt = {
+	__index = DupAddable
+}
+
+function M.duplicate_addable(addable)
+	return setmetatable({
+		addable = addable
+	}, DupAddable_mt)
+end
+
+return M

--- a/lua/luasnip/nodes/multiSnippet.lua
+++ b/lua/luasnip/nodes/multiSnippet.lua
@@ -8,7 +8,10 @@ function VirtualSnippet:get_docstring()
 	return self.snippet:get_docstring()
 end
 function VirtualSnippet:copy()
-	return self.snippet:copy()
+	local copy = self.snippet:copy()
+	copy.id = self.id
+
+	return copy
 end
 
 -- VirtualSnippet has all the fields for executing these methods.

--- a/lua/luasnip/nodes/multiSnippet.lua
+++ b/lua/luasnip/nodes/multiSnippet.lua
@@ -77,14 +77,18 @@ local function multisnippet_from_nodes(contexts, nodes, opts)
 	-- create snippet without `context`-fields!
 	-- compare to `S` (aka `s`, the default snippet-constructor) in
 	-- `nodes/snippet.lua`.
-	return multisnippet_from_snippet_obj(contexts, snip_mod._S(
-		snip_mod.init_snippet_opts(common_snip_opts),
-		nodes,
+	return multisnippet_from_snippet_obj(
+		contexts,
+		snip_mod._S(
+			snip_mod.init_snippet_opts(common_snip_opts),
+			nodes,
+			common_snip_opts
+		),
 		common_snip_opts
-	), common_snip_opts)
+	)
 end
 
 return {
 	new_multisnippet = multisnippet_from_nodes,
-	_raw_ms = multisnippet_from_snippet_obj
+	_raw_ms = multisnippet_from_snippet_obj,
 }

--- a/lua/luasnip/nodes/multiSnippet.lua
+++ b/lua/luasnip/nodes/multiSnippet.lua
@@ -38,24 +38,12 @@ function MultiSnippet:retrieve_all()
 	return self.v_snips
 end
 
-local function new_multisnippet(contexts, nodes, opts)
+local function multisnippet_from_snippet_obj(contexts, snippet, snippet_opts)
 	assert(
 		type(contexts) == "table",
 		"multisnippet: expected contexts to be a table."
 	)
-	opts = opts or {}
-	local common_snip_opts = opts.common_opts or {}
-
 	local common_context = node_util.wrap_context(contexts.common) or {}
-
-	-- create snippet without `context`-fields!
-	-- compare to `S` (aka `s`, the default snippet-constructor) in
-	-- `nodes/snippet.lua`.
-	local snippet = snip_mod._S(
-		snip_mod.init_snippet_opts(common_snip_opts),
-		nodes,
-		common_snip_opts
-	)
 
 	local v_snips = {}
 	for _, context in ipairs(contexts) do
@@ -66,7 +54,7 @@ local function new_multisnippet(contexts, nodes, opts)
 		)
 		table.insert(
 			v_snips,
-			new_virtual_snippet(complete_context, snippet, common_snip_opts)
+			new_virtual_snippet(complete_context, snippet, snippet_opts)
 		)
 	end
 
@@ -79,6 +67,21 @@ local function new_multisnippet(contexts, nodes, opts)
 	return o
 end
 
+local function multisnippet_from_nodes(contexts, nodes, opts)
+	opts = opts or {}
+	local common_snip_opts = opts.common_opts or {}
+
+	-- create snippet without `context`-fields!
+	-- compare to `S` (aka `s`, the default snippet-constructor) in
+	-- `nodes/snippet.lua`.
+	return multisnippet_from_snippet_obj(contexts, snip_mod._S(
+		snip_mod.init_snippet_opts(common_snip_opts),
+		nodes,
+		common_snip_opts
+	), common_snip_opts)
+end
+
 return {
-	new_multisnippet = new_multisnippet,
+	new_multisnippet = multisnippet_from_nodes,
+	_raw_ms = multisnippet_from_snippet_obj
 }

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -189,6 +189,9 @@ local function init_snippet_context(context, opts)
 		or context.snippetType == "snippet"     and "snippets"
 		or nil
 
+	-- may be nil.
+	effective_context.filetype = context.filetype
+
 	-- maybe do this in a better way when we have more parameters, but this is
 	-- fine for now:
 

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -47,7 +47,8 @@ end
 
 -- some values of the snippet are nil by default, list them here so snippets
 -- aren't instantiated because of them.
-local license_to_nil = { priority = true, snippetType = true, _source = true, filetype = true }
+local license_to_nil =
+	{ priority = true, snippetType = true, _source = true, filetype = true }
 
 -- context and opts are (almost) the same objects as in s(contex, nodes, opts), snippet is a string representing the snippet.
 -- opts can aditionally contain the key `parse_fn`, which will be used to parse
@@ -69,7 +70,12 @@ local function new(context, snippet, opts)
 	local sp = vim.tbl_extend(
 		"error",
 		{},
-		context and snip_mod.init_snippet_context(node_util.wrap_context(context), opts) or {},
+		context
+				and snip_mod.init_snippet_context(
+					node_util.wrap_context(context),
+					opts
+				)
+			or {},
 		snip_mod.init_snippet_opts(opts),
 		node_util.init_node_opts(opts)
 	)

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -102,7 +102,10 @@ local function new(context, snippet, opts)
 	-- when the metatable has been changed. Therefore: set copy in each instance
 	-- of snippetProxy.
 	function sp:copy()
-		return self._snippet:copy()
+		local copy = self._snippet:copy()
+		copy.id = self.id
+
+		return copy
 	end
 
 	return sp

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -53,6 +53,9 @@ local license_to_nil = { priority = true, snippetType = true, _source = true, fi
 -- opts can aditionally contain the key `parse_fn`, which will be used to parse
 -- the snippet. This is useful, since snipmate-snippets are parsed with a
 -- function than regular lsp-snippets.
+-- context can be nil, in that case the resulting object can't be inserted into
+-- the snippet-tables, but may be used after expansion (i.e. returned from
+-- snippet:copy)
 local function new(context, snippet, opts)
 	opts = opts or {}
 
@@ -66,7 +69,7 @@ local function new(context, snippet, opts)
 	local sp = vim.tbl_extend(
 		"error",
 		{},
-		snip_mod.init_snippet_context(node_util.wrap_context(context), opts),
+		context and snip_mod.init_snippet_context(node_util.wrap_context(context), opts) or {},
 		snip_mod.init_snippet_opts(opts),
 		node_util.init_node_opts(opts)
 	)

--- a/lua/luasnip/nodes/snippetProxy.lua
+++ b/lua/luasnip/nodes/snippetProxy.lua
@@ -47,7 +47,7 @@ end
 
 -- some values of the snippet are nil by default, list them here so snippets
 -- aren't instantiated because of them.
-local license_to_nil = { priority = true, snippetType = true, _source = true }
+local license_to_nil = { priority = true, snippetType = true, _source = true, filetype = true }
 
 -- context and opts are (almost) the same objects as in s(contex, nodes, opts), snippet is a string representing the snippet.
 -- opts can aditionally contain the key `parse_fn`, which will be used to parse

--- a/lua/luasnip/session/snippet_collection/init.lua
+++ b/lua/luasnip/session/snippet_collection/init.lua
@@ -256,8 +256,7 @@ function M.add_snippets(snippets, opts)
 				local snip_type = snip.snippetType ~= nil and snip.snippetType
 					or opts.type
 				assert(
-					snip_type == "autosnippets"
-						or snip_type == "snippets",
+					snip_type == "autosnippets" or snip_type == "snippets",
 					"snippetType must be either 'autosnippets' or 'snippets'"
 				)
 

--- a/lua/luasnip/session/snippet_collection/init.lua
+++ b/lua/luasnip/session/snippet_collection/init.lua
@@ -229,11 +229,11 @@ function M.clean_invalidated(opts)
 	M.invalidated_count = 0
 end
 
-local function invalidate_snippets(snippets_by_ft)
-	for _, ft_snippets in pairs(snippets_by_ft) do
-		for _, addable in ipairs(ft_snippets) do
-			for _, snip in ipairs(addable:retrieve_all()) do
-				snip:invalidate()
+local function invalidate_addables(addables_by_ft)
+	for _, addables in pairs(addables_by_ft) do
+		for _, addable in ipairs(addables) do
+			for _, expandable in ipairs(addable:retrieve_all()) do
+				expandable:invalidate()
 			end
 		end
 	end
@@ -282,7 +282,7 @@ function M.add_snippets(snippets, opts)
 
 	if opts.key then
 		if by_key[opts.key] then
-			invalidate_snippets(by_key[opts.key])
+			invalidate_addables(by_key[opts.key])
 		end
 		by_key[opts.key] = snippets
 	end

--- a/lua/luasnip/session/snippet_collection/init.lua
+++ b/lua/luasnip/session/snippet_collection/init.lua
@@ -247,26 +247,28 @@ function M.add_snippets(snippets, opts)
 	for ft, ft_snippets in pairs(snippets) do
 		for _, addable in ipairs(ft_snippets) do
 			for _, snip in ipairs(addable:retrieve_all()) do
-				snip.priority = opts.override_priority
+				local snip_prio = opts.override_priority
 					or (snip.priority and snip.priority)
 					or opts.default_priority
 					or 1000
 
 				-- if snippetType undefined by snippet, take default value from opts
-				snip.snippetType = snip.snippetType ~= nil and snip.snippetType
+				local snip_type = snip.snippetType ~= nil and snip.snippetType
 					or opts.type
 				assert(
-					snip.snippetType == "autosnippets"
-						or snip.snippetType == "snippets",
-					"snipptType must be either 'autosnippets' or 'snippets'"
+					snip_type == "autosnippets"
+						or snip_type == "snippets",
+					"snippetType must be either 'autosnippets' or 'snippets'"
 				)
+
+				local snip_ft = snip.filetype or ft
 
 				snip.id = current_id
 				current_id = current_id + 1
 
 				-- do the insertion
-				table.insert(by_prio[snip.snippetType][snip.priority][ft], snip)
-				table.insert(by_ft[snip.snippetType][ft], snip)
+				table.insert(by_prio[snip_type][snip_prio][snip_ft], snip)
+				table.insert(by_ft[snip_type][snip_ft], snip)
 				by_id[snip.id] = snip
 
 				-- set source if it was passed, and remove from snippet.

--- a/tests/data/vscode-snippets/package.json
+++ b/tests/data/vscode-snippets/package.json
@@ -31,6 +31,12 @@
 					"all"
 				],
 				"path": "snippets/all.jsonc"
+			},
+			{
+				"language": [
+					"all"
+				],
+				"path": "./snippets/all.code-snippets"
 			}
 		]
 	}

--- a/tests/data/vscode-snippets/snippets/all.code-snippets
+++ b/tests/data/vscode-snippets/snippets/all.code-snippets
@@ -1,0 +1,10 @@
+// uh oh, a comment.
+{
+	"a": {
+		"prefix": "codesnippets",
+		"body": [
+			"code-snippets!!!"
+		]
+	}
+	/* oh no a block comment */
+}

--- a/tests/data/vscode-snippets/snippets/all.jsonc
+++ b/tests/data/vscode-snippets/snippets/all.jsonc
@@ -15,6 +15,13 @@
 		"luasnip": {
 			"priority": 2000
 		}
+	},
+	"c": {
+		"prefix": "cc",
+		"body": [
+			"3"
+		],
+		"scope": "cpp,c"
 	}
 }
 

--- a/tests/data/vscode-standalone.code-snippets
+++ b/tests/data/vscode-standalone.code-snippets
@@ -1,0 +1,36 @@
+{
+	"snip1": {
+		"prefix": "vscode_lua1",
+		"body": [
+			"vscode$1lualualua"
+		],
+		"scope": "lua"
+	},
+	"snip1": {
+		"prefix": "all1",
+		"body": [
+			"expands? jumps? $1 $2 !"
+		],
+		"scope": "all"
+	},
+	"snip2": {
+		"prefix": "all2",
+		"body": [
+			"multi $1",
+			"line $2",
+			"#not removed??",
+			"snippet$0"
+		],
+		// empty scope should be all
+	},
+	"snip2": {
+		"prefix": "vscode_lua2",
+		"body": [
+			"vscode$1lualualua"
+		],
+		"luasnip": {
+			"autotrigger": true
+		},
+		"scope": "all"
+	}
+}

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -154,6 +154,14 @@ M.loaders = {
 			)
 		)
 	end,
+	["vscode(standalone)"] = function()
+		exec_lua(
+			string.format(
+				[[require("luasnip.loaders.from_vscode").load_standalone({path="%s"})]],
+				os.getenv("LUASNIP_SOURCE") .. "/tests/data/vscode-standalone.code-snippets"
+			)
+		)
+	end,
 
 	["snipmate(rtp)"] = function()
 		exec(

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -158,7 +158,8 @@ M.loaders = {
 		exec_lua(
 			string.format(
 				[[require("luasnip.loaders.from_vscode").load_standalone({path="%s"})]],
-				os.getenv("LUASNIP_SOURCE") .. "/tests/data/vscode-standalone.code-snippets"
+				os.getenv("LUASNIP_SOURCE")
+					.. "/tests/data/vscode-standalone.code-snippets"
 			)
 		)
 	end,

--- a/tests/integration/add_snippets_spec.lua
+++ b/tests/integration/add_snippets_spec.lua
@@ -309,4 +309,26 @@ describe("add_snippets", function()
 			{2:-- INSERT --}                                      |]],
 		})
 	end)
+
+	it("snippets' filetype overrides add_snippets-filetype", function()
+		exec_lua([[
+			ls.add_snippets("c", {
+				s({trig = "in_lua", filetype = "lua"}, {t"expanded in lua"})
+			})
+		]])
+		exec("set ft=c")
+		feed("iin_lua")
+		exec_lua("ls.expand()")
+		screen:expect{grid=[[
+			in_lua^                                            |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]}
+		exec("set ft=lua")
+		feed("<Cr>in_lua")
+		exec_lua("ls.expand()")
+		screen:expect{grid=[[
+			in_lua                                            |
+			expanded in lua^                                   |
+			{2:-- INSERT --}                                      |]]}
+	end)
 end)

--- a/tests/integration/add_snippets_spec.lua
+++ b/tests/integration/add_snippets_spec.lua
@@ -319,16 +319,20 @@ describe("add_snippets", function()
 		exec("set ft=c")
 		feed("iin_lua")
 		exec_lua("ls.expand()")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			in_lua^                                            |
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 		exec("set ft=lua")
 		feed("<Cr>in_lua")
 		exec_lua("ls.expand()")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			in_lua                                            |
 			expanded in lua^                                   |
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 	end)
 end)

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -497,4 +497,47 @@ describe("loaders:", function()
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]]}
 	end)
+
+	it("Respects `scope` (vscode)", function()
+		ls_helpers.loaders["vscode(rtp)"]()
+
+		feed("icc")
+		exec_lua("ls.expand()")
+		screen:expect{grid=[[
+			cc^                                                |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]}
+
+		exec("set ft=c")
+		feed("<Cr>cc")
+		exec_lua("ls.expand()")
+		screen:expect{grid=[[
+			cc                                                |
+			3^                                                 |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]}
+		-- check if invalidation affects the duplicated snippet.
+		exec_lua([[ls.get_snippets("c")[1]:invalidate()]])
+		feed("<Cr>cc")
+		exec_lua("ls.expand()")
+		screen:expect{grid=[[
+			cc                                                |
+			3                                                 |
+			cc^                                                |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]}
+
+		exec("set ft=cpp")
+		feed("<Cr>cc")
+		exec_lua("ls.expand()")
+		screen:expect{grid=[[
+			cc                                                |
+			3                                                 |
+			cc                                                |
+			3^                                                 |
+			{2:-- INSERT --}                                      |]]}
+	end)
 end)

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -496,12 +496,14 @@ describe("loaders:", function()
 
 		feed("icodesnippets")
 		exec_lua("ls.expand()")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			code-snippets!!!^                                  |
 			{0:~                                                 }|
 			{0:~                                                 }|
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 	end)
 
 	it("Respects `scope` (vscode)", function()
@@ -509,41 +511,49 @@ describe("loaders:", function()
 
 		feed("icc")
 		exec_lua("ls.expand()")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			cc^                                                |
 			{0:~                                                 }|
 			{0:~                                                 }|
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 
 		exec("set ft=c")
 		feed("<Cr>cc")
 		exec_lua("ls.expand()")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			cc                                                |
 			3^                                                 |
 			{0:~                                                 }|
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 		-- check if invalidation affects the duplicated snippet.
 		exec_lua([[ls.get_snippets("c")[1]:invalidate()]])
 		feed("<Cr>cc")
 		exec_lua("ls.expand()")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			cc                                                |
 			3                                                 |
 			cc^                                                |
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 
 		exec("set ft=cpp")
 		feed("<Cr>cc")
 		exec_lua("ls.expand()")
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			cc                                                |
 			3                                                 |
 			cc                                                |
 			3^                                                 |
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 	end)
 end)

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -388,6 +388,12 @@ describe("loaders:", function()
 		"/tests/data/vscode-snippets/snippets/all.json",
 		"<Esc>4jwlcereplaces<Esc>:w<Cr><C-O>ccall1"
 	)
+	reload_test(
+		"vscode-standalone-reload works",
+		ls_helpers.loaders["vscode(standalone)"],
+		"/tests/data/vscode-standalone.code-snippets",
+		"<Esc>11jwlcereplaces<Esc>:w<Cr><C-O>ccall1"
+	)
 
 	reload_test(
 		"lua-reload works",

--- a/tests/integration/loaders_spec.lua
+++ b/tests/integration/loaders_spec.lua
@@ -484,4 +484,17 @@ describe("loaders:", function()
 		"/tests/symlinked_data/lua-snippets/luasnippets/all.lua",
 		"<Esc>jfecereplaces<Esc>:w<Cr><C-O>ccall1"
 	)
+
+	it("Can load files with `code-snippets`-extension.", function()
+		ls_helpers.loaders["vscode(rtp)"]()
+
+		feed("icodesnippets")
+		exec_lua("ls.expand()")
+		screen:expect{grid=[[
+			code-snippets!!!^                                  |
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]}
+	end)
 end)

--- a/tests/unit/snippetProxy_spec.lua
+++ b/tests/unit/snippetProxy_spec.lua
@@ -29,6 +29,7 @@ describe("snippetProxy", function()
 		".wordTrig",
 		".regTrig",
 		".dscr",
+		".filetype",
 		".name",
 		".callbacks",
 		".condition",


### PR DESCRIPTION
This has multiple more-or-less interdependent improvements, hence me doing this in one PR:
* Snippet-filetype can be overridden via `filetype`-setting in `context`
  ```lua
  s({trig = "in lua", filetype = "lua"}, ...)
  ```
  will be added to lua even if it is in an `add_snippets`-call to another language.
  This may seem a bit weird at first, but is actually useful since it decouples
  the loaded filetype (language in `package.json`, "filetype.lua/snipmate")
  from the filetype of the added snippet. This allows doing something like
  grouping snippets by some property other than its filetype (for example all
  snippets for some framework together) which wasn't as nicely doable before
  (it was possible by splitting snippets by framework and filetype, but this is
  better).  
  Also allows adding a single snippet to multiple filetypes via multisnippet.

* Some performance/functional improvements for loaders.from_vscode. It's a bit
  cleaner now, uses multisnippet for multi-filetype/multi-trigger snippets
  (scope/prefix can have multiple entries), and does not deepcopy snippets, but
  uses `duplicate_addable/expandable`, a kind of thin wrapper around the
  original snippet which allows it to be added to multiple filetypes, without
  `invalidate` removing all snippets (kind of complicated :/).

* Finally, support for loading `.code-snippets` standalone, without a `package.json`.
