### PR TITLE
Allow callbacks via node-options.

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -172,6 +172,11 @@ Common opts:
   point in time, the snippet may contain each key only once. This means it is
   fine to return a keyed node from a `dynamicNode`, because even if it will be
   generated multiple times, those will not be valid at the same time.
+* `node_callbacks`: Define event-callbacks for this node (see
+  [events](#events)).  
+  Accepts a table that maps an event, e.g. `events.enter` to the callback
+  (essentially the same as `callbacks` passed to `s`, only that there is no
+  first mapping from jump-index to the table of callbacks).
 
 ## Api
 
@@ -3350,14 +3355,15 @@ The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 # Events
 
 Events can be used to react to some action inside snippets. These callbacks can
-be defined per snippet (`callbacks`-key in snippet constructor) or globally
-(autocommand).
+be defined per snippet (`callbacks`-key in snippet constructor), per-node by
+passing them as `node_callbacks` in `node_opts`, or globally (autocommand).
 
 `callbacks`: `fn(node[, event_args]) -> event_res`  
-All callbacks get the `node` associated with the event and event-specific
+All callbacks receive the `node` associated with the event and event-specific
 optional arguments, `event_args`.
 `event_res` is only used in one event, `pre_expand`, where some properties of
-the snippet can be changed.
+the snippet can be changed. If multiple callbacks return `event_res`, we only
+guarantee that one of them will be effective, not all of them.
 
 `autocommand`:
 Luasnip uses `User`-events. Autocommands for these can be registered using

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -247,6 +247,11 @@ Common opts:
     point in time, the snippet may contain each key only once. This means it is
     fine to return a keyed node from a `dynamicNode`, because even if it will be
     generated multiple times, those will not be valid at the same time.
+- `node_callbacks`: Define event-callbacks for this node (see
+    |luasnip-events|).
+    Accepts a table that maps an event, e.g. `events.enter` to the callback
+    (essentially the same as `callbacks` passed to `s`, only that there is no
+    first mapping from jump-index to the table of callbacks).
 
 
 API                                                         *luasnip-node-api*
@@ -3206,13 +3211,15 @@ The cache is located at `stdpath("cache")/luasnip/docstrings.json` (probably
 25. Events                                                    *luasnip-events*
 
 Events can be used to react to some action inside snippets. These callbacks can
-be defined per snippet (`callbacks`-key in snippet constructor) or globally
-(autocommand).
+be defined per snippet (`callbacks`-key in snippet constructor), per-node by
+passing them as `node_callbacks` in `node_opts`, or globally (autocommand).
 
-`callbacks`: `fn(node[, event_args]) -> event_res` All callbacks get the `node`
-associated with the event and event-specific optional arguments, `event_args`.
-`event_res` is only used in one event, `pre_expand`, where some properties of
-the snippet can be changed.
+`callbacks`: `fn(node[, event_args]) -> event_res` All callbacks receive the
+`node` associated with the event and event-specific optional arguments,
+`event_args`. `event_res` is only used in one event, `pre_expand`, where some
+properties of the snippet can be changed. If multiple callbacks return
+`event_res`, we only guarantee that one of them will be effective, not all of
+them.
 
 `autocommand`: Luasnip uses `User`-events. Autocommands for these can be
 registered using

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -1,6 +1,5 @@
 local session = require("luasnip.session")
 local util = require("luasnip.util.util")
-local node_util = require("luasnip.util.util")
 local node_util = require("luasnip.nodes.util")
 local ext_util = require("luasnip.util.ext_opts")
 local events = require("luasnip.util.events")
@@ -276,15 +275,21 @@ function Node:init_insert_positions(position_so_far)
 end
 
 function Node:event(event)
+	local node_callback = self.node_callbacks[event]
+	if node_callback then
+		node_callback(self)
+	end
+
+	-- try to get the callback from the parent.
 	if self.pos then
 		-- node needs position to get callback (nodes may not have position if
 		-- defined in a choiceNode, ie. c(1, {
 		--	i(nil, {"works!"})
 		-- }))
 		-- works just fine.
-		local callback = self.parent.callbacks[self.pos][event]
-		if callback then
-			callback(self)
+		local parent_callback = self.parent.callbacks[self.pos][event]
+		if parent_callback then
+			parent_callback(self)
 		end
 	end
 

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -158,6 +158,8 @@ local function init_node_opts(opts)
 
 	in_node.key = opts.key
 
+	in_node.node_callbacks = opts.node_callbacks or {}
+
 	return in_node
 end
 

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1448,7 +1448,7 @@ describe("snippets_basic", function()
 	end)
 
 	it("node-callbacks are executed correctly.", function()
-		exec_lua[[
+		exec_lua([[
 			enter_qwer = false
 			enter_qwer_via_parent = false
 
@@ -1461,12 +1461,12 @@ describe("snippets_basic", function()
 			end}} } )
 
 			ls.snip_expand(snip)
-		]]
+		]])
 
 		assert.are.same(true, exec_lua("return enter_qwer"))
 		assert.are.same(true, exec_lua("return enter_qwer_via_parent"))
 
-		exec_lua[[
+		exec_lua([[
 			enter_snode = false
 			enter_snode_m1 = false
 			enter_snode_via_parent = false
@@ -1486,7 +1486,7 @@ describe("snippets_basic", function()
 			end}}, } )
 
 			ls.snip_expand(snip)
-		]]
+		]])
 
 		assert.are.same(true, exec_lua("return enter_snode"))
 		assert.are.same(true, exec_lua("return enter_snode_m1"))

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1446,4 +1446,50 @@ describe("snippets_basic", function()
 		exec_lua([[ls.snip_expand(snip)]])
 		assert.are.same(2, exec_lua("return counter"))
 	end)
