### PR TITLE
fix: use relative url for submodule definition (#911)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/jsregexp"]
 	path = deps/jsregexp
-	url = https://github.com/kmarius/jsregexp/
+	url = ../../kmarius/jsregexp/

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2023 May 31
+*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 June 06
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*


### PR DESCRIPTION
Tested within secure environment without GitHub access.
Tested in normal situation with GitHub access.
