### PR TITLE
Improve behaviour in macros

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2024 October 23
+*luasnip.txt*           For NVIM v0.8.0           Last change: 2024 October 28
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -121,13 +121,7 @@ c = {
 		end)
 		if session.config.enable_autosnippets then
 			ls_autocmd("InsertCharPre", function()
-				Luasnip_just_inserted = true
-			end)
-			ls_autocmd({ "TextChangedI", "TextChangedP" }, function()
-				if Luasnip_just_inserted then
-					require("luasnip").expand_auto()
-					Luasnip_just_inserted = nil
-				end
+				require("luasnip.util.feedkeys").feedkeys_insert("<cmd>lua require('luasnip').expand_auto()<cr>")
 			end)
 		end
 

--- a/lua/luasnip/config.lua
+++ b/lua/luasnip/config.lua
@@ -121,7 +121,9 @@ c = {
 		end)
 		if session.config.enable_autosnippets then
 			ls_autocmd("InsertCharPre", function()
-				require("luasnip.util.feedkeys").feedkeys_insert("<cmd>lua require('luasnip').expand_auto()<cr>")
+				require("luasnip.util.feedkeys").feedkeys_insert(
+					"<cmd>lua require('luasnip').expand_auto()<cr>"
+				)
 			end)
 		end
 

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -6,6 +6,7 @@ local node_util = require("luasnip.nodes.util")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local extend_decorator = require("luasnip.util.extend_decorator")
+local feedkeys = require("luasnip.util.feedkeys")
 
 local function I(pos, static_text, opts)
 	static_text = util.to_string_table(static_text)
@@ -49,16 +50,7 @@ function ExitNode:input_enter(no_move, dry_run)
 		self.parent:subtree_set_pos_rgrav(begin_pos, 1, true)
 
 		if not no_move then
-			if vim.fn.mode() == "i" then
-				util.insert_move_on(begin_pos)
-			else
-				vim.api.nvim_feedkeys(
-					vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
-					"n",
-					true
-				)
-				util.normal_move_on_insert(begin_pos)
-			end
+			feedkeys.insert_at(begin_pos)
 		end
 
 		self:event(events.enter)
@@ -122,20 +114,9 @@ function InsertNode:input_enter(no_move, dry_run)
 		-- SELECT snippet text only when there is text to select (more oft than not there isnt).
 		local mark_begin_pos, mark_end_pos = self.mark:pos_begin_end_raw()
 		if not util.pos_equal(mark_begin_pos, mark_end_pos) then
-			util.any_select(mark_begin_pos, mark_end_pos)
+			feedkeys.select_range(mark_begin_pos, mark_end_pos)
 		else
-			-- if current and target mode is INSERT, there's no reason to leave it.
-			if vim.fn.mode() == "i" then
-				util.insert_move_on(mark_begin_pos)
-			else
-				-- mode might be VISUAL or something else, but <Esc> always leads to normal.
-				vim.api.nvim_feedkeys(
-					vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
-					"n",
-					true
-				)
-				util.normal_move_on_insert(mark_begin_pos)
-			end
+			feedkeys.insert_at(mark_begin_pos)
 		end
 	end
 

--- a/lua/luasnip/nodes/textNode.lua
+++ b/lua/luasnip/nodes/textNode.lua
@@ -3,6 +3,7 @@ local util = require("luasnip.util.util")
 local types = require("luasnip.util.types")
 local events = require("luasnip.util.events")
 local extend_decorator = require("luasnip.util.extend_decorator")
+local feedkeys = require("luasnip.util.feedkeys")
 
 local TextNode = node_mod.Node:new()
 
@@ -25,16 +26,7 @@ function TextNode:input_enter(no_move, dry_run)
 
 	if not no_move then
 		local mark_begin_pos = self.mark:pos_begin_raw()
-		if vim.fn.mode() == "i" then
-			util.insert_move_on(mark_begin_pos)
-		else
-			vim.api.nvim_feedkeys(
-				vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
-				"n",
-				true
-			)
-			util.normal_move_on_insert(mark_begin_pos)
-		end
+		feedkeys.insert_at(mark_begin_pos)
 	end
 
 	self:event(events.enter, no_move)

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -3,6 +3,7 @@ local ext_util = require("luasnip.util.ext_opts")
 local types = require("luasnip.util.types")
 local key_indexer = require("luasnip.nodes.key_indexer")
 local session = require("luasnip.session")
