### PR TITLE
Add a way to get the current log path through lua, add time formatting to logs

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -3452,10 +3452,11 @@ hints towards what is going wrong.
 
 The log is stored in `<vim.fn.stdpath("log")>/luasnip.log`
 (`<vim.fn.stdpath("cache")>/luasnip.log` for Neovim versions where
-`stdpath("log")` does not exist), and can be opened by calling `ls.log.open()`.
+`stdpath("log")` does not exist), and can be opened by calling `ls.log.open()`. You can get the log path through `ls.log.log_location()`.
 The loglevel (granularity of reported events) can be adjusted by calling
 `ls.log.set_loglevel("error"|"warn"|"info"|"debug")`. `"debug"` has the highest
-granularity, `"error"` the lowest, the default is `"warn"`.  
+granularity, `"error"` the lowest, the default is `"warn"`.
+You can also adjust the datetime formatting through the `ls.log.time_fmt` variable. By default, it uses the `'%X'` formatting, which results in the full time (hour, minutes and seconds) being shown.
 
 Once this log grows too large (10MiB, currently not adjustable), it will be
 renamed to `luasnip.log.old`, and a new, empty log created in its place. If

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*            For NVIM v0.8.0           Last change: 2024 August 28
+*luasnip.txt*          For NVIM v0.8.0          Last change: 2024 September 12
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -3319,9 +3319,13 @@ hints towards what is going wrong.
 The log is stored in `<vim.fn.stdpath("log")>/luasnip.log`
 (`<vim.fn.stdpath("cache")>/luasnip.log` for Neovim versions where
 `stdpath("log")` does not exist), and can be opened by calling `ls.log.open()`.
-The loglevel (granularity of reported events) can be adjusted by calling
+You can get the log path through `ls.log.log_location()`. The loglevel
+(granularity of reported events) can be adjusted by calling
 `ls.log.set_loglevel("error"|"warn"|"info"|"debug")`. `"debug"` has the highest
-granularity, `"error"` the lowest, the default is `"warn"`.
+granularity, `"error"` the lowest, the default is `"warn"`. You can also adjust
+the datetime formatting through the `ls.log.time_fmt` variable. By default, it
+uses the `'%X'` formatting, which results in the full time (hour, minutes and
+seconds) being shown.
 
 Once this log grows too large (10MiB, currently not adjustable), it will be
 renamed to `luasnip.log.old`, and a new, empty log created in its place. If

--- a/lua/luasnip/util/log.lua
+++ b/lua/luasnip/util/log.lua
@@ -56,22 +56,24 @@ local M = {}
 
 --- The file path we're currently logging into.
 function M.log_location()
-        return logpath
+	return logpath
 end
 --- Time formatting for logs. Defaults to '%X'.
-M.time_fmt = '%X'
+M.time_fmt = "%X"
 
 local function make_log_level(level)
-        return function(msg)
-                log_line_append(string.format("%s | %s | %s", level, os.date(M.time_fmt), msg))
-        end
+	return function(msg)
+		log_line_append(
+			string.format("%s | %s | %s", level, os.date(M.time_fmt), msg)
+		)
+	end
 end
 
 local log = {
-	error = make_log_level('ERROR'),
-	warn = make_log_level('WARN'),
-	info = make_log_level('INFO'),
-	debug = make_log_level('DEBUG'),
+	error = make_log_level("ERROR"),
+	warn = make_log_level("WARN"),
+	info = make_log_level("INFO"),
+	debug = make_log_level("DEBUG"),
 }
 
 -- functions copied directly by deepcopy.

--- a/lua/luasnip/util/log.lua
+++ b/lua/luasnip/util/log.lua
@@ -54,19 +54,24 @@ end
 
 local M = {}
 
+--- The file path we're currently logging into.
+function M.log_location()
+        return logpath
+end
+--- Time formatting for logs. Defaults to '%X'.
+M.time_fmt = '%X'
+
+local function make_log_level(level)
+        return function(msg)
+                log_line_append(string.format("%s | %s | %s", level, os.date(M.time_fmt), msg))
+        end
+end
+
 local log = {
-	error = function(msg)
-		log_line_append("ERROR | " .. msg)
-	end,
-	warn = function(msg)
-		log_line_append("WARN  | " .. msg)
-	end,
-	info = function(msg)
-		log_line_append("INFO  | " .. msg)
-	end,
-	debug = function(msg)
-		log_line_append("DEBUG | " .. msg)
-	end,
+	error = make_log_level('ERROR'),
+	warn = make_log_level('WARN'),
+	info = make_log_level('INFO'),
+	debug = make_log_level('DEBUG'),
 }
 
 -- functions copied directly by deepcopy.


### PR DESCRIPTION
So, for some specific debug functionality I'm adding to my config, I needed a way to get the log path used by LS, and figured other people might want to use it too.

Also, added time information to help debug other problems and/or improve understanding of when stuff happens.