### PR TITLE
Use event.buf directly to get bufnr

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2023 October 18
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 November 04
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/plugin/luasnip.lua
+++ b/plugin/luasnip.lua
@@ -83,26 +83,20 @@ require("luasnip.config")._setup()
 -- (BufWinEnter -> lazy_load() wouldn't load any files without these).
 vim.api.nvim_create_augroup("_luasnip_lazy_load", {})
 vim.api.nvim_create_autocmd({ "BufWinEnter", "FileType" }, {
-	callback = function()
-		require("luasnip.loaders.from_lua")._load_lazy_loaded(
-			tonumber(vim.fn.expand("<abuf>"))
-		)
+	callback = function(event)
+		require("luasnip.loaders.from_lua")._load_lazy_loaded(event.buf)
 	end,
 	group = "_luasnip_lazy_load",
 })
 vim.api.nvim_create_autocmd({ "BufWinEnter", "FileType" }, {
-	callback = function()
-		require("luasnip.loaders.from_snipmate")._load_lazy_loaded(
-			tonumber(vim.fn.expand("<abuf>"))
-		)
+	callback = function(event)
+		require("luasnip.loaders.from_snipmate")._load_lazy_loaded(event.buf)
 	end,
 	group = "_luasnip_lazy_load",
 })
 vim.api.nvim_create_autocmd({ "BufWinEnter", "FileType" }, {
-	callback = function()
-		require("luasnip.loaders.from_vscode")._load_lazy_loaded(
-			tonumber(vim.fn.expand("<abuf>"))
-		)
+	callback = function(event)
+		require("luasnip.loaders.from_vscode")._load_lazy_loaded(event.buf)
 	end,
 	group = "_luasnip_lazy_load",
 })


### PR DESCRIPTION
Due to the neovim's issue (https://github.com/neovim/neovim/issues/16416), using `vim.fn.expand` sometimes throws Keyboard interrupt error when pressing Ctrl-C (a common alternative to Esc).

This works around the above issue by simply getting the buffer number from event argument.