### PR TITLE
Temporary fix for snippets and undo

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 December 05
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 December 11
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -292,17 +292,17 @@ local function binarysearch_pos(
 		return nil, 1
 	end
 	while true do
-        -- Adding +1 so we avoid another indexing error
-        -- that occurs in init.lua at line 293
-        -- buf_snippet_roots[buf_snippet_roots[1] == snip and 2 or 1]:remove_from_jumplist()
-        local mid = left + math.floor((right - left) / 2) + 1
-        -- If the node[mid] is null it should return
-        -- otherwise some indexing error appears when doing .mark,
-        -- resulting in total crashing of luasnip
-        if nodes[mid] == nil then
-            return nil, 1
-        end
-        local mid_mark = nodes[mid].mark
+		-- Adding +1 so we avoid another indexing error
+		-- that occurs in init.lua at line 293
+		-- buf_snippet_roots[buf_snippet_roots[1] == snip and 2 or 1]:remove_from_jumplist()
+		local mid = left + math.floor((right - left) / 2) + 1
+		-- If the node[mid] is null it should return
+		-- otherwise some indexing error appears when doing .mark,
+		-- resulting in total crashing of luasnip
+		if nodes[mid] == nil then
+			return nil, 1
+		end
+		local mid_mark = nodes[mid].mark
 		local ok, mid_from, mid_to = pcall(mid_mark.pos_begin_end_raw, mid_mark)
 
 		if not ok then

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -292,8 +292,17 @@ local function binarysearch_pos(
 		return nil, 1
 	end
 	while true do
-		local mid = left + math.floor((right - left) / 2)
-		local mid_mark = nodes[mid].mark
+        -- Adding +1 so we avoid another indexing error
+        -- that occurs in init.lua at line 293
+        -- buf_snippet_roots[buf_snippet_roots[1] == snip and 2 or 1]:remove_from_jumplist()
+        local mid = left + math.floor((right - left) / 2) + 1
+        -- If the node[mid] is null it should return
+        -- otherwise some indexing error appears when doing .mark,
+        -- resulting in total crashing of luasnip
+        if nodes[mid] == nil then
+            return nil, 1
+        end
+        local mid_mark = nodes[mid].mark
 		local ok, mid_from, mid_to = pcall(mid_mark.pos_begin_end_raw, mid_mark)
 
 		if not ok then


### PR DESCRIPTION
A bug was detected on this environment

- NVIM v0.9.4
- typescript-language-server tsserver version 4.2.0 (installed with Mason)
- These plugins to get snippets (installed with packer):
```
 use {
        "hrsh7th/nvim-cmp",
        "hrsh7th/cmp-nvim-lsp",
        "L3MON4D3/LuaSnip",
        "saadparwaiz1/cmp_luasnip",
        "rafamadriz/friendly-snippets"
    }   
```

To reproduce
1. Open a Javascript file
2. Write a for using a snippet, but don't fill anything.
3. Press `Esc` then undo the snippet with `u`
4. Recreate a for using the snippet

You should see an indexin error as follows:
![image](https://github.com/L3MON4D3/LuaSnip/assets/85132188/e98c2411-7b39-4e8f-90ff-5b4f3089bf33)


This PR proposes a temporary fix. It may not be the best solution but it should work if I am not mistaken...
Any improvement ideas and critiques are very appreciated