### PR TITLE
Use lazyredraw to avoid flicking

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0            Last change: 2024 April 30
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2024 May 06
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -189,8 +189,7 @@ local function any_select(b, e)
 			-- set before
 			cursor_set_keys(e, true))
 		.. "o<C-G><C-r>_"
-		.. string.format("<Cmd>setlocal %slazyredraw<CR>", vim.o.lazyredraw and "" or "no")
-	)
+		.. string.format("<Cmd>setlocal %slazyredraw<CR>", vim.o.lazyredraw and "" or "no"))
 end
 
 local function normal_move_on_insert(new_cur_pos)

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -170,7 +170,8 @@ local function any_select(b, e)
 		-- Go into visual, then place endpoints.
 		-- This is to allow us to place the cursor on the \n of a line.
 		-- see #1158
-		"<esc>"
+		"<Cmd>setlocal lazyredraw<CR>"
+		.. "<esc>"
 		-- open folds that contain this selection.
 		-- we assume that the selection is contained in at most one fold, and
 		-- that that fold covers b.
@@ -187,7 +188,9 @@ local function any_select(b, e)
 			cursor_set_keys(e) or
 			-- set before
 			cursor_set_keys(e, true))
-		.. "o<C-G><C-r>_" )
+		.. "o<C-G><C-r>_"
+		.. string.format("<Cmd>setlocal %slazyredraw<CR>", vim.o.lazyredraw and "" or "no")
+	)
 end
 
 local function normal_move_on_insert(new_cur_pos)

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -165,8 +165,6 @@ end
 local function any_select(b, e)
 	-- stylua: ignore
 	replace_feedkeys(
-		-- this esc -> movement sometimes leads to a slight flicker
-		-- TODO: look into preventing that reliably.
 		-- Go into visual, then place endpoints.
 		-- This is to allow us to place the cursor on the \n of a line.
 		-- see #1158


### PR DESCRIPTION
based on https://github.com/hrsh7th/nvim-cmp/blob/8f3c541407e691af6163e2447f3af1bd6e17f9a3/lua/cmp/utils/feedkeys.lua#L15
before:

https://github.com/L3MON4D3/LuaSnip/assets/97848247/2dc8666b-0ab5-4bc6-a611-2182e1b7ea5b

after:

https://github.com/L3MON4D3/LuaSnip/assets/97848247/d722b3f2-bfb2-4b88-b1dc-78f566178234

This is especially obvious in nvim 0.10