+local feedkeys = require("luasnip.util.feedkeys")
 
 local function subsnip_init_children(parent, children)
 	for _, child in ipairs(children) do
@@ -125,7 +126,7 @@ end
 
 local function select_node(node)
 	local node_begin, node_end = node.mark:pos_begin_end_raw()
-	util.any_select(node_begin, node_end)
+	feedkeys.select_range(node_begin, node_end)
 end
 
 local function print_dict(dict)

--- a/lua/luasnip/util/feedkeys.lua
+++ b/lua/luasnip/util/feedkeys.lua
@@ -27,7 +27,15 @@ local enqueued_actions = {}
 local function _feedkeys_insert(id, keys)
 	executing_id = id
 	vim.api.nvim_feedkeys(
-		vim.api.nvim_replace_termcodes(keys .. "<cmd>lua require('luasnip.util.feedkeys').confirm(" .. id .. ")<cr>", true, false, true),
+		vim.api.nvim_replace_termcodes(
+			keys
+				.. "<cmd>lua require('luasnip.util.feedkeys').confirm("
+				.. id
+				.. ")<cr>",
+			true,
+			false,
+			true
+		),
 		-- folds are opened manually now, no need to pass t.
 		-- n prevents langmap from interfering.
 		"ni",
@@ -132,9 +140,9 @@ end
 function M.confirm(id)
 	executing_id = nil
 
-	if enqueued_actions[id+1] then
-		enqueued_actions[id+1](id+1)
-		enqueued_actions[id+1] = nil
+	if enqueued_actions[id + 1] then
+		enqueued_actions[id + 1](id + 1)
+		enqueued_actions[id + 1] = nil
 	end
 end
 

--- a/lua/luasnip/util/feedkeys.lua
+++ b/lua/luasnip/util/feedkeys.lua
@@ -1,0 +1,141 @@
+-- insert operations into typeahead buffer in a controlled manner.
+-- We want to follow these guidelines:
+-- * maintain order of luasnip-operations. Example:
+--   `ls.jump() ls.jump()`, the first jump is completely executed, and only
+--   then the second jump is.
+-- * insert our operations before other typeahead.
+--   This is to behave correctly in a macro: IIUC the complete macro is written
+--   into typeahead, so if our operations are appended, we will jump way later
+--   than in the actual recorded "session", and input won't end up where it
+--   belongs.
+--
+-- We will achieve these goals by only ever having one operation in the
+-- typeahead, and once it is finished it calls a callback that will insert any
+-- other keys that were requested to be executed.
+--
+-- This scheme is inspired by @hrsh7th's work in nvim-cmp.
+local util = require("luasnip.util.util")
+
+local M = {}
+
+local current_id = 0
+local executing_id = nil
+
+-- contains functions which take exactly one argument, the id.
+local enqueued_actions = {}
+
+local function _feedkeys_insert(id, keys)
+	executing_id = id
+	vim.api.nvim_feedkeys(
+		vim.api.nvim_replace_termcodes(keys .. "<cmd>lua require('luasnip.util.feedkeys').confirm(" .. id .. ")<cr>", true, false, true),
+		-- folds are opened manually now, no need to pass t.
+		-- n prevents langmap from interfering.
+		"ni",
+		true
+	)
+end
+
+local function enqueue_action(fn)
+	-- get unique id and increment global.
+	local keys_id = current_id
+	current_id = current_id + 1
+
+	-- if there is nothing from luasnip currently executing, we may just insert
+	-- into the typeahead
+	if executing_id == nil then
+		fn(keys_id)
+	else
+		enqueued_actions[keys_id] = fn
+	end
+end
+
+function M.feedkeys_insert(keys)
+	enqueue_action(function(id)
+		_feedkeys_insert(id, keys)
+	end)
+end
+
+-- pos: (0,0)-indexed.
+local function cursor_set_keys(pos, before)
+	if before then
+		if pos[2] == 0 then
+			pos[1] = pos[1] - 1
+			-- pos2 is set to last columnt of previous line.
+			-- # counts bytes, but win_set_cursor expects bytes, so all's good.
+			pos[2] =
+				#vim.api.nvim_buf_get_lines(0, pos[1], pos[1] + 1, false)[1]
+		else
+			pos[2] = pos[2] - 1
+		end
+	end
+
+	return "<cmd>lua vim.api.nvim_win_set_cursor(0,{"
+		-- +1, win_set_cursor starts at 1.
+		.. pos[1] + 1
+		.. ","
+		-- -1 works for multibyte because of rounding, apparently.
+		.. pos[2]
+		.. "})"
+		.. "<cr><cmd>:silent! foldopen!<cr>"
+end
+
+function M.select_range(b, e)
+	enqueue_action(function(id)
+		-- stylua: ignore
+		_feedkeys_insert(id,
+			-- this esc -> movement sometimes leads to a slight flicker
+			-- TODO: look into preventing that reliably.
+			-- Go into visual, then place endpoints.
+			-- This is to allow us to place the cursor on the \n of a line.
+			-- see #1158
+			"<esc>"
+			-- open folds that contain this selection.
+			-- we assume that the selection is contained in at most one fold, and
+			-- that that fold covers b.
+			-- if we open the fold while visual is active, the selection will be
+			-- wrong, so this is necessary before we enter VISUAL.
+			.. cursor_set_keys(b)
+			-- start visual highlight and move to b again.
+			-- since we are now in visual, this might actually move the cursor.
+			.. "v"
+			.. cursor_set_keys(b)
+			-- swap to other end of selection, and move it to e.
+			.. "o"
+			.. (vim.o.selection == "exclusive" and
+				cursor_set_keys(e) or
+				-- set before
+				cursor_set_keys(e, true))
+			.. "o<C-G><C-r>_" )
+	end)
+end
+
+-- move the cursor to a position and enter insert-mode (or stay in it).
+function M.insert_at(pos)
+	enqueue_action(function(id)
+		-- if current and target mode is INSERT, there's no reason to leave it.
+		if vim.fn.mode() == "i" then
+			-- can skip feedkeys here, we can complete this command from lua.
+			-- Just have to make sure to call confirm afterward, since there
+			-- may be more actions enqueued.
+			-- We don't have to set the executing_id, since there's no way
+			-- enqueue_action could be called before `confirm`.
+			util.set_cursor_0ind(pos)
+			vim.api.nvim_command("redraw!")
+			M.confirm(id)
+		else
+			-- mode might be VISUAL or something else => <Esc> to know we're in NORMAL.
+			_feedkeys_insert(id, "<Esc>i" .. cursor_set_keys(pos))
+		end
+	end)
+end
+
+function M.confirm(id)
+	executing_id = nil
+
+	if enqueued_actions[id+1] then
+		enqueued_actions[id+1](id+1)
+		enqueued_actions[id+1] = nil
+	end
+end
+
+return M

--- a/tests/integration/choice_spec.lua
+++ b/tests/integration/choice_spec.lua
@@ -98,9 +98,7 @@ describe("ChoiceNode", function()
 		-- change text in insertNode.
 		feed("c")
 		exec_lua("ls.jump(1)")
-		exec_lua("vim.wait(10, function() end)")
 		exec_lua("ls.change_choice(1)")
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			c ^b                                               |
@@ -118,9 +116,7 @@ describe("ChoiceNode", function()
 
 		-- change choice on outer choiceNode.
 		exec_lua("ls.jump(-1)")
-		exec_lua("vim.wait(10, function() end)")
 		exec_lua("ls.change_choice(1)")
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			^b                                                 |

--- a/tests/integration/jump_spec.lua
+++ b/tests/integration/jump_spec.lua
@@ -139,7 +139,6 @@ describe("Jumping", function()
 
 		-- jump into restoreNode in first choice.
 		exec_lua("ls.jump(1)")
-		exec_lua("vim.wait(10, function() end)")
 		exec_lua("ls.change_choice(1)")
 		screen:expect({
 			grid = [[

--- a/tests/integration/session_spec.lua
+++ b/tests/integration/session_spec.lua
@@ -2156,7 +2156,8 @@ describe("session", function()
 				{0:~                                                 }|
 				{0:~                                                 }|
 				{0:~                                                 }|
-				{2:-- INSERT --recording @a}                          |]] })
+				{2:-- INSERT --recording @a}                          |]],
+		})
 		change()
 		jump()
 		screen:expect({
@@ -2190,7 +2191,8 @@ describe("session", function()
 				{0:~                                                 }|
 				{0:~                                                 }|
 				{0:~                                                 }|
-				{2:-- INSERT --recording @a}                          |]] })
+				{2:-- INSERT --recording @a}                          |]],
+		})
 		change()
 		feed("aa")
 		jump()
