### PR TITLE
refactor: don't load modules in lazy_load until they are needed

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 June 16
+*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 June 18
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -2,14 +2,15 @@ local ls = require("luasnip")
 local cache = require("luasnip.loaders._caches").snipmate
 local loader_util = require("luasnip.loaders.util")
 local Path = require("luasnip.util.path")
-local sp = require("luasnip.nodes.snippetProxy")
-local snipmate_parse_fn = require("luasnip.util.parser").parse_snipmate
-local source = require("luasnip.session.snippet_collection.source")
-local session = require("luasnip.session")
 
 local log = require("luasnip.util.log").new("snipmate-loader")
 
 local function parse_snipmate(buffer, filename)
+	local sp = require("luasnip.nodes.snippetProxy")
+	local snipmate_parse_fn = require("luasnip.util.parser").parse_snipmate
+	local source = require("luasnip.session.snippet_collection.source")
+	local session = require("luasnip.session")
+
 	-- could also be separate variables, but easier to access this way.
 	local snippets = {
 		snippet = {},

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -4,12 +4,7 @@ local standalone_cache = require("luasnip.loaders._caches").vscode_standalone
 local util = require("luasnip.util.util")
 local loader_util = require("luasnip.loaders.util")
 local Path = require("luasnip.util.path")
-local sp = require("luasnip.nodes.snippetProxy")
 local log = require("luasnip.util.log").new("vscode-loader")
-local session = require("luasnip.session")
-local source = require("luasnip.session.snippet_collection.source")
-local multisnippet = require("luasnip.nodes.multiSnippet")
-local duplicate = require("luasnip.nodes.duplicate")
 
 local json_decoders = {
 	json = util.json_decode,
@@ -45,6 +40,11 @@ end
 
 -- return all snippets in `file`.
 local function get_file_snippets(file)
+	local sp = require("luasnip.nodes.snippetProxy")
+	local session = require("luasnip.session")
+	local source = require("luasnip.session.snippet_collection.source")
+	local multisnippet = require("luasnip.nodes.multiSnippet")
+
 	-- since most snippets we load don't have a scope-field, we just insert this here by default.
 	local snippets = {}
 
@@ -120,6 +120,8 @@ end
 -- `refresh_notify`: refresh snippets for filetype immediately, default false.
 -- `force_reload`: don't use cache when reloading, default false
 local function load_snippet_file(file, filetype, add_opts, opts)
+	local duplicate = require("luasnip.nodes.duplicate")
+
 	opts = opts or {}
 	local refresh_notify =
 		util.ternary(opts.refresh_notify ~= nil, opts.refresh_notify, false)


### PR DESCRIPTION
I think it's useful when running neovim without filename.

Before:

```
078.070  000.118  000.118: require('luasnip.session')
078.078  000.519  000.401: require('luasnip.util.util')
078.454  000.101  000.101: require('luasnip.session.snippet_collection.source')
078.460  000.380  000.279: require('luasnip.session.snippet_collection')
079.290  000.627  000.627: require('luasnip.util._builtin_vars')
079.420  000.959  000.332: require('luasnip.util.environ')
079.560  000.138  000.138: require('luasnip.util.extend_decorator')
079.872  000.109  000.109: require('luasnip.loaders._caches')
080.325  000.223  000.223: require('luasnip.util.path')
080.331  000.457  000.234: require('luasnip.loaders.util')
080.355  000.792  000.226: require('luasnip.loaders')
080.592  000.232  000.232: require('luasnip.util.log')
081.075  000.108  000.108: require('luasnip.util.types')
081.288  000.210  000.210: require('luasnip.util.ext_opts')
081.436  000.145  000.145: require('luasnip.extras.filetype_functions')
081.687  001.074  000.611: require('luasnip.config')
081.691  004.601  000.508: require('luasnip')
082.176  000.483  000.483: require('snippets.jinja_utils')
082.386  000.203  000.203: require('treesitter.utils')
086.181  000.095  000.095: require('luasnip.nodes.key_indexer')
086.188  000.350  000.255: require('luasnip.nodes.util')
086.288  000.098  000.098: require('luasnip.util.events')
086.301  000.842  000.395: require('luasnip.nodes.node')
086.670  000.368  000.368: require('luasnip.nodes.insertNode')
086.833  000.160  000.160: require('luasnip.nodes.textNode')
087.046  000.210  000.210: require('luasnip.util.mark')
087.200  000.151  000.151: require('luasnip.util.pattern_tokenizer')
087.343  000.140  000.140: require('luasnip.util.dict')
087.394  002.670  000.798: require('luasnip.nodes.snippet')
088.413  000.387  000.387: require('luasnip.util.parser.neovim_ast')
088.733  000.317  000.317: require('luasnip.util.str')
089.298  000.158  000.158: require('jsregexp.core')
089.309  000.460  000.302: require('jsregexp')
089.613  000.302  000.302: require('luasnip.util.directed_graph')
089.636  001.953  000.486: require('luasnip.util.parser.ast_utils')
090.278  000.641  000.641: require('luasnip.nodes.functionNode')
091.010  000.729  000.729: require('luasnip.nodes.choiceNode')
091.480  000.467  000.467: require('luasnip.nodes.dynamicNode')
091.614  000.131  000.131: require('luasnip.util.functions')
091.621  004.226  000.305: require('luasnip.util.parser.ast_parser')
091.955  000.333  000.333: require('luasnip.util.parser.neovim_parser')
091.962  007.445  000.216: require('luasnip.util.parser')
091.966  007.656  000.211: require('luasnip.nodes.snippetProxy')
092.202  000.234  000.234: require('luasnip.nodes.multiSnippet')
092.321  000.116  000.116: require('luasnip.nodes.duplicate')
092.647  000.323  000.323: require('luasnip.util.jsonc')
092.653  008.754  000.426: require('luasnip.loaders.from_vscode')
093.498  000.245  000.245: require('luasnip.loaders.from_snipmate')
094.310  000.205  000.205: require('luasnip.loaders.from_lua')
```

After:

```
079.503  000.100  000.100: require('luasnip.session')
079.519  000.549  000.449: require('luasnip.util.util')
080.015  000.168  000.168: require('luasnip.session.snippet_collection.source')
080.032  000.511  000.343: require('luasnip.session.snippet_collection')
081.174  000.927  000.927: require('luasnip.util._builtin_vars')
081.241  001.208  000.281: require('luasnip.util.environ')
081.392  000.148  000.148: require('luasnip.util.extend_decorator')
081.762  000.146  000.146: require('luasnip.loaders._caches')
082.237  000.225  000.225: require('luasnip.util.path')
082.242  000.477  000.252: require('luasnip.loaders.util')
082.278  000.884  000.261: require('luasnip.loaders')
082.552  000.267  000.267: require('luasnip.util.log')
083.148  000.158  000.158: require('luasnip.util.types')
083.339  000.188  000.188: require('luasnip.util.ext_opts')
083.491  000.149  000.149: require('luasnip.extras.filetype_functions')
083.893  001.314  000.819: require('luasnip.config')
083.897  005.456  000.573: require('luasnip')
084.378  000.479  000.479: require('snippets.jinja_utils')
084.594  000.208  000.208: require('treesitter.utils')
086.583  000.532  000.532: require('luasnip.util.jsonc')
086.593  000.961  000.428: require('luasnip.loaders.from_vscode')
087.463  000.341  000.341: require('luasnip.loaders.from_snipmate')
088.476  000.280  000.280: require('luasnip.loaders.from_lua')
```