### PR TITLE
Use event.buf/event.file directly instead of vim.fn.expand

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 November 13
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 November 20
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -264,10 +264,10 @@ c = {
 			end)
 		end
 		-- Remove buffers' nodes on deletion+wipeout.
-		ls_autocmd({ "BufDelete", "BufWipeout" }, function()
+		ls_autocmd({ "BufDelete", "BufWipeout" }, function(event)
 			local current_nodes = require("luasnip").session.current_nodes
 			if current_nodes then
-				current_nodes[tonumber(vim.fn.expand("<abuf>"))] = nil
+				current_nodes[event.buf] = nil
 			end
 		end)
 		if session.config.enable_autosnippets then

--- a/lua/luasnip/loaders/init.lua
+++ b/lua/luasnip/loaders/init.lua
@@ -146,8 +146,8 @@ end
 
 vim.api.nvim_create_autocmd("BufWritePost", {
 	group = vim.api.nvim_create_augroup("luasnip_watch_reload", {}),
-	callback = function()
-		require("luasnip.loaders").reload_file(vim.fn.expand("<afile>"))
+	callback = function(event)
+		require("luasnip.loaders").reload_file(event.file)
 	end,
 })
 function M.reload_file(filename)


### PR DESCRIPTION
We don't need to use `vim.fn.expand(...)` to get the buffer or file for the autocmd callbacks. Instead, use `event.buf` or `event.file` directly from the callback function argument.

See also #1047.