### PR TITLE
fix: remove debug print

### DIFF
--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -379,7 +379,6 @@ end
 -- ... is passed to pcall as-is.
 local function safe_choice_action(snip, ...)
 	local ok, res = pcall(...)
-	print(ok, res)
 	if ok then
 		return res
 	else


### PR DESCRIPTION
I guess it shouldn't be there. It prints something like

```
true table: 0x7fffea36bbc0
true table: 0x7fffea36bab0
true table: 0x7fffea36bbc0
true table: 0x7fffea36bab0
```