### PR TITLE
feat: Allow `desc` to set snippet description

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -176,7 +176,7 @@ s({trig="trigger"}, {})
     By default, "matches" means the text in front of the cursor matches the
     trigger exactly, this behaviour can be modified through `trigEngine`
   - `name`: string, can be used by e.g. `nvim-compe` to identify the snippet.
-  - `dscr`: string, description of the snippet, \n-separated or table
+  - `desc` (or `dscr`): string, description of the snippet, \n-separated or table
     for multiple lines.
   - `wordTrig`: boolean, if true, the snippet is only expanded if the word
     (`[%w_]+`) before the cursor matches the trigger entirely.
@@ -254,7 +254,7 @@ s({trig="trigger"}, {})
     read it for more examples.
 
   - `docstring`: string, textual representation of the snippet, specified like
-    `dscr`. Overrides docstrings loaded from json.
+    `desc`. Overrides docstrings loaded from json.
   - `docTrig`: string, used as `line_to_cursor` during docstring-generation.
     This might be relevant if the snippet relies on specific values in the
     capture-groups (for example, numbers, which won't work with the default

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -251,7 +251,7 @@ The most direct way to define snippets is `s`:
         matches the trigger exactly, this behaviour can be modified through
         `trigEngine`
     - `name`: string, can be used by e.g. `nvim-compe` to identify the snippet.
-    - `dscr`: string, description of the snippet, -separated or table for multiple
+    - `desc` (or `dscr`): string, description of the snippet, -separated or table for multiple
         lines.
     - `wordTrig`: boolean, if true, the snippet is only expanded if the word
         (`[%w_]+`) before the cursor matches the trigger entirely. True by default.
@@ -322,7 +322,7 @@ The most direct way to define snippets is `s`:
         <https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/nodes/util/trig_engines.lua>,
         read it for more examples.
     - `docstring`: string, textual representation of the snippet, specified like
-        `dscr`. Overrides docstrings loaded from json.
+        `desc`. Overrides docstrings loaded from json.
     - `docTrig`: string, used as `line_to_cursor` during docstring-generation. This
         might be relevant if the snippet relies on specific values in the
         capture-groups (for example, numbers, which won’t work with the default

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -251,8 +251,8 @@ The most direct way to define snippets is `s`:
         matches the trigger exactly, this behaviour can be modified through
         `trigEngine`
     - `name`: string, can be used by e.g. `nvim-compe` to identify the snippet.
-    - `desc` (or `dscr`): string, description of the snippet, -separated or table for multiple
-        lines.
+    - `desc` (or `dscr`): string, description of the snippet, -separated or table for
+        multiple lines.
     - `wordTrig`: boolean, if true, the snippet is only expanded if the word
         (`[%w_]+`) before the cursor matches the trigger entirely. True by default.
     - `regTrig`: boolean, whether the trigger should be interpreted as a lua pattern.

--- a/lua/luasnip/extras/snippet_list.lua
+++ b/lua/luasnip/extras/snippet_list.lua
@@ -4,7 +4,7 @@ local function snip_info(snippet)
 	return {
 		name = snippet.name,
 		trigger = snippet.trigger,
-		description = snippet.dscr,
+		description = snippet.description,
 		wordTrig = snippet.wordTrig and true or false,
 		regTrig = snippet.regTrig and true or false,
 		docstring = snippet:get_docstring(),

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -56,7 +56,7 @@ local function default_snip_info(snip)
 	return {
 		name = snip.name,
 		trigger = snip.trigger,
-		description = snip.dscr,
+		description = snip.description,
 		wordTrig = snip.wordTrig and true or false,
 		regTrig = snip.regTrig and true or false,
 	}

--- a/lua/luasnip/loaders/from_snipmate.lua
+++ b/lua/luasnip/loaders/from_snipmate.lua
@@ -53,7 +53,7 @@ local function parse_snipmate(buffer, filename)
 		local snip = sp(
 			{
 				trig = prefix,
-				dscr = description,
+				desc = description,
 				wordTrig = true,
 				priority = snipmate_opts.priority,
 			},

--- a/lua/luasnip/loaders/from_vscode.lua
+++ b/lua/luasnip/loaders/from_vscode.lua
@@ -66,7 +66,7 @@ local function get_file_snippets(file)
 		-- context common to all snippets generated here.
 		local common_context = {
 			name = name,
-			dscr = parts.description or name,
+			desc = parts.description or name,
 			wordTrig = ls_conf.wordTrig,
 			priority = ls_conf.priority,
 			snippetType = ls_conf.autotrigger and "autosnippet" or "snippet",

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -194,8 +194,11 @@ local function init_snippet_context(context, opts)
 
 	effective_context.name = context.name or context.trig
 
-	-- context.dscr could be nil, string or table.
-	effective_context.dscr = util.to_line_table(context.dscr or context.trig)
+	-- context.{desc,dscr} could be nil, string or table.
+	-- (defaults to trigger)
+	effective_context.description = util.to_line_table(context.desc or context.dscr or context.trig)
+	-- (keep dscr to avoid breaking downstream usages)
+	effective_context.dscr = effective_context.description
 
 	-- might be nil, but whitelisted in snippetProxy.
 	effective_context.priority = context.priority

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -196,7 +196,8 @@ local function init_snippet_context(context, opts)
 
 	-- context.{desc,dscr} could be nil, string or table.
 	-- (defaults to trigger)
-	effective_context.description = util.to_line_table(context.desc or context.dscr or context.trig)
+	effective_context.description =
+		util.to_line_table(context.desc or context.dscr or context.trig)
 	-- (keep dscr to avoid breaking downstream usages)
 	effective_context.dscr = effective_context.description
 

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -747,7 +747,11 @@ describe("snippets_basic", function()
 					"description",
 					[[{"thedescription"}]],
 				},
-				{ [[ s({trig="a"}, { t"justsometext" }) ]], "description", [[{"a"}]] },
+				{
+					[[ s({trig="a"}, { t"justsometext" }) ]],
+					"description",
+					[[{"a"}]],
+				},
 				{
 					[[ s({trig="a", dscr = "thedescription"}, { t"justsometext" }) ]],
 					"dscr",

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -744,10 +744,15 @@ describe("snippets_basic", function()
 
 				{
 					[[ s({trig="a", dscr = "thedescription"}, { t"justsometext" }) ]],
+					"description",
+					[[{"thedescription"}]],
+				},
+				{ [[ s({trig="a"}, { t"justsometext" }) ]], "description", [[{"a"}]] },
+				{
+					[[ s({trig="a", dscr = "thedescription"}, { t"justsometext" }) ]],
 					"dscr",
 					[[{"thedescription"}]],
 				},
-				{ [[ s({trig="a"}, { t"justsometext" }) ]], "dscr", [[{"a"}]] },
 
 				{
 					[[ s({trig="a", docstring = "thedocstring"}, { t"justsometext" }) ]],

--- a/tests/unit/snippetProxy_spec.lua
+++ b/tests/unit/snippetProxy_spec.lua
@@ -29,6 +29,7 @@ describe("snippetProxy", function()
 		".wordTrig",
 		".regTrig",
 		".dscr",
+		".description",
 		".filetype",
 		".name",
 		".callbacks",


### PR DESCRIPTION
Setting the description with `dscr` is still supported.
Access to the description is done through `description` or `dscr`.

Closes #997 
