### PR TITLE
feat(snip_expand): fix improper call to `nvim_buf_set_text`

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0            Last change: 2023 July 18
+*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 October 04
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -214,7 +214,7 @@ API                                                         *luasnip-node-api*
 - `get_buf_position(opts) -> {from_position, to_position}`:
     Determines the range of the buffer occupied by this node. `from`- and
     `to_position` are `row,column`-tuples, `0,0`-indexed (first line is 0, first
-    column is 0) and end-inclusive (see `:h api-indexing`, this is extmarks
+    column is 0) and end-inclusive (see |api-indexing|, this is extmarks
     indexing).
     - `opts`: `table|nil`, options, valid keys are:
         - `raw`: `bool`, default `true`. This can be used to switch between

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -230,12 +230,18 @@ local function snip_expand(snippet, opts)
 	-- position, which is just as bad) if text before the cursor, on the same
 	-- line is cleared.
 	if opts.clear_region then
+		-- Zer based indexing; this prevents negative values
+		local start_row = math.max(0, opts.clear_region.from[1])
+		local start_col = math.max(0, opts.clear_region.from[2])
+		local end_row   = math.max(0, opts.clear_region.to[1])
+		local end_col   = math.max(0, opts.clear_region.to[2]  )
+
 		vim.api.nvim_buf_set_text(
 			0,
-			opts.clear_region.from[1],
-			opts.clear_region.from[2],
-			opts.clear_region.to[1],
-			opts.clear_region.to[2],
+			start_row,
+			start_col,
+			end_row,
+			end_col,
 			{ "" }
 		)
 	end

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -233,8 +233,8 @@ local function snip_expand(snippet, opts)
 		-- Zer based indexing; this prevents negative values
 		local start_row = math.max(0, opts.clear_region.from[1])
 		local start_col = math.max(0, opts.clear_region.from[2])
-		local end_row   = math.max(0, opts.clear_region.to[1])
-		local end_col   = math.max(0, opts.clear_region.to[2]  )
+		local end_row = math.max(0, opts.clear_region.to[1])
+		local end_col = math.max(0, opts.clear_region.to[2])
 
 		vim.api.nvim_buf_set_text(
 			0,


### PR DESCRIPTION
https://github.com/L3MON4D3/LuaSnip/blob/ad089ed4580a65e0e4f89abb2876d7c132366713/lua/luasnip/init.lua#L326-L335

https://github.com/L3MON4D3/LuaSnip/blob/ad089ed4580a65e0e4f89abb2876d7c132366713/lua/luasnip/init.lua#L354-L361

**This PR ensures that text is never put below line 0.** 

`snip_expand()`  calls `nvim_buf_set_text()` which has zero-based indexing. The above chunks of code potentially introduce negative line rows. This PR should fix this.

This PR intended to save my patch. The issue was orignally discovered when I was using the [benfowler/telescope-luasnip.nvim](https://github.com/benfowler/telescope-luasnip.nvim) plugin.

See `h nvim_buf_set_text` 