### PR TITLE
Add nil for type opt for parse_snippet

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*          For NVIM v0.8.0          Last change: 2023 September 24
+*luasnip.txt*          For NVIM v0.8.0          Last change: 2023 September 25
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/parser/init.lua
+++ b/lua/luasnip/util/parser/init.lua
@@ -16,7 +16,7 @@ local M = {}
 --- - number: Returns a snippetNode, `context` is its' jump-position.
 --- - nil: Returns a flat list of luasnip-nodes, to be used however.
 ---@param body string: the representation of the snippet.
----@param opts table: optional parameters. Valid keys:
+---@param opts table|nil: optional parameters. Valid keys:
 --- - `trim_empty`: boolean, remove empty lines from the snippet.
 --- - `dedent`: boolean, remove common indent from the snippet's lines.
 --- - `variables`: map[string-> (fn()->string)], variables to be used only in this


### PR DESCRIPTION
This commit fixes the typing issues that lua lsp would complain about the argument being required.

<img width="1301" alt="image" src="https://github.com/L3MON4D3/LuaSnip/assets/6276582/0cf79a7b-47a5-45fc-82d0-335e75a16996">
