### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ loaders and their benefits. The following list serves only as a short overview.
     ```lua
     -- load snippets from path/of/your/nvim/config/my-cool-snippets
     require("luasnip.loaders.from_vscode").lazy_load({ paths = { "./my-cool-snippets" } })
+
+    (Note: It's mandatory to have a 'package.json' file in the snippet directory. For examples, see documentation.)
     ```
 	For more info on the VS Code loader, check the [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L501) or [documentation](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#loaders).
 


### PR DESCRIPTION
Just to make clear it's needed a 'package.json' file with proper content in order to require("luasnip.loaders.from_vscode").lazy_load({ paths = { "./my-cool-snippets" } }) to work.

I think the way this section is written right now may lead the reader to think package.json may be just a config file that can be added later on. Personally, it took me too much time to figure out this (imho) detail. This necessity wasn't entirely clear for me even after reading the documentation. I know "vscode: any directory in runtimepath that contains a package.json contributing snippets." is clear enough, sure. But, idk. I had to read this 3 times to realize I didn't had this file in my snippets folder.

Hope this 2¢ may help other anxious people like me to set their cool snippets up. This is just a suggestion, please change it if you like. Thank you.