### PR TITLE
Add indent string conversion in fmt for multiline string

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1526,6 +1526,23 @@ ls.add_snippets("all", {
   }, {
     repeat_duplicates = true
   }))
+  s("example5", fmt([[
+    line1: no indent
+
+      line3: 2 space -> 1 indent ('\t')
+        line4: 4 space -> 2 indent ('\t\t')
+  ]], {}, {
+    indent_string = "  "
+  }))
+  -- NOTE: [[\t]] means '\\t'
+  s("example6", fmt([[
+    line1: no indent
+
+    \tline3: '\\t' -> 1 indent ('\t')
+    \t\tline4: '\\t\\t' -> 2 indent ('\t\t')
+  ]], {}, {
+    indent_string = [[\t]]
+  }))
 })
 ```
 
@@ -1560,6 +1577,9 @@ any way, correspond to the jump-index of the nodes!
   	when passing multiline strings via `[[]]` (default true).
   * `dedent`: remove indent common to all lines in `format`. Again, makes
   	passing multiline-strings a bit nicer (default true).
+  * `indent_string`: convert `indent_string` at beginning of each line to unit
+        indent ('\t'). This is applied after `dedent`. Useful when using
+        multiline string in `fmt`. (default empty string, disabled)
   * `repeat_duplicates`: repeat nodes when a key is reused instead of copying
         the node if it has a jump-index, refer to [Basics-Jump-Index](#jump-index) to
         know which nodes have a jump-index (default false).

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 27
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 28
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -1462,7 +1462,7 @@ Simple example:
       s("example5", fmt([[
         line1: no indent
     
-          line3: two space -> 1 indent ('\t')
+          line3: 2 space -> 1 indent ('\t')
             line4: 4 space -> 2 indent ('\t\t')
       ]], {}, {
         indent_string = "  "

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 18
+*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 November 27
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -1459,6 +1459,23 @@ Simple example:
       }, {
         repeat_duplicates = true
       }))
+      s("example5", fmt([[
+        line1: no indent
+    
+          line3: two space -> 1 indent ('\t')
+            line4: 4 space -> 2 indent ('\t\t')
+      ]], {}, {
+        indent_string = "  "
+      }))
+      -- NOTE: [[\t]] means '\\t'
+      s("example6", fmt([[
+        line1: no indent
+    
+        \tline3: '\\t' -> 1 indent ('\t')
+        \t\tline4: '\\t\\t' -> 2 indent ('\t\t')
+      ]], {}, {
+        indent_string = [[\t]]
+      }))
     })
 <
 
@@ -1487,6 +1504,9 @@ any way, correspond to the jump-index of the nodes!
         when passing multiline strings via `[[]]` (default true).
     - `dedent`: remove indent common to all lines in `format`. Again, makes
         passing multiline-strings a bit nicer (default true).
+    - `indent_string`: convert `indent_string` at beginning of each line to unit
+        indent (’). This is applied after `dedent`. Useful when using
+        multiline string in `fmt`. (default empty string, disabled)
     - `repeat_duplicates`: repeat nodes when a key is reused instead of copying
         the node if it has a jump-index, refer to |luasnip-basics-jump-index| to
         know which nodes have a jump-index (default false).

--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -185,12 +185,15 @@ end
 --   opts: optional table
 --     trim_empty: boolean, remove whitespace-only first/last lines, default true
 --     dedent: boolean, remove all common indent in `str`, default true
+--     indent_string: string, convert `indent_string` at beginning of each line to unit indent ('\t')
+--                            after applying `dedent`, default empty string (disabled)
 --     ... the rest is passed to `interpolate`
 -- Returns: list of snippet nodes
 local function format_nodes(str, nodes, opts)
 	local defaults = {
 		trim_empty = true,
 		dedent = true,
+		indent_string = "",
 	}
 	opts = vim.tbl_extend("force", defaults, opts or {})
 

--- a/tests/unit/str_spec.lua
+++ b/tests/unit/str_spec.lua
@@ -60,3 +60,138 @@ describe("str.unescaped_pairs", function()
 		{ { 1, 3 }, { 5, 8 }, { 9, 11 } }
 	)
 end)
+
+describe("str.dedent", function()
+	-- apparently clear() needs to run before anything else...
+	ls_helpers.clear()
+	exec("set rtp+=" .. os.getenv("LUASNIP_SOURCE"))
+	local function get_dedent_result(input_string)
+		local result = exec_lua(
+			string.format(
+				[[return require("luasnip.util.str").dedent("%s")]],
+				input_string
+			)
+		)
+		return result
+	end
+
+	it("spaces at beginnig", function()
+		local input_table = {
+			"  line1",
+			"  ",
+			"    line3",
+			"      line4",
+		}
+		local input_string = table.concat(input_table, [[\n]])
+		local expect_table = {
+			"line1",
+			"",
+			"  line3",
+			"    line4",
+		}
+		local expected = table.concat(expect_table, "\n")
+
+		local result = get_dedent_result(input_string)
+
+		assert.are.same(expected, result)
+	end)
+	it("tabs at beginnig", function()
+		local input_table = {
+			[[\t\tline1]],
+			[[\t\t]],
+			[[\t\t\tline3]],
+			[[\t\t\t\tline4]],
+		}
+		local input_string = table.concat(input_table, [[\n]])
+		local expect_table = {
+			"line1",
+			"",
+			"\tline3",
+			"\t\tline4",
+		}
+		local expected = table.concat(expect_table, "\n")
+
+		local result = get_dedent_result(input_string)
+
+		assert.are.same(expected, result)
+	end)
+	it("tabs & spaces at beginnig", function()
+		local input_table = {
+			[[\t\t line1]],
+			[[\t\t ]],
+			[[\t\t \t  line3]],
+			[[\t\t \t\t  line4]],
+		}
+		local input_string = table.concat(input_table, [[\n]])
+		local expect_table = {
+			"line1",
+			"",
+			"\t  line3",
+			"\t\t  line4",
+		}
+		local expected = table.concat(expect_table, "\n")
+
+		local result = get_dedent_result(input_string)
+
+		assert.are.same(expected, result)
+	end)
+end)
+
+describe("str.convert_indent", function()
+	-- apparently clear() needs to run before anything else...
+	ls_helpers.clear()
+	exec("set rtp+=" .. os.getenv("LUASNIP_SOURCE"))
+	local function get_convert_indent_result(input_string, indent_string)
+		local result = exec_lua(
+			string.format(
+				[[return require("luasnip.util.str").convert_indent("%s", "%s")]],
+				input_string,
+				indent_string
+			)
+		)
+		return result
+	end
+
+	it("two spaces to tab", function()
+		local input_table = {
+			"line1: no indent",
+			"",
+			"  line3: 1 indent",
+			"    line4: 2 indent",
+		}
+		local input_string = table.concat(input_table, [[\n]])
+		local indent_string = "  "
+		local expect_table = {
+			"line1: no indent",
+			"",
+			"\tline3: 1 indent",
+			"\t\tline4: 2 indent",
+		}
+		local expected = table.concat(expect_table, "\n")
+
+		local result = get_convert_indent_result(input_string, indent_string)
+
+		assert.are.same(expected, result)
+	end)
+	it([[literal \t to tab]], function()
+		local input_table = {
+			"line1: no indent",
+			"",
+			[[\\tline3: 1 indent]],
+			[[\\t\\tline4: 2 indent]],
+		}
+		local input_string = table.concat(input_table, [[\n]])
+		local indent_string = [[\\t]]
+		local expect_table = {
+			"line1: no indent",
+			"",
+			"\tline3: 1 indent",
+			"\t\tline4: 2 indent",
+		}
+		local expected = table.concat(expect_table, "\n")
+
+		local result = get_convert_indent_result(input_string, indent_string)
+
+		assert.are.same(expected, result)
+	end)
+end)


### PR DESCRIPTION
- Problem:

The following code outputs spaces instead of tabs `'\t'`:

```lua
fmt([[
  line1 (no spaces after dedent)

    line3: -> '  line3' (two spaces)
      line4: -> '    line4' (4 spaces)
]], {}, { dedent = true })
```

The following does not output tabs:

```lua
fmt([[
  line1 (no spaces after dedent)

  \tline3: -> '\\tline3'
  \t\tline4: -> '\\t\\tline3'
]], {}, { dedent = true })
```

- Solution:

This PR adds option `indent_string` to `fmt`, default to empty string (disabled for backward compatibility).

Users can specify `indent_string` to let `fmt` convert them to tabs `'\t'`:

```lua
fmt([[
  line1 (no spaces after dedent)

  \tlin3: 1 indent ('\\t' -> '\t')
  \t\tlin4: 2 indent ('\\t\\t' -> '\t\t')
]], {}, { indent_string = [[\t]] })
```