### PR TITLE
Improved syntax file and ftplugin for SnipMate snippets.

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0            Last change: 2024 June 28
+*luasnip.txt*             For NVIM v0.8.0            Last change: 2024 July 21
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/ftplugin/snippets.vim
+++ b/ftplugin/snippets.vim
@@ -5,10 +5,9 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setl et< sts< cms< fdm< fde<"
+let b:undo_ftplugin = "setl cms< fdm< fde<"
 
-" Use hard tabs
-setlocal noexpandtab softtabstop=0
+setlocal foldmethod=expr foldexpr=getline(v:lnum)=~'^#\\\|^e\\\|^p'?0:getline(v:lnum)!~'^\\t\\\|^\ \\\|^$'?'>1':1
 
 setlocal commentstring=#\ %s
 setlocal nospell

--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -8,14 +8,13 @@ syn match snipCommand '\%(\\\@<!\%(\\\\\)*\)\@<=`.\{-}\%(\\\@<!\%(\\\\\)*\)\@<=`
 syn match snippet '^snippet.*' contains=multiSnipText,snipKeyword
 syn match snippet '^autosnippet.*' contains=multiSnipText,snipKeyword
 syn match snippet '^extends.*' contains=snipKeyword
-syn match snippet '^version.*' contains=snipKeyword
 syn match snippet '^priority.*' contains=snipKeyword,priority
 syn match priority '\d\+' contained
 syn match multiSnipText '\S\+ \zs.*' contained
-syn match snipKeyword '^(snippet|extends|version|autosnippet|priority)'me=s+8 contained
+syn match snipKeyword '^\%(snippet\|extends\|autosnippet\|priority\)' contained
 " normally we'd want a \s in that group, but that doesn't work => cover common
 " cases with \t and " ".
-syn match snipError "^[^#vsaep\t ].*$"
+syn match snipError '^[^#saep\t ].*$'
 
 hi link snippet       Identifier
 hi link snipComment   Comment

--- a/tests/data/syntaxtest.snippets
+++ b/tests/data/syntaxtest.snippets
@@ -1,0 +1,17 @@
+extends lua
+
+priority 2000
+autosnippet hello "Comment"
+	Hello World! :)
+
+snippet asdf comment
+	0qwer
+	$1 qwer ${2:hjkl}
+	\\d
+	1qwer
+	2qwer
+
+snippet qwer
+    asdf
+    asdf
+    asdf

--- a/tests/integration/snippet_ft_spec.lua
+++ b/tests/integration/snippet_ft_spec.lua
@@ -21,7 +21,10 @@ describe("snippet-ft tooling", function()
 			[5] = { foreground = Screen.colors.Yellow1 },
 			[6] = { foreground = Screen.colors.Magenta1 },
 			[7] = { bold = true, foreground = Screen.colors.Blue1 },
-			[8] = { foreground = Screen.colors.Blue4, background = Screen.colors.LightGray },
+			[8] = {
+				foreground = Screen.colors.Blue4,
+				background = Screen.colors.LightGray,
+			},
 		})
 		exec([[
 			hi Identifier guifg=Red
@@ -43,9 +46,17 @@ describe("snippet-ft tooling", function()
 	end)
 
 	it("syntax works as expected", function()
-		exec(("edit %s"):format(os.getenv("LUASNIP_SOURCE") .. "/tests/data/syntaxtest.snippets"))
+		exec(
+			("edit %s"):format(
+				os.getenv("LUASNIP_SOURCE") .. "/tests/data/syntaxtest.snippets"
+			)
+		)
 
-		exec(("source %s/syntax/snippets.vim"):format(os.getenv("LUASNIP_SOURCE")))
+		exec(
+			("source %s/syntax/snippets.vim"):format(
+				os.getenv("LUASNIP_SOURCE")
+			)
+		)
 
 		screen:expect({
 			grid = [[
@@ -78,14 +89,27 @@ describe("snippet-ft tooling", function()
 				{7:~                                                 }|
 				{7:~                                                 }|
 				{7:~                                                 }|
-				                                                  |]] })
+				                                                  |]],
+		})
 	end)
 
 	it("folding works as expected", function()
-		exec(("edit %s"):format(os.getenv("LUASNIP_SOURCE") .. "/tests/data/syntaxtest.snippets"))
+		exec(
+			("edit %s"):format(
+				os.getenv("LUASNIP_SOURCE") .. "/tests/data/syntaxtest.snippets"
+			)
+		)
 
-		exec(("source %s/ftplugin/snippets.vim"):format(os.getenv("LUASNIP_SOURCE")))
-		exec(("source %s/syntax/snippets.vim"):format(os.getenv("LUASNIP_SOURCE")))
+		exec(
+			("source %s/ftplugin/snippets.vim"):format(
+				os.getenv("LUASNIP_SOURCE")
+			)
+		)
+		exec(
+			("source %s/syntax/snippets.vim"):format(
+				os.getenv("LUASNIP_SOURCE")
+			)
+		)
 
 		exec("set foldenable foldlevel=99")
 		feed("zM")
@@ -121,6 +145,7 @@ describe("snippet-ft tooling", function()
 				{7:~                                                 }|
 				{7:~                                                 }|
 				{7:~                                                 }|
-				                                                  |]] })
+				                                                  |]],
+		})
 	end)
 end)

