### PR TITLE
Properly exit snippets when exit node is reached

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -154,10 +154,6 @@ Since there would almost always be more jumps if the roots are linked, regular
 `<Tab>` would not work almost all the time, and thus `link_roots` has to stay
 disabled.
 
-If the snippet is not a child, but a root, it can be exited when reaching to
-last node, `$0`, if `exit_roots` is enabled. This setting may avoid unexpected
-behavior by disallowing to jump earlier (finished) snippets.
-
 # Node
 
 Every node accepts, as its last parameter, an optional table of arguments.
@@ -3506,8 +3502,11 @@ These are the settings you can provide to `luasnip.setup()`:
   [Basics-Snippet-Insertion](#snippet-insertion) for more context.
 - `link_roots`: Whether snippet-roots should be linked. See
   [Basics-Snippet-Insertion](#snippet-insertion) for more context.
-- `exit_roots`: Whether snippet-roots should exit at reaching at their `$0`.
-  See [Basics-Snippet-Insertion](#snippet-insertion) for more context.
+- `exit_roots`: Whether snippet-roots should exit at reaching at their last
+  node, `$0`. This setting is only valid for root snippets, not child snippets.
+  This setting may avoid unexpected behavior by disallowing to jump earlier
+  (finished) snippets. Check [Basics-Snippet-Insertion](#snippet-insertion) for
+  more information on snippet-roots.
 - `link_children`: Whether children should be linked. See
   [Basics-Snippet-Insertion](#snippet-insertion) for more context.
 - `history` (deprecated): if not nil, `keep_roots`, `link_roots`, and

--- a/DOC.md
+++ b/DOC.md
@@ -154,6 +154,10 @@ Since there would almost always be more jumps if the roots are linked, regular
 `<Tab>` would not work almost all the time, and thus `link_roots` has to stay
 disabled.
 
+If the snippet is not a child, but a root, it can be exited when reaching to
+last node, `$0`, if `exit_roots` is enabled. This setting may avoid unexpected
+behavior by disallowing to jump earlier (finished) snippets.
+
 # Node
 
 Every node accepts, as its last parameter, an optional table of arguments.
@@ -3502,11 +3506,14 @@ These are the settings you can provide to `luasnip.setup()`:
   [Basics-Snippet-Insertion](#snippet-insertion) for more context.
 - `link_roots`: Whether snippet-roots should be linked. See
   [Basics-Snippet-Insertion](#snippet-insertion) for more context.
+- `exit_roots`: Whether snippet-roots should exit at reaching at their `$0`.
+  See [Basics-Snippet-Insertion](#snippet-insertion) for more context.
 - `link_children`: Whether children should be linked. See
   [Basics-Snippet-Insertion](#snippet-insertion) for more context.
 - `history` (deprecated): if not nil, `keep_roots`, `link_roots`, and
-  `link_children` will bet set to the value of `history`.  
-  This is just to ensure backwards-compatibility.
+  `link_children` will be set to the value of `history`, and
+  `exit_roots` will set to inverse value of `history`. This is just to ensure
+  backwards-compatibility.
 - `update_events`: Choose which events trigger an update of the active nodes'
   dependents. Default is just `'InsertLeave'`, `'TextChanged,TextChangedI'`
   would update on every change.

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ JSREGEXP005_PATH=deps/jsregexp005
 jsregexp:
 	git submodule init
 	git submodule update
-	$(MAKE) "INCLUDE_DIR=-I'$(shell pwd)/deps/lua51_include/'" LDLIBS="${LUA_LDLIBS}" -C "${JSREGEXP_PATH}"
-	$(MAKE) "INCLUDE_DIR=-I'$(shell pwd)/deps/lua51_include/'" LDLIBS="${LUA_LDLIBS}" -C "${JSREGEXP005_PATH}"
+	$(MAKE) "CC=$(CC)" "INCLUDE_DIR=-I'$(shell pwd)/deps/lua51_include/'" LDLIBS="${LUA_LDLIBS}" -C "${JSREGEXP_PATH}"
+	$(MAKE) "CC=$(CC)" "INCLUDE_DIR=-I'$(shell pwd)/deps/lua51_include/'" LDLIBS="${LUA_LDLIBS}" -C "${JSREGEXP005_PATH}"
 
 install_jsregexp: jsregexp
 	# remove old binary.

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 20
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 21
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 25
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 26
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 16
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 19
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -227,6 +227,10 @@ roots, but don’t jump to them) is useful for a super-tab like mapping
 previous roots. Since there would almost always be more jumps if the roots are
 linked, regular `<Tab>` would not work almost all the time, and thus
 `link_roots` has to stay disabled.
+
+If the snippet is not a child, but a root, it can be exited when reaching to
+last node, `$0`, if `exit_roots` is enabled. This setting may avoid unexpected
+behavior by disallowing to jump earlier (finished) snippets.
 
 
 ==============================================================================
@@ -3372,10 +3376,13 @@ These are the settings you can provide to `luasnip.setup()`:
     |luasnip-basics-snippet-insertion| for more context.
 - `link_roots`: Whether snippet-roots should be linked. See
     |luasnip-basics-snippet-insertion| for more context.
+- `exit_roots`: Whether snippet-roots should exit at reaching at their `$0`. See
+    |luasnip-basics-snippet-insertion| for more context.
 - `link_children`: Whether children should be linked. See
     |luasnip-basics-snippet-insertion| for more context.
 - `history` (deprecated): if not nil, `keep_roots`, `link_roots`, and
-    `link_children` will bet set to the value of `history`. This is just to ensure
+    `link_children` will be set to the value of `history`, and `exit_roots` will
+    set to inverse value of `history`. This is just to ensure
     backwards-compatibility.
 - `update_events`: Choose which events trigger an update of the active nodes’
     dependents. Default is just `'InsertLeave'`, `'TextChanged,TextChangedI'` would

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 19
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 20
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -227,10 +227,6 @@ roots, but don’t jump to them) is useful for a super-tab like mapping
 previous roots. Since there would almost always be more jumps if the roots are
 linked, regular `<Tab>` would not work almost all the time, and thus
 `link_roots` has to stay disabled.
-
-If the snippet is not a child, but a root, it can be exited when reaching to
-last node, `$0`, if `exit_roots` is enabled. This setting may avoid unexpected
-behavior by disallowing to jump earlier (finished) snippets.
 
 
 ==============================================================================
@@ -3376,8 +3372,11 @@ These are the settings you can provide to `luasnip.setup()`:
     |luasnip-basics-snippet-insertion| for more context.
 - `link_roots`: Whether snippet-roots should be linked. See
     |luasnip-basics-snippet-insertion| for more context.
-- `exit_roots`: Whether snippet-roots should exit at reaching at their `$0`. See
-    |luasnip-basics-snippet-insertion| for more context.
+- `exit_roots`: Whether snippet-roots should exit at reaching at their last node,
+    `$0`. This setting is only valid for root snippets, not child snippets. This
+    setting may avoid unexpected behavior by disallowing to jump earlier (finished)
+    snippets. Check |luasnip-basics-snippet-insertion| for more information on
+    snippet-roots.
 - `link_children`: Whether children should be linked. See
     |luasnip-basics-snippet-insertion| for more context.
 - `history` (deprecated): if not nil, `keep_roots`, `link_roots`, and

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -58,6 +58,7 @@ c = {
 		if user_config.history ~= nil then
 			conf.keep_roots = user_config.history
 			conf.link_roots = user_config.history
+			conf.exit_roots = not user_config.history
 			conf.link_children = user_config.history
 
 			-- unset key to prevent handling twice.

--- a/lua/luasnip/default_config.lua
+++ b/lua/luasnip/default_config.lua
@@ -103,6 +103,7 @@ return {
 	-- corresponds to legacy "history=false".
 	keep_roots = false,
 	link_roots = false,
+	exit_roots = true,
 	link_children = false,
 
 	update_events = "InsertLeave",

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -162,7 +162,7 @@ local function jump(dir)
 		local next_node = util.no_region_check_wrap(safe_jump_current, dir)
 
 		if session.config.exit_roots then
-			if (next_node.pos == 0 and next_node.parent.parent_node == nil) then
+			if next_node.pos == 0 and next_node.parent.parent_node == nil then
 				session.current_nodes[vim.api.nvim_get_current_buf()] = nil
 				return true
 			end

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -159,8 +159,15 @@ end
 local function jump(dir)
 	local current = session.current_nodes[vim.api.nvim_get_current_buf()]
 	if current then
-		session.current_nodes[vim.api.nvim_get_current_buf()] =
-			util.no_region_check_wrap(safe_jump_current, dir)
+		local next_node = util.no_region_check_wrap(safe_jump_current, dir)
+
+		if session.config.exit_roots then
+			if (next_node.pos == 0 and next_node.parent.parent_node == nil) then
+				session.current_nodes[vim.api.nvim_get_current_buf()] = nil
+				return true
+			end
+		end
+		session.current_nodes[vim.api.nvim_get_current_buf()] = next_node
 		return true
 	else
 		return false

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -160,7 +160,10 @@ local function jump(dir)
 	local current = session.current_nodes[vim.api.nvim_get_current_buf()]
 	if current then
 		local next_node = util.no_region_check_wrap(safe_jump_current, dir)
-
+		if next_node == nil then
+			session.current_nodes[vim.api.nvim_get_current_buf()] = nil
+			return false
+		end
 		if session.config.exit_roots then
 			if next_node.pos == 0 and next_node.parent.parent_node == nil then
 				session.current_nodes[vim.api.nvim_get_current_buf()] = nil

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -162,7 +162,7 @@ local function jump(dir)
 		local next_node = util.no_region_check_wrap(safe_jump_current, dir)
 		if next_node == nil then
 			session.current_nodes[vim.api.nvim_get_current_buf()] = nil
-			return false
+			return true
 		end
 		if session.config.exit_roots then
 			if next_node.pos == 0 and next_node.parent.parent_node == nil then

--- a/tests/integration/session_spec.lua
+++ b/tests/integration/session_spec.lua
@@ -392,6 +392,10 @@ describe("session", function()
 		jump(1)
 	end)
 	it("Deleting nested snippet only removes it.", function()
+		ls_helpers.session_setup_luasnip({
+			setup_extend = { exit_roots = false },
+			hl_choiceNode = true
+		})
 		feed("o<Cr><Cr><Up>fn")
 		exec_lua("ls.expand()")
 		screen:expect({
@@ -700,6 +704,7 @@ describe("session", function()
 			exec_lua(([[
 				ls.setup({
 					link_children = %s,
+					exit_roots = false,
 				})
 			]]):format(link_children_val))
 
@@ -1466,6 +1471,7 @@ describe("session", function()
 			ls.setup({
 				keep_roots = true,
 				link_roots = true,
+				exit_roots = false,
 				link_children = true,
 				delete_check_events = "TextChanged",
 				ext_opts = {
@@ -1928,6 +1934,7 @@ describe("session", function()
 			ls.setup({
 				keep_roots = true,
 				link_roots = true,
+				exit_roots = false,
 				link_children = true
 			})
 		]])

--- a/tests/integration/session_spec.lua
+++ b/tests/integration/session_spec.lua
@@ -20,7 +20,10 @@ describe("session", function()
 
 	before_each(function()
 		ls_helpers.clear()
-		ls_helpers.session_setup_luasnip({ hl_choiceNode = true })
+		ls_helpers.session_setup_luasnip({
+			setup_extend = { exit_roots = false },
+			hl_choiceNode = true,
+		})
 
 		-- add a rather complicated snippet.
 		-- It may be a bit hard to grasp, but will cover lots and lots of
@@ -392,10 +395,6 @@ describe("session", function()
 		jump(1)
 	end)
 	it("Deleting nested snippet only removes it.", function()
-		ls_helpers.session_setup_luasnip({
-			setup_extend = { exit_roots = false },
-			hl_choiceNode = true,
-		})
 		feed("o<Cr><Cr><Up>fn")
 		exec_lua("ls.expand()")
 		screen:expect({

--- a/tests/integration/session_spec.lua
+++ b/tests/integration/session_spec.lua
@@ -394,7 +394,7 @@ describe("session", function()
 	it("Deleting nested snippet only removes it.", function()
 		ls_helpers.session_setup_luasnip({
 			setup_extend = { exit_roots = false },
-			hl_choiceNode = true
+			hl_choiceNode = true,
 		})
 		feed("o<Cr><Cr><Up>fn")
 		exec_lua("ls.expand()")

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1372,6 +1372,64 @@ describe("snippets_basic", function()
 			})
 		end
 	)
+	it(
+		"exit_roots = false stays in the root node but exits child.",
+		function()
+			exec_lua([[
+			ls.setup({
+				exit_roots = false
+			})
+			ls.add_snippets("all", {
+			s("aa", { t{"( "}, i(1, "1"), t{" )"}, i(0, "0") })
+			})
+		]])
+
+			feed("iaa")
+			exec_lua("ls.expand()")
+			screen:expect({
+				grid = [[
+			( ^1 )0                                            |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]],
+			})
+			-- screen:snapshot_util()
+			feed("aa")
+			exec_lua("ls.expand()")
+			screen:expect({
+				grid = [[
+			( ( ^1 )0 )0                                       |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]],
+			})
+			-- do not exit when reaching to a child root
+			exec_lua("ls.jump(1) ls.jump(-1)")
+			screen:expect({
+				grid = [[
+			( ( ^1 )0 )0                                       |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]],
+			})
+			-- root $0 does not exit.
+			exec_lua("ls.jump(1) ls.jump(1) ls.jump(-1)")
+			screen:expect({
+				grid = [[
+			( ^({3: 1 )0} )0                                       |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]
+			})
+			-- new root snippet exits earlier root.
+			exec_lua("ls.jump(1)")
+			feed("aa")
+			exec_lua("ls.expand()")
+			exec_lua("ls.jump(-1) ls.jump(-1)")
+			screen:expect({
+				grid = [[
+			( ( 1 )0 )^( 1 )0                                  |
+			{0:~                                                 }|
+			{2:-- INSERT --}                                      |]]
+			})
+		end
+	)
 
 	it("focus correctly adjusts gravities of parent-snippets.", function()
 		exec_lua([[

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1326,8 +1326,10 @@ describe("snippets_basic", function()
 		})
 	end)
 
-	it("exit_roots exits when the last node of snippet-root is reached.", function()
-		exec_lua([[
+	it(
+		"exit_roots exits when the last node of snippet-root is reached.",
+		function()
+			exec_lua([[
 			ls.setup({
 				exit_roots = true
 			})
@@ -1336,39 +1338,40 @@ describe("snippets_basic", function()
 			})
 		]])
 
-		feed("iaa")
-		exec_lua("ls.expand()")
-		screen:expect({
-			grid = [[
+			feed("iaa")
+			exec_lua("ls.expand()")
+			screen:expect({
+				grid = [[
 			( ^1 )0                                            |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]
-		})
-		feed("aa")
-		exec_lua("ls.expand()")
-		screen:expect({
-			grid = [[
+			{2:-- SELECT --}                                      |]],
+			})
+			feed("aa")
+			exec_lua("ls.expand()")
+			screen:expect({
+				grid = [[
 			( ( ^1 )0 )0                                       |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]
-		})
-		-- verify we do not exit when reaching to a child root
-		exec_lua("ls.jump(1) ls.jump(-1)")
-		screen:expect({
-			grid = [[
+			{2:-- SELECT --}                                      |]],
+			})
+			-- verify we do not exit when reaching to a child root
+			exec_lua("ls.jump(1) ls.jump(-1)")
+			screen:expect({
+				grid = [[
 			( ( ^1 )0 )0                                       |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]
-		})
-		-- be sure that reaching root $0 exits.
-		exec_lua("ls.jump(1) ls.jump(1) ls.jump(-1)")
-		screen:expect({
-			grid = [[
+			{2:-- SELECT --}                                      |]],
+			})
+			-- be sure that reaching root $0 exits.
+			exec_lua("ls.jump(1) ls.jump(1) ls.jump(-1)")
+			screen:expect({
+				grid = [[
 			( ( 1 )0 )^0                                       |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]
-		})
-	end)
+			{2:-- SELECT --}                                      |]],
+			})
+		end
+	)
 
 	it("focus correctly adjusts gravities of parent-snippets.", function()
 		exec_lua([[

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1372,10 +1372,8 @@ describe("snippets_basic", function()
 			})
 		end
 	)
-	it(
-		"exit_roots = false stays in the root node but exits child.",
-		function()
-			exec_lua([[
+	it("exit_roots = false stays in the root node but exits child.", function()
+		exec_lua([[
 			ls.setup({
 				exit_roots = false
 			})
@@ -1384,52 +1382,51 @@ describe("snippets_basic", function()
 			})
 		]])
 
-			feed("iaa")
-			exec_lua("ls.expand()")
-			screen:expect({
-				grid = [[
+		feed("iaa")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
 			( ^1 )0                                            |
 			{0:~                                                 }|
 			{2:-- SELECT --}                                      |]],
-			})
-			-- screen:snapshot_util()
-			feed("aa")
-			exec_lua("ls.expand()")
-			screen:expect({
-				grid = [[
+		})
+		-- screen:snapshot_util()
+		feed("aa")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
 			( ( ^1 )0 )0                                       |
 			{0:~                                                 }|
 			{2:-- SELECT --}                                      |]],
-			})
-			-- do not exit when reaching to a child root
-			exec_lua("ls.jump(1) ls.jump(-1)")
-			screen:expect({
-				grid = [[
+		})
+		-- do not exit when reaching to a child root
+		exec_lua("ls.jump(1) ls.jump(-1)")
+		screen:expect({
+			grid = [[
 			( ( ^1 )0 )0                                       |
 			{0:~                                                 }|
 			{2:-- SELECT --}                                      |]],
-			})
-			-- root $0 does not exit.
-			exec_lua("ls.jump(1) ls.jump(1) ls.jump(-1)")
-			screen:expect({
-				grid = [[
+		})
+		-- root $0 does not exit.
+		exec_lua("ls.jump(1) ls.jump(1) ls.jump(-1)")
+		screen:expect({
+			grid = [[
 			( ^({3: 1 )0} )0                                       |
 			{0:~                                                 }|
-			{2:-- SELECT --}                                      |]]
-			})
-			-- new root snippet exits earlier root.
-			exec_lua("ls.jump(1)")
-			feed("aa")
-			exec_lua("ls.expand()")
-			exec_lua("ls.jump(-1) ls.jump(-1)")
-			screen:expect({
-				grid = [[
+			{2:-- SELECT --}                                      |]],
+		})
+		-- new root snippet exits earlier root.
+		exec_lua("ls.jump(1)")
+		feed("aa")
+		exec_lua("ls.expand()")
+		exec_lua("ls.jump(-1) ls.jump(-1)")
+		screen:expect({
+			grid = [[
 			( ( 1 )0 )^( 1 )0                                  |
 			{0:~                                                 }|
-			{2:-- INSERT --}                                      |]]
-			})
-		end
-	)
+			{2:-- INSERT --}                                      |]],
+		})
+	end)
 
 	it("focus correctly adjusts gravities of parent-snippets.", function()
 		exec_lua([[

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1326,6 +1326,50 @@ describe("snippets_basic", function()
 		})
 	end)
 
+	it("exit_roots exits when the last node of snippet-root is reached.", function()
+		exec_lua([[
+			ls.setup({
+				exit_roots = true
+			})
+			ls.add_snippets("all", {
+			s("aa", { t{"( "}, i(1, "1"), t{" )"}, i(0, "0") })
+			})
+		]])
+
+		feed("iaa")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
+			( ^1 )0                                            |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]
+		})
+		feed("aa")
+		exec_lua("ls.expand()")
+		screen:expect({
+			grid = [[
+			( ( ^1 )0 )0                                       |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]
+		})
+		-- verify we do not exit when reaching to a child root
+		exec_lua("ls.jump(1) ls.jump(-1)")
+		screen:expect({
+			grid = [[
+			( ( ^1 )0 )0                                       |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]
+		})
+		-- be sure that reaching root $0 exits.
+		exec_lua("ls.jump(1) ls.jump(1) ls.jump(-1)")
+		screen:expect({
+			grid = [[
+			( ( 1 )0 )^0                                       |
+			{0:~                                                 }|
+			{2:-- SELECT --}                                      |]]
+		})
+	end)
+
 	it("focus correctly adjusts gravities of parent-snippets.", function()
 		exec_lua([[
 			ls.setup{


### PR DESCRIPTION
This pull request fixes the bug introduced in https://github.com/L3MON4D3/LuaSnip/commit/d9cb6ab976bca0bbf0ce790bc3c56af5ae80f4b8. Basically, when user reaches exit nodes, user can keep jumping to earlier nodes unless another action, e.g. creating another snippet outside of the current snippet.

This pull request fixes https://github.com/L3MON4D3/LuaSnip/issues/1161.

The logic behind commit that fixes nested snippet behavior, d48cb22f4849a5b0d48119020c97700322328767, appears flaky. Is there any better way to do this?

