### PR TITLE
fix(jsregexp): fix install_jsregexp on Windows

### DIFF
--- a/.github/data/project-dictionary.txt
+++ b/.github/data/project-dictionary.txt
@@ -105,3 +105,12 @@ there'd
 truthy
 varargs
 vsnip
+Unix
+MinGW
+CC's
+usr
+gcc
+exe
+Makefile's
+MSYS
+SHELLFLAGS

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ nvim: | ${NVIM_PATH}
 	git -C ${NVIM_MASTER_PATH} fetch origin master --depth 1
 	git -C ${NVIM_MASTER_PATH} checkout FETCH_HEAD
 
-LUASNIP_DETECTED_OS?=$(shell uname)
+LUASNIP_DETECTED_OS?=$(shell uname 2>/dev/null)
 ifeq ($(LUASNIP_DETECTED_OS),Darwin)
 	# flags for dynamic linking on macos, from luarocks
 	# (https://github.com/luarocks/luarocks/blob/9a3c5a879849f4f411a96cf1bdc0c4c7e26ade42/src/luarocks/core/cfg.lua#LL468C37-L468C80)
@@ -41,28 +41,61 @@ ifeq ($(LUASNIP_DETECTED_OS),Darwin)
 	LUA_LDLIBS=-undefined dynamic_lookup -all_load
 endif
 
-JSREGEXP_PATH=deps/jsregexp
-JSREGEXP005_PATH=deps/jsregexp005
+# Windows may have $OS env been set natively
+OS_ENV?=$(OS)
+ifeq ($(OS_ENV),Windows_NT)
+	LUASNIP_DETECTED_OS:=Windows
+endif
+# Example output on Windows: MINGW64_NT-10.0-19045 DESKTOP-ABCDE 3.4.10-1234567.x86_64 2024-02-14 20:17 UTC x86_64 Msys
+UNAME_ALL:=$(shell uname -a 2>/dev/null)
+ifneq (,$(findstring MINGW,$(UNAME_ALL)))
+	LUASNIP_DETECTED_OS:=Windows
+endif
+ifneq (,$(findstring Msys,$(UNAME_ALL)))
+	LUASNIP_DETECTED_OS:=Windows
+endif
+
+# On Windows, you may need to set:
+# 	SHELL=C:/path/to/Git/usr/bin/sh.exe
+# 	.SHELLFLAGS=-c
+# 	CC=gcc
+#	NEOVIM_BIN_PATH=C:/path/to/Neovim/bin # contains lua51.dll, or use your own LUA_LDLIBS
+ifeq ($(LUASNIP_DETECTED_OS),Windows)
+	# If neovim is installed by scoop, only scoop/shims is exposed. We need to find original nvim/bin that contains lua51.dll
+	# If neovim is installed by winget or other methods, nvim/bin is already included in PATH.
+	NEOVIM_BIN_PATH?=$(shell \
+		if (scoop prefix neovim | grep -v 'Could not find app path for') >/dev/null 2>&1; then \
+			echo "$$(scoop prefix neovim)/bin" | sed 's/\\\\/\\//g' | sed 's/\\(.*\\) \\(.*\\)/"\\1 \\2"/'; \
+		elif which nvim > /dev/null 2>&1; then \
+			dirname "$$(which nvim)" | sed 's/^\\/\\(.\\)\\//\\U\\1:\\//' | sed 's/\\(.*\\) \\(.*\\)/"\\1 \\2"/'; \
+		fi)
+
+	LUA_LDLIBS?=$(if $(strip $(NEOVIM_BIN_PATH)),-L$(NEOVIM_BIN_PATH) -llua51,)
+endif
+
+PROJECT_ROOT:=$(shell pwd 2>/dev/null)
+JSREGEXP_PATH=$(PROJECT_ROOT)/deps/jsregexp
+JSREGEXP005_PATH=$(PROJECT_ROOT)/deps/jsregexp005
 jsregexp:
 	git submodule init
 	git submodule update