--- a/tests/integration/snippet_ft_spec.lua
+++ b/tests/integration/snippet_ft_spec.lua
@@ -1,0 +1,126 @@
+local ls_helpers = require("helpers")
+local exec_lua, feed, exec =
+	ls_helpers.exec_lua, ls_helpers.feed, ls_helpers.exec
+local Screen = require("test.functional.ui.screen")
+
+describe("snippet-ft tooling", function()
+	local screen
+
+	before_each(function()
+		ls_helpers.clear()
+		ls_helpers.session_setup_luasnip()
+
+		screen = Screen.new(50, 30)
+		screen:attach()
+		screen:set_default_attr_ids({
+			[0] = { bold = false, foreground = Screen.colors.Gray0 },
+			[1] = { foreground = Screen.colors.Cyan1 },
+			[2] = { foreground = Screen.colors.Red1 },
+			[3] = { foreground = Screen.colors.LightRed },
+			[4] = { foreground = Screen.colors.WebGrey },
+			[5] = { foreground = Screen.colors.Yellow1 },
+			[6] = { foreground = Screen.colors.Magenta1 },
+			[7] = { bold = true, foreground = Screen.colors.Blue1 },
+			[8] = { foreground = Screen.colors.Blue4, background = Screen.colors.LightGray },
+		})
+		exec([[
+			hi Identifier guifg=Red
+			hi Comment guifg=Green
+			hi String guifg=Blue
+			hi Keyword guifg=Cyan
+			hi SpecialChar guifg=Magenta
+			hi Special guifg=Yellow
+			hi String guifg=Gray
+			hi Error guifg=Orange
+			hi Number guifg=LightRed
+
+			syntax on
+		]])
+	end)
+
+	after_each(function()
+		screen:detach()
+	end)
+
+	it("syntax works as expected", function()
+		exec(("edit %s"):format(os.getenv("LUASNIP_SOURCE") .. "/tests/data/syntaxtest.snippets"))
+
+		exec(("source %s/syntax/snippets.vim"):format(os.getenv("LUASNIP_SOURCE")))
+
+		screen:expect({
+			grid = [[
+				{1:^extends}{2: lua}                                       |
+				                                                  |
+				{1:priority}{2: }{3:2000}                                     |
+				{1:autosnippet}{2: hello }{4:"Comment"}                       |
+				        Hello World! :)                           |
+				                                                  |
+				{1:snippet}{2: asdf }{4:comment}                              |
+				        0qwer                                     |
+				        {5:$1} qwer {5:${2:hjkl}}                         |
+				        {6:\\}d                                       |
+				        1qwer                                     |
+				        2qwer                                     |
+				                                                  |
+				{1:snippet}{2: qwer}                                      |
+				    asdf                                          |
+				    asdf                                          |
+				    asdf                                          |
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				                                                  |]] })
+	end)
+
+	it("folding works as expected", function()
+		exec(("edit %s"):format(os.getenv("LUASNIP_SOURCE") .. "/tests/data/syntaxtest.snippets"))
+
+		exec(("source %s/ftplugin/snippets.vim"):format(os.getenv("LUASNIP_SOURCE")))
+		exec(("source %s/syntax/snippets.vim"):format(os.getenv("LUASNIP_SOURCE")))
+
+		exec("set foldenable foldlevel=99")
+		feed("zM")
+
+		screen:expect({
+			grid = [[
+				{1:^extends}{2: lua}                                       |
+				                                                  |
+				{1:priority}{2: }{3:2000}                                     |
+				{8:+--  3 lines: autosnippet hello "Comment"·········}|
+				{8:+--  7 lines: snippet asdf comment················}|
+				{8:+--  4 lines: snippet qwer························}|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				{7:~                                                 }|
+				                                                  |]] })
+	end)
+end)


