### PR TITLE
Fix `apply_common_opts()` wrong substring when `opts.max_len` is set

### DIFF
--- a/lua/luasnip/nodes/util/trig_engines.lua
+++ b/lua/luasnip/nodes/util/trig_engines.lua
@@ -6,7 +6,9 @@ local default_match_pattern, default_match_plain, default_match_vim
 
 local function apply_common_opts(line_to_cursor, opts)
 	if opts and opts.max_len then
-		return line_to_cursor:sub(#line_to_cursor - opts.max_len + 1)
+		return line_to_cursor:sub(
+			math.max(0, #line_to_cursor - opts.max_len + 1)
+		)
 	else
 		return line_to_cursor
 	end


### PR DESCRIPTION
When `opts.max_len` is set and `opts.max_len` > `#line_to_cursor`, `#line_to_cursor - opts.max_len + 1` will be negative which gives the wrong substring, see doc of `string.sub`