### PR TITLE
Implement more trigger-types

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -170,7 +170,11 @@ s({trig="trigger"}, {})
   ```
 
   The following keys are valid:
-  - `trig`: string, plain text by default. The only entry that must be given.
+  - `trig`: string, the trigger of the snippet. If the text in front of (to the
+    left of) the cursor when `ls.expand()` is called matches it, the snippet
+    will be expanded.  
+    By default, "matches" means the text in front of the cursor matches the
+    trigger exactly, this behaviour can be modified through `trigEngine`
   - `name`: string, can be used by e.g. `nvim-compe` to identify the snippet.
   - `dscr`: string, description of the snippet, \n-separated or table
     for multiple lines.
@@ -178,11 +182,83 @@ s({trig="trigger"}, {})
     (`[%w_]+`) before the cursor matches the trigger entirely.
     True by default.
   - `regTrig`: boolean, whether the trigger should be interpreted as a
-    lua pattern. False by default.
+    lua pattern. False by default.  
+    Consider setting `trigEngine` to `"pattern"` instead, it is more expressive,
+    and in line with other settings.
+  - `trigEngine`: (function|string), determines how `trig` is interpreted, and
+    what it means for it to "match" the text in front of the cursor.  
+    This behaviour can be completely customized by passing a function, but the
+    predefined ones, which are accessible by passing their identifier, should
+    suffice in most cases:
+    * `"plain"`: the default-behaviour, the trigger has to match the text before
+      the cursor exactly.
+    * `"pattern"`: the trigger is interpreted as a lua-pattern, and is a match if
+      `trig .. "$"` matches the line up to the cursor. Capture-groups will be
+      accessible as `snippet.captures`.
+    * `"ecma"`: the trigger is interpreted as an ECMAscript-regex, and is a
+      match if `trig .. "$"` matches the line up to the cursor. Capture-groups
+      will be accessible as `snippet.captures`.  
+      This `trigEngine` requires `jsregexp` (see
+      [lsp-snippets-transformations](#transformations)) to be installed, if it
+      is not, this engine will behave like `"plain"`.
+    * `"vim"`: the trigger is interpreted as a vim-regex, and is a match if
+      `trig .. "$"` matches the line up to the cursor. As with the other
+      regex/pattern-engines, captures will be available as `snippet.captures`,
+      but there is one caveat: the matching is done using `matchlist`, so for
+      now empty-string submatches will be interpreted as unmatched, and the
+      corresponding `snippet.capture[i]` will be `nil` (this will most likely
+      change, don't rely on this behavior).
+
+    Besides these predefined engines, it is also possible to create new ones:
+    Instead of a string, pass a function which satisfies
+    `trigEngine(trigger) -> (matcher(line_to_cursor, trigger) -> whole_match,
+    captures)`
+    (ie. the function receives `trig`, can, for example, precompile a regex, and
+    then returns a function responsible for determining whether the current
+    cursor-position (represented by the line up to the cursor) matches the
+    trigger (it is passed again here so engines which don't do any
+    trigger-specific work (like compilation) can just return a static
+    `matcher`), and what the capture-groups are).
+    The `lua`-engine, for example, can be (and is!) implemented like this:
+    ```lua
+    local function matcher(line_to_cursor, trigger)
+        -- look for match which ends at the cursor.
+        -- put all results into a list, there might be many capture-groups.
+        local find_res = { line_to_cursor:find(trigger .. "$") }
+
+        if #find_res > 0 then
+            -- if there is a match, determine matching string, and the
+            -- capture-groups.
+            local captures = {}
+            -- find_res[1] is `from`, find_res[2] is `to` (which we already know
+            -- anyway).
+            local from = find_res[1]
+            local match = line_to_cursor:sub(from, #line_to_cursor)
+            -- collect capture-groups.
+            for i = 3, #find_res do
+                captures[i - 2] = find_res[i]
+            end
+            return match, captures
+        else
+            return nil
+        end
+    end
+
+    local function engine(trigger)
+        -- don't do any special work here, can't precompile lua-pattern.
+        return matcher
+    end
+    ```
+    The predefined engines are defined in
+    [`trig_engines.lua`](https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/nodes/util/trig_engines.lua),
+    read it for more examples.
+
   - `docstring`: string, textual representation of the snippet, specified like
     `dscr`. Overrides docstrings loaded from json.
-  - `docTrig`: string, for snippets triggered using a lua pattern: define the
-    trigger that is used during docstring-generation.
+  - `docTrig`: string, used as `line_to_cursor` during docstring-generation.
+    This might be relevant if the snippet relies on specific values in the
+    capture-groups (for example, numbers, which won't work with the default
+    `$CAPTURESN` used during docstring-generation)
   - `hidden`: boolean, hint for completion-engines.
     If set, the snippet should not show up when querying snippets.
   - `priority`: positive number, Priority of the snippet, 1000 by default.  

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 June 19
+*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 June 24
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -243,24 +243,92 @@ The most direct way to define snippets is `s`:
         }
     <
     The following keys are valid:
-    - `trig`: string, plain text by default. The only entry that must be given.
+    - `trig`: string, the trigger of the snippet. If the text in front of (to the
+        left of) the cursor when `ls.expand()` is called matches it, the snippet will
+        be expanded. By default, "matches" means the text in front of the cursor
+        matches the trigger exactly, this behaviour can be modified through
+        `trigEngine`
     - `name`: string, can be used by e.g. `nvim-compe` to identify the snippet.
-    - `dscr`: string, description of the snippet, -separated or table
-        for multiple lines.
+    - `dscr`: string, description of the snippet, -separated or table for multiple
+        lines.
     - `wordTrig`: boolean, if true, the snippet is only expanded if the word
-        (`[%w_]+`) before the cursor matches the trigger entirely.
-        True by default.
-    - `regTrig`: boolean, whether the trigger should be interpreted as a
-        lua pattern. False by default.
+        (`[%w_]+`) before the cursor matches the trigger entirely. True by default.
+    - `regTrig`: boolean, whether the trigger should be interpreted as a lua pattern.
+        False by default. Consider setting `trigEngine` to `"pattern"` instead, it is
+        more expressive, and in line with other settings.
+    - `trigEngine`: (function|string), determines how `trig` is interpreted, and what
+        it means for it to "match" the text in front of the cursor. This behaviour can
+        be completely customized by passing a function, but the predefined ones, which
+        are accessible by passing their identifier, should suffice in most cases:
+        - `"plain"`: the default-behaviour, the trigger has to match the text before
+            the cursor exactly.
+        - `"pattern"`: the trigger is interpreted as a lua-pattern, and is a match if
+            `trig .. "$"` matches the line up to the cursor. Capture-groups will be
+            accessible as `snippet.captures`.
+        - `"ecma"`: the trigger is interpreted as an ECMAscript-regex, and is a
+            match if `trig .. "$"` matches the line up to the cursor. Capture-groups
+            will be accessible as `snippet.captures`.
+            This `trigEngine` requires `jsregexp` (see
+            |luasnip-lsp-snippets-transformations|) to be installed, if it
+            is not, this engine will behave like `"plain"`.
+        - `"vim"`: the trigger is interpreted as a vim-regex, and is a match if
+            `trig .. "$"` matches the line up to the cursor. As with the other
+            regex/pattern-engines, captures will be available as `snippet.captures`,
+            but there is one caveat: the matching is done using `matchlist`, so for
+            now empty-string submatches will be interpreted as unmatched, and the
+            corresponding `snippet.capture[i]` will be `nil` (this will most likely
+            change, don’t rely on this behavior).
+        Besides these predefined engines, it is also possible to create new ones:
+        Instead of a string, pass a function which satisfies `trigEngine(trigger) ->
+        (matcher(line_to_cursor, trigger) -> whole_match, captures)` (ie. the function
+        receives `trig`, can, for example, precompile a regex, and then returns a
+        function responsible for determining whether the current cursor-position
+        (represented by the line up to the cursor) matches the trigger (it is passed
+        again here so engines which don’t do any trigger-specific work (like
+        compilation) can just return a static `matcher`), and what the capture-groups
+        are). The `lua`-engine, for example, can be (and is!) implemented like this:
+        >lua
+            local function matcher(line_to_cursor, trigger)
+                -- look for match which ends at the cursor.
+                -- put all results into a list, there might be many capture-groups.
+                local find_res = { line_to_cursor:find(trigger .. "$") }
+            
+                if #find_res > 0 then
+                    -- if there is a match, determine matching string, and the
+                    -- capture-groups.
+                    local captures = {}
+                    -- find_res[1] is `from`, find_res[2] is `to` (which we already know
+                    -- anyway).
+                    local from = find_res[1]
+                    local match = line_to_cursor:sub(from, #line_to_cursor)
+                    -- collect capture-groups.
+                    for i = 3, #find_res do
+                        captures[i - 2] = find_res[i]
+                    end
+                    return match, captures
+                else
+                    return nil
+                end
+            end
+            
+            local function engine(trigger)
+                -- don't do any special work here, can't precompile lua-pattern.
+                return matcher
+            end
+        <
+        The predefined engines are defined in `trig_engines.lua`
+        <https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/nodes/util/trig_engines.lua>,
+        read it for more examples.
     - `docstring`: string, textual representation of the snippet, specified like
         `dscr`. Overrides docstrings loaded from json.
-    - `docTrig`: string, for snippets triggered using a lua pattern: define the
-        trigger that is used during docstring-generation.
-    - `hidden`: boolean, hint for completion-engines.
-        If set, the snippet should not show up when querying snippets.
-    - `priority`: positive number, Priority of the snippet, 1000 by default.
-        Snippets with high priority will be matched to a trigger before those with a
-        lower one.
+    - `docTrig`: string, used as `line_to_cursor` during docstring-generation. This
+        might be relevant if the snippet relies on specific values in the
+        capture-groups (for example, numbers, which won’t work with the default
+        `$CAPTURESN` used during docstring-generation)
+    - `hidden`: boolean, hint for completion-engines. If set, the snippet should not
+        show up when querying snippets.
+    - `priority`: positive number, Priority of the snippet, 1000 by default. Snippets
+        with high priority will be matched to a trigger before those with a lower one.
         The priority for multiple snippets can also be set in `add_snippets`.
     - `snippetType`: string, should be either `snippet` or `autosnippet` (ATTENTION:
         singular form is used), decides whether this snippet has to be triggered by
@@ -279,13 +347,13 @@ The most direct way to define snippets is `s`:
         - `line_to_cursor`: `string`, the line up to the cursor.
         This function is (should be) evaluated by completion engines, indicating
         whether the snippet should be included in current completion candidates.
-        Defaults to a function returning `true`.
-        This is different from `condition` because `condition` is evaluated by
-        LuaSnip on snippet expansion (and thus has access to the matched trigger and
-        captures), while `show_condition` is (should be) evaluated by the
-        completion engines when scanning for available snippet candidates.
-    - `filetype`: `string`, the filetype of the snippet.
-        This overrides the filetype the snippet is added (via `add_snippet`) as.
+        Defaults to a function returning `true`. This is different from `condition`
+        because `condition` is evaluated by LuaSnip on snippet expansion (and thus has
+        access to the matched trigger and captures), while `show_condition` is (should
+        be) evaluated by the completion engines when scanning for available snippet
+        candidates.
+    - `filetype`: `string`, the filetype of the snippet. This overrides the filetype
+        the snippet is added (via `add_snippet`) as.
 - `nodes`: A single node or a list of nodes. The nodes that make up the snippet.
 - `opts`: A table with the following valid keys:
     - `callbacks`: Contains functions that are called upon entering/leaving a node of

--- a/lua/luasnip/extras/select_choice.lua
+++ b/lua/luasnip/extras/select_choice.lua
@@ -11,7 +11,10 @@ local function set_choice_callback(_, indx)
 end
 
 local function select_choice()
-	assert(session.active_choice_nodes[vim.api.nvim_get_current_buf()], "No active choiceNode")
+	assert(
+		session.active_choice_nodes[vim.api.nvim_get_current_buf()],
+		"No active choiceNode"
+	)
 	vim.ui.select(
 		ls.get_current_choices(),
 		{ kind = "luasnip" },

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -394,7 +394,8 @@ local function safe_choice_action(snip, ...)
 	end
 end
 local function change_choice(val)
-	local active_choice = session.active_choice_nodes[vim.api.nvim_get_current_buf()]
+	local active_choice =
+		session.active_choice_nodes[vim.api.nvim_get_current_buf()]
 	assert(active_choice, "No active choiceNode")
 	local new_active = util.no_region_check_wrap(
 		safe_choice_action,
@@ -408,7 +409,8 @@ local function change_choice(val)
 end
 
 local function set_choice(choice_indx)
-	local active_choice = session.active_choice_nodes[vim.api.nvim_get_current_buf()]
+	local active_choice =
+		session.active_choice_nodes[vim.api.nvim_get_current_buf()]
 	assert(active_choice, "No active choiceNode")
 	local choice = active_choice.choices[choice_indx]
 	assert(choice, "Invalid Choice")
@@ -424,7 +426,8 @@ local function set_choice(choice_indx)
 end
 
 local function get_current_choices()
-	local active_choice = session.active_choice_nodes[vim.api.nvim_get_current_buf()]
+	local active_choice =
+		session.active_choice_nodes[vim.api.nvim_get_current_buf()]
 	assert(active_choice, "No active choiceNode")
 
 	local choice_lines = {}

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -141,7 +141,8 @@ function ChoiceNode:input_enter(_, dry_run)
 	self.mark:update_opts(self.ext_opts.active)
 	self:focus()
 
-	self.prev_choice_node = session.active_choice_nodes[vim.api.nvim_get_current_buf()]
+	self.prev_choice_node =
+		session.active_choice_nodes[vim.api.nvim_get_current_buf()]
 	session.active_choice_nodes[vim.api.nvim_get_current_buf()] = self
 	self.visited = true
 	self.active = true
@@ -159,7 +160,8 @@ function ChoiceNode:input_leave(_, dry_run)
 
 	self.mark:update_opts(self:get_passive_ext_opts())
 	self:update_dependents()
-	session.active_choice_nodes[vim.api.nvim_get_current_buf()] = self.prev_choice_node
+	session.active_choice_nodes[vim.api.nvim_get_current_buf()] =
+		self.prev_choice_node
 	self.active = false
 end
 
@@ -341,7 +343,8 @@ function ChoiceNode:exit()
 	end
 	self.mark:clear()
 	if self.active then
-		session.active_choice_nodes[vim.api.nvim_get_current_buf()] = self.prev_choice_node
+		session.active_choice_nodes[vim.api.nvim_get_current_buf()] =
+			self.prev_choice_node
 	end
 	self.active = false
 end

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -219,7 +219,11 @@ local function init_snippet_context(context, opts)
 		-- otherwise, it is nil or string, if it is string, that is the name,
 		-- otherwise use "pattern" if regTrig is set, and finally fall back to
 		-- "plain" if it is not.
-		local engine_name = util.ternary(context.trigEngine ~= nil, context.trigEngine, util.ternary(context.regTrig ~= nil, "pattern", "plain"))
+		local engine_name = util.ternary(
+			context.trigEngine ~= nil,
+			context.trigEngine,
+			util.ternary(context.regTrig ~= nil, "pattern", "plain")
+		)
 		engine = trig_engines[engine_name]
 	end
 	effective_context.trig_matcher = engine(effective_context.trigger)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -208,6 +208,8 @@ local function init_snippet_context(context, opts)
 	effective_context.regTrig =
 		util.ternary(context.regTrig ~= nil, context.regTrig, false)
 
+	effective_context.docTrig = context.docTrig
+
 	effective_context.condition = context.condition
 		or opts.condition
 		or true_func

--- a/lua/luasnip/nodes/util/trig_engines.lua
+++ b/lua/luasnip/nodes/util/trig_engines.lua
@@ -8,10 +8,8 @@ local jsregexp = require("luasnip.util.util").jsregexp
 
 local function match_plain(line_to_cursor, trigger)
 	if
-		line_to_cursor:sub(
-			#line_to_cursor - #trigger + 1,
-			#line_to_cursor
-		) == trigger
+		line_to_cursor:sub(#line_to_cursor - #trigger + 1, #line_to_cursor)
+		== trigger
 	then
 		-- no captures for plain trigger.
 		return trigger, {}
@@ -53,14 +51,16 @@ if jsregexp then
 			local match = trig_compiled(line_to_cursor)[1]
 			if match then
 				-- return full match, and all groups.
-				return line_to_cursor:sub(match.begin_ind-1), match.groups
+				return line_to_cursor:sub(match.begin_ind - 1), match.groups
 			else
 				return nil
 			end
 		end
 	end
 else
-	ecma_engine = function() return match_plain end
+	ecma_engine = function()
+		return match_plain
+	end
 end
 
 local function match_vim(line_to_cursor, trigger)
@@ -82,8 +82,14 @@ local function match_vim(line_to_cursor, trigger)
 end
 
 return {
-	plain = function() return match_plain end,
-	pattern = function() return match_pattern end,
+	plain = function()
+		return match_plain
+	end,
+	pattern = function()
+		return match_pattern
+	end,
 	ecma = ecma_engine,
-	vim = function() return match_vim end
+	vim = function()
+		return match_vim
+	end,
 }

--- a/lua/luasnip/nodes/util/trig_engines.lua
+++ b/lua/luasnip/nodes/util/trig_engines.lua
@@ -1,0 +1,89 @@
+local jsregexp = require("luasnip.util.util").jsregexp
+
+-- these functions get the line up to the cursor, the trigger, and then
+-- determine whether the trigger matches the current line.
+-- If the trigger does not match, the functions shall return nil, otherwise
+-- the matching substring and the list of captures (empty table if there aren't
+-- any).
+
+local function match_plain(line_to_cursor, trigger)
+	if
+		line_to_cursor:sub(
+			#line_to_cursor - #trigger + 1,
+			#line_to_cursor
+		) == trigger
+	then
+		-- no captures for plain trigger.
+		return trigger, {}
+	else
+		return nil
+	end
+end
+
+local function match_pattern(line_to_cursor, trigger)
+	-- look for match which ends at the cursor.
+	-- put all results into a list, there might be many capture-groups.
+	local find_res = { line_to_cursor:find(trigger .. "$") }
+
+	if #find_res > 0 then
+		-- if there is a match, determine matching string, and the
+		-- capture-groups.
+		local captures = {}
+		-- find_res[1] is `from`, find_res[2] is `to` (which we already know
+		-- anyway).
+		local from = find_res[1]
+		local match = line_to_cursor:sub(from, #line_to_cursor)
+		-- collect capture-groups.
+		for i = 3, #find_res do
+			captures[i - 2] = find_res[i]
+		end
+		return match, captures
+	else
+		return nil
+	end
+end
+
+local ecma_engine
+if jsregexp then
+	ecma_engine = function(trig)
+		local trig_compiled = jsregexp.compile(trig .. "$", "")
+
+		return function(line_to_cursor, _)
+			-- get first (very likely only, since we appended the "$") match.
+			local match = trig_compiled(line_to_cursor)[1]
+			if match then
+				-- return full match, and all groups.
+				return line_to_cursor:sub(match.begin_ind-1), match.groups
+			else
+				return nil
+			end
+		end
+	end
+else
+	ecma_engine = function() return match_plain end
+end
+
+local function match_vim(line_to_cursor, trigger)
+	local matchlist = vim.fn.matchlist(line_to_cursor, trigger .. "$")
+	if #matchlist > 0 then
+		local groups = {}
+		for i = 2, 10 do
+			-- PROBLEM: vim does not differentiate between an empty ("")
+			-- and a missing capture.
+			-- Since we need to differentiate between the two (Check `:h
+			-- luasnip-variables-lsp-variables`), we assume, here, that an
+			-- empty string is an unmatched group.
+			groups[i - 1] = matchlist[i] ~= "" and matchlist[i] or nil
+		end
+		return matchlist[1], groups
+	else
+		return nil
+	end
+end
+
+return {
+	plain = function() return match_plain end,
+	pattern = function() return match_pattern end,
+	ecma = ecma_engine,
+	vim = function() return match_vim end
+}

--- a/lua/luasnip/util/parser/ast_utils.lua
+++ b/lua/luasnip/util/parser/ast_utils.lua
@@ -3,12 +3,7 @@ local types = Ast.node_type
 local util = require("luasnip.util.util")
 local Str = require("luasnip.util.str")
 local log = require("luasnip.util.log").new("parser")
-
--- jsregexp: first try loading the version installed by luasnip, then global ones.
-local jsregexp_ok, jsregexp = pcall(require, "luasnip-jsregexp")
-if not jsregexp_ok then
-	jsregexp_ok, jsregexp = pcall(require, "jsregexp")
-end
+local jsregexp = require("luasnip.util.util").jsregexp
 
 local directed_graph = require("luasnip.util.directed_graph")
 
@@ -308,7 +303,7 @@ local function apply_transform_format(nodes, captures)
 end
 
 function M.apply_transform(transform)
-	if jsregexp_ok then
+	if jsregexp then
 		local reg_compiled =
 			jsregexp.compile(transform.pattern, transform.option)
 		-- can be passed to functionNode!

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -1,5 +1,11 @@
 local session = require("luasnip.session")
 
+-- jsregexp: first try loading the version installed by luasnip, then global ones.
+local jsregexp_ok, jsregexp = pcall(require, "luasnip-jsregexp")
+if not jsregexp_ok then
+	jsregexp_ok, jsregexp = pcall(require, "jsregexp")
+end
+
 local function get_cursor_0ind()
 	local c = vim.api.nvim_win_get_cursor(0)
 	c[1] = c[1] - 1
@@ -637,4 +643,5 @@ return {
 	indx_of = indx_of,
 	lazy_table = lazy_table,
 	ternary = ternary,
+	jsregexp = jsregexp_ok and jsregexp
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -643,5 +643,5 @@ return {
 	indx_of = indx_of,
 	lazy_table = lazy_table,
 	ternary = ternary,
-	jsregexp = jsregexp_ok and jsregexp
+	jsregexp = jsregexp_ok and jsregexp,
 }

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1142,20 +1142,28 @@ describe("snippets_basic", function()
 		ecma = [[(\d+)]],
 	}
 	for engine, trig in pairs(engine_data) do
-		it("trigEngine \"" .. engine .. "\" works", function()
-			exec_lua([[
+		it('trigEngine "' .. engine .. '" works', function()
+			exec_lua(
+				[[
 				trigEngine, trig, body, doctrig = ...
 				snip = s({trig = trig, docTrig = "3", trigEngine = trigEngine}, {t"c1: ", l(l.CAPTURE1)})
 				ls.add_snippets("all", {snip})
-			]], engine, trig)
+			]],
+				engine,
+				trig
+			)
 			feed("i3")
 			exec_lua("ls.expand()")
-			screen:expect{grid=[[
+			screen:expect({
+				grid = [[
 				c1: 3^                                             |
 				{0:~                                                 }|
-				{2:-- INSERT --}                                      |]]}
+				{2:-- INSERT --}                                      |]],
+			})
 			-- make sure docTrig works with all engines.
-			assert.is_true(exec_lua([[return snip:get_docstring()[1] == "c1: 3$0"]]))
+			assert.is_true(
+				exec_lua([[return snip:get_docstring()[1] == "c1: 3$0"]])
+			)
 		end)
 	end
 
@@ -1173,9 +1181,11 @@ describe("snippets_basic", function()
 		]])
 		feed("iasdf")
 		exec_lua([[ ls.expand() ]])
-		screen:expect{grid=[[
+		screen:expect({
+			grid = [[
 			aaaaa^                                             |
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]}
+			{2:-- INSERT --}                                      |]],
+		})
 	end)
 end)


### PR DESCRIPTION
This implements a new option, `trigMatcher`, which determines how the trigger is matched to the current line.

I've veered from calling it `trigType`, since it sounds like it would only accepts a string, whereas I'd like to make it possible to completely customize the trigger-matching by passing a function.
So, currently, `trigMatcher` accepts either a function (then uses that), a string (any from "plain", "pattern", "vim", "ecma" for plain strings, lua-patterns, vim-regex and ecma-regex respectively (the last two are not yet implemented)). If `trigMatcher` is not set at all, we look if `regTrig` is set and use "pattern" if it is, and if that is not set as well, we fall back to "plain".
I think this will also deprecate `regTrig` since that name was misleading from the start (but a very soft deprecation, I don't think we will actually remove it)

I'm not completely convinced by the name `trigMatcher`, if somebody has a different idea, mention it :D