### PR DESCRIPTION
Hi again :))
I've made a few changes to improve the syntax highlighting and folding behavior for code snippets.

I noticed that both the ftplugin and syntax files in vsnip and luasnip are copied from vim-snipmate, and the issue is that they both have syntax errors from the start. I had asked a question about this on Reddit (see link below).
[Link to Reddit question](https://www.reddit.com/r/vim/comments/1cxt55r/check_a_syntax_file/)

List of changes:

Changes to syntax file:
1. Removed the syntax for the "version" keyword. This is related to vim-snipmate, which has two different versions of the snippet engine.

2. Fixed a syntax error in the snipKeyword definition.
In regular expressions, there are two types of groups: capturing groups and non-capturing groups.
In Vim, since regular expressions are in magic mode by default, groups must be escaped with a backslash.
For better syntax highlighting, it's also recommended to use non-capturing groups because they don't store unnecessary substrings and are faster.

The capturing group syntax is:
   ```
   \(\)
   ```
And the non-capturing group syntax is:
   ```
   \%(\)
   ```
It's also important to note that the OR operator in Vim's magic mode regular expressions is:
   ```
   \|
   ```
We also don't need `me=s+8`. This prevents the "autosnippet" keyword from being highlighted correctly. Without it, everything works fine, so there's no need to write extra code. :)
See the screenshot for a visual representation of the changes.

**Changes to ftplugin file:**
1. I personally use spaces instead of tabs, and I think it's better to leave it to the user's default settings. So, I removed the part about using tabs.

2. I slightly improved the folding functionality. It now works for both files written with hard tabs and soft tabs.
Also, the words "expand," "priority," and comments are not folded.
I wanted to submit these changes to vsnip in the past, but I needed more time to learn regex in Vim. By the time I was ready, I was using luasnip, so I'm sending them to you instead. :))

**A few notes:**
* Please test them yourself. I've tried them on several files from the vim-snippet project.
* I also don't know if it's better by default to have the code folded or unfolded when the file is opened. So, I didn't use foldlevel in the ftplugin file.

I hope this is helpful. Thank you! :))
Before the changes:
![Screenshot_20240715-193941_Termux](https://github.com/user-attachments/assets/87bbbb05-d3b4-4515-b495-58d666ad4ec5)
After the changes in the syntax file (pay attention to the problem with the word autosnippet, Because of this piece of code me=s+8)
![Screenshot_20240715-194102_Termux](https://github.com/user-attachments/assets/a78f4b7b-83ca-4209-b0c0-6036e563f3b3)
And examples after complete changes
![Screenshot_20240715-194147_Termux](https://github.com/user-attachments/assets/b1554476-a290-4f6a-bff5-0dd2b0c919fb)
![Screenshot_20240715-195248_Termux](https://github.com/user-attachments/assets/a0d83826-6a1c-4495-a4a9-2329552dee49)
![Screenshot_20240715-200915_Termux](https://github.com/user-attachments/assets/b4686fb2-e643-4021-aa4e-66bfa2b81c94)