### PR TITLE
Duplicate examples in `luasnip-extra-match` docs

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1349,7 +1349,7 @@ something other than strings).
 
 Examples:
 
-* `match(n, "^ABC$", "A")`, where `n = 1`
+* `match(n, "^ABC$", "A")`
 
   ```lua
     s("extras1", {
@@ -1364,7 +1364,7 @@ Examples:
 
   <!-- panvimdoc-ignore-end -->
 
-* `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")`, where `n = 1`
+* `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")`
 
   ```lua
   s("extras2", {
@@ -1378,7 +1378,7 @@ Examples:
   ![extras2](https://user-images.githubusercontent.com/25300418/184359435-21e4de9f-c56b-4ee1-bff4-331b68e1c537.gif)
 
   <!-- panvimdoc-ignore-end -->
-* `match(n, lambda._1:match("^" .. lambda._2 .. "$"), lambda._1:gsub("a", "e"))`, where `n = { 1, 2 }`
+* `match(n, lambda._1:match("^" .. lambda._2 .. "$"), lambda._1:gsub("a", "e"))`
 
   ```lua
   s("extras3", {

--- a/DOC.md
+++ b/DOC.md
@@ -1349,19 +1349,9 @@ something other than strings).
 
 Examples:
 
-* `match(n, "^ABC$", "A")` .
-* `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")` 
+* `match(n, "^ABC$", "A")`, where `n = 1`
 
   ```lua
-  s("trig", {
-  	i(1), t":",
-  	i(2), t"::",
-  	m({1, 2}, l._1:match("^"..l._2.."$"), l._1:gsub("a", "e"))
-  })
-  ```
-
-
-* ```lua
     s("extras1", {
       i(1), t { "", "" }, m(1, "^ABC$", "A")
     })
@@ -1369,12 +1359,14 @@ Examples:
   Inserts "A" if the node with jump-index `n` matches "ABC" exactly, nothing otherwise.
 
   <!-- panvimdoc-ignore-start -->
-  
+
   ![extras1](https://user-images.githubusercontent.com/25300418/184359431-50f90599-3db0-4df0-a3a9-27013e663649.gif)
-  
+
   <!-- panvimdoc-ignore-end -->
 
-* ```lua
+* `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")`, where `n = 1`
+
+  ```lua
   s("extras2", {
     i(1, "INPUT"), t { "", "" }, m(1, l._1:match(l._1:reverse()), "PALINDROME")
   })
@@ -1386,7 +1378,9 @@ Examples:
   ![extras2](https://user-images.githubusercontent.com/25300418/184359435-21e4de9f-c56b-4ee1-bff4-331b68e1c537.gif)
 
   <!-- panvimdoc-ignore-end -->
-* ```lua
+* `match(n, lambda._1:match("^" .. lambda._2 .. "$"), lambda._1:gsub("a", "e"))`, where `n = { 1, 2 }`
+
+  ```lua
   s("extras3", {
     i(1), t { "", "" }, i(2), t { "", "" },
     m({ 1, 2 }, l._1:match("^" .. l._2 .. "$"), l._1:gsub("a", "e"))

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0          Last change: 2024 December 30
+*luasnip.txt*           For NVIM v0.8.0           Last change: 2025 January 04
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -1324,7 +1324,7 @@ parameters as specified above). `then`’s default-value depends on the
 
 Examples:
 
-- `match(n, "^ABC$", "A")`, where `n = 1`
+- `match(n, "^ABC$", "A")`
     >lua
           s("extras1", {
             i(1), t { "", "" }, m(1, "^ABC$", "A")
@@ -1332,15 +1332,14 @@ Examples:
     <
     Inserts "A" if the node with jump-index `n` matches "ABC" exactly, nothing
     otherwise.
-- `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")`, where `n = 1`
+- `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")`
     >lua
         s("extras2", {
           i(1, "INPUT"), t { "", "" }, m(1, l._1:match(l._1:reverse()), "PALINDROME")
         })
     <
     Inserts `"PALINDROME"` if i(1) contains a palindrome.
-- `match(n, lambda._1:match("^" .. lambda._2 .. "$"), lambda._1:gsub("a", "e"))`,
-    where `n = { 1, 2 }`
+- `match(n, lambda._1:match("^" .. lambda._2 .. "$"), lambda._1:gsub("a", "e"))`
     >lua
         s("extras3", {
           i(1), t { "", "" }, i(2), t { "", "" },

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1324,29 +1324,23 @@ parameters as specified above). `then`’s default-value depends on the
 
 Examples:
 
-- `match(n, "^ABC$", "A")`.
-- `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")`
-    >lua
-        s("trig", {
-          i(1), t":",
-          i(2), t"::",
-          m({1, 2}, l._1:match("^"..l._2.."$"), l._1:gsub("a", "e"))
-        })
-    <
-- >lua
+- `match(n, "^ABC$", "A")`, where `n = 1`
+  >lua
             s("extras1", {
               i(1), t { "", "" }, m(1, "^ABC$", "A")
             })
     <
     Inserts "A" if the node with jump-index `n` matches "ABC" exactly, nothing
     otherwise.
-- >lua
+- `match(n, lambda._1:match(lambda._1:reverse()), "PALINDROME")`, where `n = 1`
+  >lua
           s("extras2", {
             i(1, "INPUT"), t { "", "" }, m(1, l._1:match(l._1:reverse()), "PALINDROME")
           })
     <
     Inserts `"PALINDROME"` if i(1) contains a palindrome.
-- >lua
+- `match(n, lambda._1:match("^" .. lambda._2 .. "$"), lambda._1:gsub("a", "e"))`, where `n = { 1, 2 }`
+  >lua
           s("extras3", {
             i(1), t { "", "" }, i(2), t { "", "" },
             m({ 1, 2 }, l._1:match("^" .. l._2 .. "$"), l._1:gsub("a", "e"))


### PR DESCRIPTION
Found duplicate examples and single-line code examples without explanations in `luasnip-extras-match`. This commit fixes this for better user readability.