-	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I'$(shell pwd)/deps/lua51_include/'" LDLIBS="${LUA_LDLIBS}" -C "${JSREGEXP_PATH}"
-	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I'$(shell pwd)/deps/lua51_include/'" LDLIBS="${LUA_LDLIBS}" -C "${JSREGEXP005_PATH}"
+	$(MAKE) "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" LDLIBS='$(LUA_LDLIBS)' -C "$(JSREGEXP_PATH)"
+	$(MAKE) "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" LDLIBS='$(LUA_LDLIBS)' -C "$(JSREGEXP005_PATH)"
 
 install_jsregexp: jsregexp
 	# remove old binary.
-	rm "$(shell pwd)/lua/luasnip-jsregexp.so" || true
+	rm "$(PROJECT_ROOT)/lua/luasnip-jsregexp.so" || true
 	# there is some additional trickery to make this work with jsregexp-0.0.6 in
 	# util/jsregexp.lua.
-	cp "$(shell pwd)/${JSREGEXP_PATH}/jsregexp.lua" "$(shell pwd)/lua/luasnip-jsregexp.lua"
+	cp "$(JSREGEXP_PATH)/jsregexp.lua" "$(PROJECT_ROOT)/lua/luasnip-jsregexp.lua"
 	# just move out of jsregexp-directory, so it is not accidentially deleted.
-	cp "$(shell pwd)/${JSREGEXP_PATH}/jsregexp.so" "$(shell pwd)/deps/luasnip-jsregexp.so"
+	cp "$(JSREGEXP_PATH)/jsregexp.so" "$(PROJECT_ROOT)/deps/luasnip-jsregexp.so"
 
 uninstall_jsregexp:
 	# also remove binaries of older version.
-	rm -f "$(shell pwd)/lua/luasnip-jsregexp.so"
-	rm -f "$(shell pwd)/deps/luasnip-jsregexp.so"
-	rm -f "$(shell pwd)/lua/luasnip-jsregexp.lua"
+	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.so"
+	rm -f "$(PROJECT_ROOT)/deps/luasnip-jsregexp.so"
+	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.lua"
 
 TEST_07?=true
 TEST_09?=true
@@ -73,11 +106,11 @@ test: nvim install_jsregexp
 	# add our helper-functions to lpath.
 	# exit as soon as an error occurs.
 	unset LUA_PATH LUA_CPATH; \
-	export LUASNIP_SOURCE=$(shell pwd); \
-	export JSREGEXP_ABS_PATH=$(shell pwd)/${JSREGEXP_PATH}; \
-	export JSREGEXP005_ABS_PATH=$(shell pwd)/${JSREGEXP005_PATH}; \
+	export LUASNIP_SOURCE=$(PROJECT_ROOT); \
+	export JSREGEXP_ABS_PATH=$(JSREGEXP_PATH); \
+	export JSREGEXP005_ABS_PATH=$(JSREGEXP005_PATH); \
 	export TEST_FILE=$(realpath ${TEST_FILE}); \
