### PR TITLE
add "\" for wordtrig

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0            Last change: 2024 June 28
+*luasnip.txt*             For NVIM v0.8.0            Last change: 2024 July 13
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -826,7 +826,7 @@ function Snippet:matches(line_to_cursor)
 			from == 1
 			or string.match(
 					string.sub(line_to_cursor, from - 1, from - 1),
-					"[%w_]"
+					"[\\%w_]"
 				)
 				== nil
 		)


### PR DESCRIPTION
I think it should not be difficult to add API for configuration of `wordTrig`, but I don't know how to do it.
When writing latex, I still need to use `\` for some uncommon symbols and I have to care about whether it will trigger any snippet, which is quite disturbing.