### PR TITLE
fix(Makefile): defensively validate scoop output path

### DIFF
--- a/.github/data/project-dictionary.txt
+++ b/.github/data/project-dictionary.txt
@@ -111,6 +111,5 @@ CC's
 usr
 gcc
 exe
-Makefile's
 MSYS
 SHELLFLAGS

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Neovim >= 0.7 (extmarks)
 SHELL=C:/path/to/Git/usr/bin/sh.exe # if Git/MinGW/MSYS2 `sh.exe` is not in PATH
 .SHELLFLAGS=-c # if Git/MinGW/MSYS2 `sh.exe` is not in PATH
 CC=gcc.exe # if CC's default value cc is not set (when `which cc` fails to find the compiler command)
-NEOVIM_BIN_PATH=C:/path/to/Neovim/bin # if the Makefile's fails to automatically detect the Neovim/bin path
+NEOVIM_BIN_PATH=C:/path/to/Neovim/bin # if the Makefile fails to automatically detect the Neovim/bin path
 ```
 
 ## Keymaps

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 11
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 12
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*


### PR DESCRIPTION
`scoop prefix package` on Git Bash returns 0 and writes error to stdout even if scoop does not find the `package`. (<https://github.com/ScoopInstaller/Scoop/issues/6228>)

Both #1252 and this change will work if future scoop returns 1 for unknown `package`

---

#1252 will fail when the followings happen:

1. scoop still returns 0 for unknown `package` **AND**
2. `grep -v 'Could not find app path for'` fails by
  2.1. scoop changes error message of `scoop prefix package`, **OR**
  2.2. `scoop prefix neovim` returns a path that contains `Could not find app path for` (very rare)

The following change enables defensive path validation against the output. Works on either forward slash or backslash as path separator.

```diff
-               if (scoop prefix neovim | grep -v 'Could not find app path for') >/dev/null 2>&1; then \
+               if (scoop prefix neovim | grep '^[A-Z]:[/\\]') >/dev/null 2>&1; then \
```