@@ -2229,7 +2231,8 @@ describe("session", function()
 				{0:~                                                 }|
 				{0:~                                                 }|
 				{0:~                                                 }|
-				{2:-- INSERT --recording @a}                          |]] })
+				{2:-- INSERT --recording @a}                          |]],
+		})
 		feed("cc<Esc>Gqo<Esc>@a")
 		screen:expect({
 			grid = [[
@@ -2262,6 +2265,7 @@ describe("session", function()
 				{0:~                                                 }|
 				{0:~                                                 }|
 				{0:~                                                 }|
-				                                                  |]] })
+				                                                  |]],
+		})
 	end)
 end)

--- a/tests/integration/session_spec.lua
+++ b/tests/integration/session_spec.lua
@@ -151,7 +151,6 @@ describe("session", function()
 	it("Deleted snippet is handled properly in expansion.", function()
 		feed("o<Cr><Cr><Up>fn")
 		exec_lua("ls.expand()")
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			                                                  |
@@ -186,11 +185,8 @@ describe("session", function()
 			{2:-- INSERT --}                                      |]],
 		})
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			                                                  |
@@ -233,7 +229,6 @@ describe("session", function()
 		-- if we did something wrong.
 		jump(-1)
 		jump(-1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			^/**                                               |
@@ -275,7 +270,6 @@ describe("session", function()
 		jump(1)
 		jump(1)
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			/**                                               |
@@ -310,13 +304,11 @@ describe("session", function()
 			{2:-- INSERT --}                                      |]],
 		})
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({ unchanged = true })
 	end)
 	it("Deleted snippet is handled properly when jumping.", function()
 		feed("o<Cr><Cr><Up>fn")
 		exec_lua("ls.expand()")
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			                                                  |
@@ -351,11 +343,8 @@ describe("session", function()
 			{2:-- INSERT --}                                      |]],
 		})
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			                                                  |
@@ -1384,17 +1373,11 @@ describe("session", function()
 		expand()
 		-- jump to one before jumping out of child-snippet.
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			/**                                               |
@@ -1565,7 +1548,6 @@ describe("session", function()
 		jump(1)
 		jump(1)
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			/**                                               |
@@ -1639,11 +1621,8 @@ describe("session", function()
 
 		-- check connectivity.
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			/**                                               |
@@ -1724,21 +1703,13 @@ describe("session", function()
 
 		-- end up back in last node, not in textNode-expanded snippet.
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		jump(1)
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			/**                                               |
@@ -2025,11 +1996,8 @@ describe("session", function()
 			feed("o<Cr><Cr><Cr><Esc>kkifn")
 			expand()
 			jump(1)
-			exec_lua("vim.wait(10, function() end)")
 			jump(1)
-			exec_lua("vim.wait(10, function() end)")
 			jump(1)
-			exec_lua("vim.wait(10, function() end)")
 			feed("int a")
 			screen:expect({
 				grid = [[
@@ -2144,4 +2112,156 @@ describe("session", function()
 			})
 		end
 	)
+
+	it("macro-replay is correct.", function()
+		local function expand()
+			feed("<Plug>luasnip-expand-snippet")
+		end
+		local function jump()
+			feed("<Plug>luasnip-jump-next")
+		end
+		local function change()
+			feed("<Plug>luasnip-next-choice")
+		end
+		feed("qaifn")
+		expand()
+		screen:expect({
+			grid = [[
+				/**                                               |
+				 * A short Description                            |
+				 */                                               |
+				^public void myFunc() { {4:●}                          |
+				                                                  |
+				}                                                 |
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{2:-- INSERT --recording @a}                          |]] })
+		change()
+		jump()
+		screen:expect({
+			grid = [[
+				/**                                               |
+				 * A short Description                            |
+				 */                                               |
+				private ^void myFunc() { {4:●}                         |
+				                                                  |
+				}                                                 |
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{2:-- INSERT --recording @a}                          |]] })
+		change()
+		feed("aa")
+		jump()
+		feed("bb")
+		jump()
+		jump()
+		change()
+		screen:expect({
+			grid = [[
+				/**                                               |
+				 * A short Description                            |
+				 *                                                |
+				 * @return                                        |
+				 *                                                |
+				 * @throws                                        |
+				 */                                               |
+				private aa bb() {4:●}                                 |
+				 throws ^ {                                        |
+				                                                  |
+				}                                                 |
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{2:-- INSERT --recording @a}                          |]] })
+		feed("cc<Esc>Gqo<Esc>@a")
+		screen:expect({
+			grid = [[
+				/**                                               |
+				 * A short Description                            |
+				 *                                                |
+				 * @return                                        |
+				 *                                                |
+				 * @throws cc                                     |
+				 */                                               |
+				private aa bb()                                   |
+				 throws cc {                                      |
+				                                                  |
+				}                                                 |
+				/**                                               |
+				 * A short Description                            |
+				 *                                                |
+				 * @return                                        |
+				 *                                                |
+				 * @throws                                        |
+				 */                                               |
+				private aa bb() {4:●}                                 |
+				 throws cc {                                      |
+				                                                  |
+				^}                                                 |
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				{0:~                                                 }|
+				                                                  |]] })
+	end)
 end)

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -47,8 +47,6 @@ describe("snippets_basic", function()
 	end)
 
 	it("Can accept custom jump_into_func.", function()
-		local snip = [[
-		]]
 		exec_lua([[
 			ls.add_snippets("all", {
 				s("trig", {
@@ -190,7 +188,6 @@ describe("snippets_basic", function()
 		exec_lua("ls.snip_expand(" .. snip .. ")")
 		exec_lua("vim.wait(10, function() end)")
 		exec_lua("ls.snip_expand(" .. snip .. ")")
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			a[a[^]ab]ab                                        |
@@ -201,7 +198,6 @@ describe("snippets_basic", function()
 
 		-- jump into second of inner.
 		exec_lua("ls.jump(1)")
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			a[a[]a^b]ab                                        |
@@ -350,6 +346,7 @@ describe("snippets_basic", function()
 			}) )
 		]]
 			exec_lua(expand_snip)
+			exec_lua("vim.wait(10, function() end)")
 			exec_lua(expand_snip)
 			screen:expect({
 				grid = [[
@@ -1260,9 +1257,7 @@ describe("snippets_basic", function()
 
 		feed("aa")
 		exec_lua([[ ls.expand() ]])
-		exec_lua("vim.wait(10, function() end)")
 		exec_lua([[ ls.jump(1) ]])
-		exec_lua("vim.wait(10, function() end)")
 		screen:expect({
 			grid = [[
 			a:(a:(^))                                          |
@@ -1646,5 +1641,18 @@ describe("snippets_basic", function()
 				{0:~                                                 }|
 				{2:-- INSERT --}                                      |]],
 		})
+	end)
+
+	it("autosnippets are triggered in macro.", function()
+		exec_lua([[
+			ls.add_snippets("all", {
+				s({trig="qwer", snippetType="autosnippet"}, { t"asdf" }) })
+		]])
+		feed("qaiqwer<Esc>qo<Esc>@a")
+		screen:expect({
+			grid = [[
+			  qwer                                              |
+			  qwe^r                                              |
+			                                                    |]]})
 	end)
 end)

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -1653,6 +1653,7 @@ describe("snippets_basic", function()
 			grid = [[
 			  qwer                                              |
 			  qwe^r                                              |
-			                                                    |]]})
+			                                                    |]],
+		})
 	end)
 end)


### PR DESCRIPTION
Currently, there are a few issues with recording and replaying a snippet-expansion via a macro:
* autosnippets are not expanded at all (#1243)
This is because we use a TextChangedI-hook for triggering them, but this is not called while the typeahead is non-empty, which is the case when replaying a macro
* inputs are not inserted correctly into insertNodes
This happens because we have to use `feedkeys` to select nodes and move the cursor around, and currently use `"n"`, which appends to the typeahead, which currently contains all the keys of the macro, which means that the jump in the replay is performed at another point in time than in the original session.

This patch solves both of these problems by building a kind of queue that inserts the actions we want to perform at the beginning of the typeahed (so they happen at the correct time when being replayed!) while also maintaining the order in which the actions were inserted (an action will complete before an action enqueued after it will begin execution)
In practice, this slightly roundabout way of doing things should not be noticeable, and ensure correct ordering of all actions that use the `feedkeys`-mechanism.

Here's a quick example of the flawless replay :)

https://github.com/user-attachments/assets/cce841fe-fc01-4fa6-8744-2e5e0a8e8af3