### PR TITLE
fix: catch undocumented edge case in scandir()

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 July 18
+*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 July 26
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/path.lua
+++ b/lua/luasnip/util/path.lua
@@ -77,6 +77,14 @@ function Path.scandir(root)
 		while name do
 			name, type = uv.fs_scandir_next(fs)
 			local path = Path.join(root, name)
+			-- On networked filesystems, it can happen that we get
+			-- a name, but no type. In this case, we must query the
+			-- type manually via fs_stat(). See issue:
+			-- https://github.com/luvit/luv/issues/660
+			if name and not type then
+				local stat = uv.fs_stat(path)
+				type = stat and stat.type
+			end
 			if type == "file" then
 				table.insert(files, path)
 			elseif type == "directory" then


### PR DESCRIPTION
While [libuv/vim.loop docs](https://github.com/luvit/luv/blob/master/docs.md#uvfs_scandir_nextfs) say that `fs_scandir_next()` either returns `nil` or `string, string` or fails, there is an edge case on networked filesystems. In those cases, `uv__fs_scandir()` returns the type `UV_DIRENT_UNKNOWN` and `luv.fs_scandir_next()` [converts][1] this into returning a single string.

This means in those cases, `name` is a string and `type` is `nil`. See the [upstream bug report][2].

The situation can be remedied by explicitly calling `fs_stat()` on those files. This always fetches the correct type, as far as I can see.

PS: Thanks for this awesome plugin! :slightly_smiling_face: 

[1]: https://github.com/luvit/luv/blob/master/src/fs.c#L116
[2]: https://github.com/luvit/luv/issues/660