-	export BUSTED_ARGS=--lpath=$(shell pwd)/tests/?.lua; \
+	export BUSTED_ARGS=--lpath=$(PROJECT_ROOT)/tests/?.lua; \
 	set -e; \
 	if ${TEST_07}; then "$(MAKE)" -C ${NVIM_0.7_PATH} functionaltest DEPS_CMAKE_FLAGS=-DUSE_BUNDLED_GPERF=OFF; fi; \
 	if ${TEST_09}; then "$(MAKE)" -C ${NVIM_0.9_PATH} functionaltest; fi; \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Neovim >= 0.7 (extmarks)
 `jsregexp` for `lsp-snippet-transformations` (see [here](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#transformations) for some tips on installing it).
 
 # Setup
-## Install 
+## Install
 * With your preferred plugin manager i.e. [vim-plug](https://github.com/junegunn/vim-plug), [Packer](https://github.com/wbthomason/packer.nvim) or [lazy](https://github.com/folke/lazy.nvim)  
   **Packer**:
   ```lua
@@ -60,6 +60,19 @@ Neovim >= 0.7 (extmarks)
   Releases will be tagged as `vMajor.Minor.Patch`, we recommend following the latest Major release.  
   Consider watching the repository's releases so you're notified when a new version becomes available.
 
+> [!NOTE]
+> On Windows, you need to use a shell that can run Unix commands (MinGW,MSYS2,etc).
+> Luckily, Git offers a `sh.exe`, so you don't need to install a heavy MSYS2 environment.
+> Other than Git, you also need a C compiler and `make` to install `jsregexp`.
+> You may also need to change the build command: `make install_jsregexp CC=gcc.exe SHELL=C:/path/to/sh.exe .SHELLFLAGS=-c`:
+
+```text
+SHELL=C:/path/to/Git/usr/bin/sh.exe # if Git/MinGW/MSYS2 `sh.exe` is not in PATH
+.SHELLFLAGS=-c # if Git/MinGW/MSYS2 `sh.exe` is not in PATH
+CC=gcc.exe # if CC's default value cc is not set (when `which cc` fails to find the compiler command)
+NEOVIM_BIN_PATH=C:/path/to/Neovim/bin # if the Makefile's fails to automatically detect the Neovim/bin path
+```
+
 ## Keymaps
 In Vim script, with `<Tab>` for jumping forward/expanding a snippet, `<Shift-Tab>` for
 jumping backward, and `<Ctrl-E>` for changing the current choice when in a
@@ -67,7 +80,7 @@ jumping backward, and `<Ctrl-E>` for changing the current choice when in a
 ```vim
 " press <Tab> to expand or jump in a snippet. These can also be mapped separately
 " via <Plug>luasnip-expand-snippet and <Plug>luasnip-jump-next.
-imap <silent><expr> <Tab> luasnip#expand_or_jumpable() ? '<Plug>luasnip-expand-or-jump' : '<Tab>' 
+imap <silent><expr> <Tab> luasnip#expand_or_jumpable() ? '<Plug>luasnip-expand-or-jump' : '<Tab>'
 " -1 for jumping backwards.
 inoremap <silent> <S-Tab> <cmd>lua require'luasnip'.jump(-1)<Cr>
 
@@ -177,7 +190,7 @@ Note: instead of immediately reading the official documentation, you may want to
 - The [Wiki](https://github.com/L3MON4D3/LuaSnip/wiki) contains some useful LuaSnip extensions and some examples of advanced snippets and configs.
 - Configuration is documented [in `DOC.md`](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#config-options) as well.
 
-【中文版】DOC in Chinese is [here](https://zjp-cn.github.io/neovim0.6-blogs/nvim/luasnip/doc1.html). 
+【中文版】DOC in Chinese is [here](https://zjp-cn.github.io/neovim0.6-blogs/nvim/luasnip/doc1.html).
 
 ### Resources for new users
 Here are some LuaSnip videos and tutorials on the Web:

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 10
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 11
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 06
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 10
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*


### PR DESCRIPTION
Users on Windows may install neovim by many means:

1. `scoop install neovim`: `which nvim` shows `~/scoop/shims/nvim`
2. `winget install neovim` or manually download Windows installer and set env: `which nvim` shows `C:/Program Files/Neovim/bin/nvim`

Either way, we can use `lua51.dll` in the original `nvim` directory (`$(scoop prefix neovim)/bin` or `C:/Program Files/Neovim/bin/nvim`)

Care must be taken when path contains spaces. Quotes are needed to let gcc understand `L"C:/Program Files/..."` such directories.

> [!NOTE]
> Users may also need to set:
>   SHELL=C:/path/to/Git/usr/bin/sh.exe # if git sh.exe is not in PATH
>   .SHELLFLAGS=-c # if git sh.exe is not in PATH
>   CC=gcc # if default cc is not set to any compiler
>   NEOVIM_BIN_PATH=C:/path/to/Neovim/bin # if Neovim/bin is not detected by the Makefile

Related: #759 #986 #1130 #1190 #1220