### PR TITLE
feat(builtin): support vscode snippet variable CURRENT_TIMEZONE_OFFSET

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 December 14
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2023 December 17
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/_builtin_vars.lua
+++ b/lua/luasnip/util/_builtin_vars.lua
@@ -1,5 +1,6 @@
 local util = require("luasnip.util.util")
 local select_util = require("luasnip.util.select")
+local time_util = require("luasnip.util.time")
 local lazy_vars = {}
 
 -- Variables defined in https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables
@@ -108,6 +109,12 @@ end
 
 function lazy_vars.CURRENT_SECONDS_UNIX()
 	return tostring(os.time())
+end
+
+function lazy_vars.CURRENT_TIMEZONE_OFFSET()
+	return time_util
+			.get_timezone_offset(os.time())
+		:gsub("([+-])(%d%d)(%d%d)$", "%1%2:%3")
 end
 
 -- For inserting random values

--- a/lua/luasnip/util/_builtin_vars.lua
+++ b/lua/luasnip/util/_builtin_vars.lua
@@ -113,7 +113,7 @@ end
 
 function lazy_vars.CURRENT_TIMEZONE_OFFSET()
 	return time_util
-			.get_timezone_offset(os.time())
+		.get_timezone_offset(os.time())
 		:gsub("([+-])(%d%d)(%d%d)$", "%1%2:%3")
 end
 

--- a/lua/luasnip/util/time.lua
+++ b/lua/luasnip/util/time.lua
@@ -1,0 +1,13 @@
+-- http://lua-users.org/wiki/TimeZone
+local function get_timezone_offset(ts)
+	local utcdate = os.date("!*t", ts)
+	local localdate = os.date("*t", ts)
+	localdate.isdst = false -- this is the trick
+	local diff = os.difftime(os.time(localdate), os.time(utcdate))
+	local h, m = math.modf(diff / 3600)
+	return string.format("%+.4d", 100 * h + 60 * m)
+end
+
+return {
+	get_timezone_offset = get_timezone_offset,
+}


### PR DESCRIPTION
`CURRENT_TIMEZONE_OFFSET` was added since [April 2023 (version 1.78)](https://code.visualstudio.com/updates/v1_78#_new-snippet-variable-for-timezone-offset) in vscode.

Also [Snippets in Visual Studio Code](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax) the doc here mentions:

> CURRENT_TIMEZONE_OFFSET The current UTC time zone offset as +HH:MM or -HH:MM (example -07:00).

This PR is to support the variable in LuaSnip. 