### PR TITLE
Typehinting luasnip

### DIFF
--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -11,7 +11,7 @@ local function set_snip_env(target_conf_defaults, user_config)
 	-- either "set" or "extend", make sure it does not appear in the final snip_env.
 	local snip_env_behaviour = user_config.snip_env.__snip_env_behaviour ~= nil
 			and user_config.snip_env.__snip_env_behaviour
-		or "extend"
+			or "extend"
 	assert(
 		snip_env_behaviour == "set" or snip_env_behaviour == "extend",
 		"Unknown __snip_env_behaviour, `" .. snip_env_behaviour .. "`"
@@ -34,7 +34,16 @@ end
 -- declare here to use in set_config.
 local c
 
+---@class UserConfig
+---@field ext_opts table<string, table>
+---@field history boolean
+---@field update_events string[]
+---@field updateevents string[]
+
+---@alias SetConfig fun(user_config: UserConfig)
+
 c = {
+	---@type SetConfig
 	set_config = function(user_config)
 		user_config = user_config or {}
 		local conf = vim.deepcopy(conf_defaults)
@@ -43,13 +52,13 @@ c = {
 		ext_util.clear_invalid(conf.ext_opts)
 		conf.ext_opts = ext_util.child_complete(conf.ext_opts)
 		user_config.ext_opts =
-			ext_util.child_complete(user_config.ext_opts or {})
+				ext_util.child_complete(user_config.ext_opts or {})
 		ext_util.child_extend(user_config.ext_opts, conf.ext_opts)
 
 		-- use value from update_events, then updateevents.
 		-- also nil updateevents, don't spill it into the main config.
 		user_config.update_events = user_config.update_events
-			or user_config.updateevents
+				or user_config.updateevents
 		user_config.updateevents = nil
 
 		set_snip_env(conf, user_config)

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -245,6 +245,7 @@ local function _jump_into_default(snippet)
 end
 
 ---@class Snippet
+---@field id integer
 ---@field name string
 ---@field trigger string
 ---@field trigger_expand unknown
@@ -880,19 +881,40 @@ end
 
 
 ---@alias SnippetFunction fun(context: any, nodes: any, opts: any): unknown
----@alias TextNode fun(static_text: string, opts: any): unknown
+---@alias TextNodeFunction fun(static_text: string, opts: any): unknown
 ---@alias FunctionNode fun(func: function, args: any, opts: any): unknown
----@alias InsertNode fun(pos: string, static_text: any, opts: any): unknown
----@alias ChoiceNode fun(pos: any, choices: any, opts: any): unknown
----@alias DynamicNode fun(pos: any, func: function, args: any, opts: any): unknown
+---@alias InsertNodeFunction fun(pos: string, static_text: any, opts: any): unknown
+---@alias ChoiceNodeFunction fun(pos: any, choices: any, opts: any): unknown
+---@alias DynamicNodeFunction fun(func: function, args: any, opts: any): unknown
+---@alias RestoreNodeFunction fun(opts: any): unknown
+---@alias ParentIndexer fun(indx: any): unknown
+---@alias IndentSnippetNode fun(pos: any, nodes: any, indent_text: string, opts: any): unknown
+---@alias MultiSnippet fun(contexts: any, nodes: any, opts: any): unknown
 
 ---@class LazyDefs
 ---@field s SnippetFunction
 ---@field sn SnippetFunction
----@field t TextNode
+---@field t TextNodeFunction
 ---@field f FunctionNode
----@field i InsertNode
----@field c ChoiceNode
+---@field i InsertNodeFunction
+---@field c ChoiceNodeFunction
+---@field d DynamicNodeFunction
+---@field r RestoreNodeFunction
+---@field snippet SnippetFunction
+---@field snippet_node SnippetFunction
+---@field parent_indexer ParentIndexer
+---@field indent_snippet_node IndentSnippetNode
+---@field text_node TextNodeFunction
+---@field function_node FunctionNode
+---@field insert_node InsertNodeFunction
+---@field choice_node ChoiceNodeFunction
+---@field dynamic_node DynamicNodeFunction
+---@field restore_node RestoreNodeFunction
+---@field parser Parser
+---@field config UserConfig
+---@field multi_snippet MultiSnippet
+---@field snippet_source SnippetSource
+---@field select_keys string
 -- make these lazy, such that we don't have to load them before it's really
 -- necessary (drives up cost of initial load, otherwise).
 -- stylua: ignore
@@ -915,12 +937,13 @@ local lazy_defs = {
 	choice_node = function() return require("luasnip.nodes.choiceNode").C end,
 	dynamic_node = function() return require("luasnip.nodes.dynamicNode").D end,
 	restore_node = function() return require("luasnip.nodes.restoreNode").R end,
-	parser = function() return require("luasnip.util.parser") end,
-	config = function() return require("luasnip.config") end,
-	multi_snippet = function() return require("luasnip.nodes.multiSnippet").new_multisnippet end,
-	snippet_source = function() return require("luasnip.session.snippet_collection.source") end,
-	select_keys = function() return require("luasnip.util.select").select_keys end
+	parser = function() return require("luasnip.util.parser") end, ---@diagnostic disable-line: assign-type-mismatch
+	config = function() return require("luasnip.config") end,---@diagnostic disable-line: assign-type-mismatch
+	multi_snippet = function() return require("luasnip.nodes.multiSnippet").new_multisnippet end,---@diagnostic disable-line: assign-type-mismatch
+	snippet_source = function() return require("luasnip.session.snippet_collection.source") end,---@diagnostic disable-line: assign-type-mismatch
+	select_keys = function() return require("luasnip.util.select").select_keys end---@diagnostic disable-line: assign-type-mismatch
 }
+
 
 ---@class LazyT
 ---@field expand_or_jumpable fun(): boolean
@@ -1013,5 +1036,18 @@ local lazy_t = {
 
 ---@type LazyT|LazyDefs
 ls = lazy_table(lazy_t, lazy_defs)
+
+
+
+
+
+ls.d()
+
+ls.session.hello
+
+ls.parser.parse_snippet(2)
+
+ls.snip_expand("mama")
+
 
 return ls

--- a/lua/luasnip/session/init.lua
+++ b/lua/luasnip/session/init.lua
@@ -1,3 +1,16 @@
+---@class LuasnipSession
+---@field active_choice_nodes table
+---@field config table
+---@field current_nodes table<integer, table>
+---@field ft_redirect table
+---@field get_snip_env fun(): table
+---@field jump_active boolean
+---@field last_expand_opts any
+---@field last_expand_snip any
+---@field latest_load_ft unknown
+---@field loaded_fts table
+---@field ns_id number
+---@field snippet_roots table
 -- used to store values like current nodes or the active node for autocommands.
 local M = {}
 
@@ -45,6 +58,7 @@ M.config = require("luasnip.default_config")
 
 M.loaded_fts = {}
 
+---@return table
 function M.get_snip_env()
 	return M.config.snip_env
 end

--- a/lua/luasnip/session/init.lua
+++ b/lua/luasnip/session/init.lua
@@ -11,6 +11,7 @@
 ---@field loaded_fts table
 ---@field ns_id number
 ---@field snippet_roots table
+---@field event_node any
 -- used to store values like current nodes or the active node for autocommands.
 local M = {}
 

--- a/lua/luasnip/session/snippet_collection/init.lua
+++ b/lua/luasnip/session/snippet_collection/init.lua
@@ -105,6 +105,7 @@ local by_ft_snippets_mt = {
 setmetatable(by_ft.snippets, by_ft_snippets_mt)
 setmetatable(by_ft.autosnippets, by_ft_snippets_mt)
 
+---@type table<integer, table>
 local by_id = setmetatable({}, {
 	-- make by_id-table weak (v).
 	-- this means it won't be necessary to explicitly nil values (snippets) in
@@ -295,6 +296,9 @@ function M.get_snippets(ft, type)
 	end
 end
 
+---@alias GetIdSnippet fun(id: integer): table
+
+---@type GetIdSnippet
 function M.get_id_snippet(id)
 	return by_id[id]
 end

--- a/lua/luasnip/session/snippet_collection/source.lua
+++ b/lua/luasnip/session/snippet_collection/source.lua
@@ -1,5 +1,10 @@
 local id_to_source = {}
 
+---@class SnippetSource
+---@field from_debuginfo fun(debuginfo: table): table
+---@field from_location fun(file: string, opts: table|nil): table
+---@field get fun(snippet: Snippet): Snippet
+---@field set fun(snippet: Snippet, source: table): nil
 local M = {}
 
 function M.from_debuginfo(debuginfo)

--- a/lua/luasnip/util/environ.lua
+++ b/lua/luasnip/util/environ.lua
@@ -70,6 +70,14 @@ end
 
 local builtin_ns_names = vim.inspect(vim.tbl_keys(builtin_namespace.builtin_ns))
 
+---@class EnvNamespaceOpts
+---@field eager unknown
+---@field init unknown
+---@field is_table fun(key: string): boolean
+---@field multiline_vars unknown
+---@field vars unknown
+
+---@type fun(name: string, opts: EnvNamespaceOpts): nil
 local function _env_namespace(name, opts)
 	assert(
 		opts and type(opts) == "table",
@@ -131,6 +139,9 @@ end
 
 _env_namespace("", builtin_namespace)
 
+---@alias EnvNamespace fun(name: string, opts: table): nil
+
+---@type EnvNamespace
 -- The exposed api checks for the names to avoid accidental overrides
 function Environ.env_namespace(name, opts)
 	assert(

--- a/lua/luasnip/util/extend_decorator.lua
+++ b/lua/luasnip/util/extend_decorator.lua
@@ -1,3 +1,6 @@
+---@class ExtendDecorator
+---@field apply fun(arg: table|nil, extend: table|nil): table
+---@field register fun(fn: function, ...: table[]): nil
 local M = {}
 
 -- map fn -> {arg_indx = int, extend = fn}[]
@@ -8,8 +11,8 @@ local function default_extend(arg, extend)
 end
 
 ---Create a new decorated version of `fn`.
----@param fn The function to create a decorator for.
----@vararg The values to extend with. These should match the descriptions passed
+----@param fn The function to create a decorator for.
+----@vararg The values to extend with. These should match the descriptions passed
 ---in `register`:
 ---```lua
 ---local function somefn(arg1, arg2, opts1, opts2)
@@ -20,7 +23,7 @@ end
 ---	{key = "opts2 is extended with this"},
 ---	{key = "and opts1 with this"})
 ---```
----@return function: The decorated function.
+----@return function: The decorated function.
 function M.apply(fn, ...)
 	local extend_properties = function_properties[fn]
 	assert(

--- a/lua/luasnip/util/log.lua
+++ b/lua/luasnip/util/log.lua
@@ -52,6 +52,13 @@ else
 	end
 end
 
+---@alias LogLevel "error" | "warn" | "info" | "debug" | "none"
+
+---@class LuasnipLog
+---@field new fun(module_name: string): table<string, function>
+---@field open fun(): nil
+---@field ping fun(): nil
+---@field set_loglevel fun(target_level: LogLevel): nil
 local M = {}
 
 local log = {
@@ -73,7 +80,8 @@ local log = {
 -- will be initialized later on, by set_loglevel.
 local effective_log
 
--- levels sorted by importance, descending.
+---@type table<integer, LogLevel>
+---levels sorted by importance, descending.
 local loglevels = { "error", "warn", "info", "debug" }
 
 -- special key none disable all logging.

--- a/lua/luasnip/util/parser/init.lua
+++ b/lua/luasnip/util/parser/init.lua
@@ -7,6 +7,9 @@ local functions = require("luasnip.util.functions")
 local util = require("luasnip.util.util")
 local extend_decorator = require("luasnip.util.extend_decorator")
 
+---@class Parser
+---@field parse_snippet fun(context: table|number|string, body: string, opts: table|nil): table
+---@field parse_snipmate fun(context: table|number|string, body: string, opts: table|nil): table
 local M = {}
 
 ---Parse snippet represented by `body`.

--- a/lua/luasnip/util/select.lua
+++ b/lua/luasnip/util/select.lua
@@ -57,10 +57,11 @@ local function restore_registers(restore_data)
 	end
 end
 
+---@type string
 -- subtle: `:lua` exits VISUAL, which means that the '< '>-marks will be set correctly!
 -- Afterwards, we can just use <cmd>lua, which does not change the mode.
 M.select_keys =
-	[[:lua require("luasnip.util.select").pre_cut()<Cr>gv"zs<cmd>lua require('luasnip.util.select').post_cut("z")<Cr>]]
+[[:lua require("luasnip.util.select").pre_cut()<Cr>gv"zs<cmd>lua require('luasnip.util.select').post_cut("z")<Cr>]]
 
 local saved_registers
 local lines
@@ -71,7 +72,7 @@ function M.pre_cut()
 	-- "" is affected since we perform a cut (s), 1-9 also (although :h
 	-- quote_number seems to state otherwise for cuts to specific registers..?).
 	saved_registers =
-		store_registers("", "1", "2", "3", "4", "5", "6", "7", "8", "9", "z")
+			store_registers("", "1", "2", "3", "4", "5", "6", "7", "8", "9", "z")
 
 	-- store data needed for de-indenting lines.
 	start_line = vim.fn.line("'<") - 1
@@ -116,7 +117,7 @@ function M.post_cut(register_name)
 			select_dedent[#select_dedent] = ""
 		else
 			select_dedent[#select_dedent] =
-				select_dedent[#select_dedent]:gsub("^" .. min_indent, "")
+					select_dedent[#select_dedent]:gsub("^" .. min_indent, "")
 		end
 	else
 		-- in block: if indent is in block, remove the part of it that is inside

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -325,7 +325,9 @@ local function find_outer_snippet(node)
 	return node
 end
 
+---@param fts string[]
 local function redirect_filetypes(fts)
+	---@type string[]
 	local snippet_fts = {}
 
 	for _, ft in ipairs(fts) do
@@ -334,7 +336,9 @@ local function redirect_filetypes(fts)
 
 	return snippet_fts
 end
-
+---@generic T : table
+---@param list T
+---@return T
 local function deduplicate(list)
 	vim.validate({ list = { list, "table" } })
 	local ret = {}


### PR DESCRIPTION
See #1110

As Luasnip uses lazy loading in the code logic, the type hinting chain breaks before getting to the user. This is the first step towards a better type hinted Luasnip, leveraging the `lua-ls` LSP server and its use of the annotations (e. g. `---@params name string`).

I don't see another way to ensure type hinting than to cast a type to the lazy table at the end of `lua/luasnip/init.lua`. But I am sure we can still improve the type hiniting from functions that are using too ofter an `any` type. Typically for the `opts` or for the `snippets`.

This first try put the type hints a bit all over the place, so the author can better understand to what part of the code they are linked. It would be advisable to put the `---@alias` in a `types.lua` file in the future, so that the type hints don't pollute too much of the code.

I apologize if it is sometimes messy, I wanted to do this first iteration quickly before I get lost into the type hinting madness ^^ I am of course available if you have questions or if I can help in any way (I'm sure you will 😅).