+
+	it("node-callbacks are executed correctly.", function()
+		exec_lua[[
+			enter_qwer = false
+			enter_qwer_via_parent = false
+
+			snip = s("foo", {
+				t"asdf", i(1, "qwer", {node_callbacks = {[events.enter] = function()
+					enter_qwer = true
+				end}})
+			}, {callbacks = {[1] = { [events.enter] = function()
+				enter_qwer_via_parent = true
+			end}} } )
+
+			ls.snip_expand(snip)
+		]]
+
+		assert.are.same(true, exec_lua("return enter_qwer"))
+		assert.are.same(true, exec_lua("return enter_qwer_via_parent"))
+
+		exec_lua[[
+			enter_snode = false
+			enter_snode_m1 = false
+			enter_snode_via_parent = false
+
+			snip = s("foo", {
+				sn(1, {t"qwer"}, {
+					node_callbacks = {[events.enter] = function()
+						enter_snode = true
+					end},
+					callbacks = { [-1] = {
+						[events.enter] = function()
+							enter_snode_m1 = true
+						end }}
+				} )
+			}, {callbacks = {[1] = { [events.enter] = function()
+				enter_snode_via_parent = true
+			end}}, } )
+
+			ls.snip_expand(snip)
+		]]
+
+		assert.are.same(true, exec_lua("return enter_snode"))
+		assert.are.same(true, exec_lua("return enter_snode_m1"))
+		assert.are.same(true, exec_lua("return enter_snode_via_parent"))
+	end)
 end)


### PR DESCRIPTION
Currently the event-callbacks are only settable by providing the jump-index to the parent-node, which is pretty roundabout, and annoying for usage in eg. `fmt`.

```lua
s("qwer", {t'  ', i(1, "asdf", {node_callbacks = {[events.enter] = function()
	print("enter!!!")
end}})})
```

Calling it `node_callbacks` for now, since the option also applies to `snippetNode`, where  the key `callbacks` is already taken :/

Also, as of now the per-node-callbacks disable/override the parent-callbacks, maybe both should be executed?