### PR TITLE
Merge multi-snippet common field, fix #921

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 June 14
+*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 June 15
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/nodes/multiSnippet.lua
+++ b/lua/luasnip/nodes/multiSnippet.lua
@@ -96,8 +96,8 @@ local function extend_multisnippet_contexts(passed_arg, extend_arg)
 	-- extend ("keep") valid keyword-arguments.
 	passed_arg.common = vim.tbl_deep_extend(
 		"keep",
-		passed_arg.common or {},
-		extend_arg.common or {}
+		node_util.wrap_context(passed_arg.common) or {},
+		node_util.wrap_context(extend_arg.common) or {}
 	)
 
 	return passed_arg

--- a/lua/luasnip/nodes/multiSnippet.lua
+++ b/lua/luasnip/nodes/multiSnippet.lua
@@ -94,7 +94,11 @@ local function extend_multisnippet_contexts(passed_arg, extend_arg)
 	vim.list_extend(passed_arg, extend_arg)
 
 	-- extend ("keep") valid keyword-arguments.
-	passed_arg.common = passed_arg.common or extend_arg.common
+	passed_arg.common = vim.tbl_deep_extend(
+		"keep",
+		passed_arg.common or {},
+		extend_arg.common or {}
+	)
 
 	return passed_arg
 end


### PR DESCRIPTION
Should fix #921 
 

Currently the `common` field is replaced as a whole when the passed arg has this field set instead of merging the passed arg and the extend arg, which is not expected.

To clarify, consider the following cases:

I create some luasnip conds and define a new multi-snippet that only expand if ts is not active or ts and active and the cursor is not in a comment or string:

```lua
local msc = ls.extend_decorator.apply(ms, {
  common = {
    condition = -conds.ts_active
      + -conds.in_tsnode('comment') * -conds.in_tsnode('string'),
    show_condition = -conds.ts_active
      + -conds.in_tsnode('comment') * -conds.in_tsnode('string'),
  },
})
```

Then I want to create a multi-snippet with regex trigger and only expand when the cursor is not in a comment or string:

```lua
msc(
  {
    common = { regTrig = true },
    { trig = '(%S?)(%s*)%.%.%s*ck' },
    { trig = '(%S?)(%s*)%.%.%s*check' },
  },
  fmta('<spc>.. ", <v>: " .. vim.inspect(<v>)', {
    spc = f(function(_, snip, _)
      return snip.captures[1] == '' and snip.captures[2]
        or snip.captures[1] .. ' '
    end, {}, {}),
    v = i(1),
  }, { repeat_duplicates = true })
)
```

the original condition field is dropped because I provide the `common` field in the new snippet, making the original `common` table completely replaced by the new one i.e. `{ regTrig = true, condition = nil, show_condition = nil, ... }`

I would suggest using `vim.tbl_deep_extend` to merge the `common` table, this fixes the issue (in function `extend_multisnippet_contexts`:


```lua
	-- extend ("keep") valid keyword-arguments.
	passed_arg.common = vim.tbl_deep_extend(
		"keep",
		passed_arg.common or {},
		extend_arg.common or {}
	)
```