### PR TITLE
Document ft_func with an example

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1701,6 +1701,7 @@ Contains some utility functions that can be passed to the `ft_func` or
 
   ```lua
   ls.setup({
+  	ft_func = require("luasnip.extras.filetype_functions").from_pos_or_filetype,
   	load_ft_func =
   		-- Also load both lua and json when a markdown-file is opened,
   		-- javascript for html.

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1611,6 +1611,7 @@ Contains some utility functions that can be passed to the `ft_func` or
     passed to `load_ft_func` and takes care of extending the filetypes properly.
     >lua
         ls.setup({
+          ft_func = require("luasnip.extras.filetype_functions").from_pos_or_filetype,
           load_ft_func =
               -- Also load both lua and json when a markdown-file is opened,
               -- javascript for html.


### PR DESCRIPTION
`ft_func` and `load_ft_func` need to be configured together. This commit updates the example to include both settings at once.

I know it's a small change, but it took me quite some time to work this out. So I hope the example configuration will be helpful to others and will save them time.