### PR TITLE
refocus: don't leave the snippet if the active node is an exitNode (fix #1112).

### DIFF
--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -519,8 +519,11 @@ local function refocus(from, to)
 			-- here.
 			-- snippet does not have input_leave_children, so only input_leave
 			-- needs to be called.
-			ok2 =
-				pcall(from.parent.snippet.input_leave, from.parent.snippet, true)
+			ok2 = pcall(
+				from.parent.snippet.input_leave,
+				from.parent.snippet,
+				true
+			)
 		end
 		if not ok1 or not ok2 then
 			from.parent.snippet:remove_from_jumplist()
@@ -536,8 +539,11 @@ local function refocus(from, to)
 			ok3 = true
 		else
 			ok2 = pcall(leave_nodes_between, node.parent.snippet, node, true)
-			ok3 =
-				pcall(node.parent.snippet.input_leave, node.parent.snippet, true)
+			ok3 = pcall(
+				node.parent.snippet.input_leave,
+				node.parent.snippet,
+				true
+			)
 		end
 
 		if not ok1 or not ok2 or not ok3 then

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1431,4 +1431,25 @@ describe("snippets_basic", function()
 		exec_lua([[ls.jump( 1)]])
 		screen:expect({ unchanged = true })
 	end)
+
+	it("node-event is not triggered twice for exitNode.", function()
+		exec_lua[[
+			counter = 0
+			snip = s("mk", t"asdf", {callbacks = {[-1] = {[events.leave] = function()
+				counter = counter + 1
+			end}}})
+		]]
+		exec_lua([[ls.snip_expand(snip)]])
+		assert.are.same(
+			1,
+			exec_lua("return counter")
+		)
+
+		-- +1 for entering the exit-node of the second expansion.
+		exec_lua([[ls.snip_expand(snip)]])
+		assert.are.same(
+			2,
+			exec_lua("return counter")
+		)
+	end)
 end)

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1433,23 +1433,17 @@ describe("snippets_basic", function()
 	end)
 
 	it("node-event is not triggered twice for exitNode.", function()
-		exec_lua[[
+		exec_lua([[
 			counter = 0
 			snip = s("mk", t"asdf", {callbacks = {[-1] = {[events.leave] = function()
 				counter = counter + 1
 			end}}})
-		]]
+		]])
 		exec_lua([[ls.snip_expand(snip)]])
-		assert.are.same(
-			1,
-			exec_lua("return counter")
-		)
+		assert.are.same(1, exec_lua("return counter"))
 
 		-- +1 for entering the exit-node of the second expansion.
 		exec_lua([[ls.snip_expand(snip)]])
-		assert.are.same(
-			2,
-			exec_lua("return counter")
-		)
+		assert.are.same(2, exec_lua("return counter"))
 	end)
 end)


### PR DESCRIPTION
If the node active within a snippet is an exitNode the leave-callback has already been called, and we should not trigger it again.

I think this should work, doing it as a PR since I want to add tests.