### PR TITLE
feat(Makefile): enable auto detect compiler

### DIFF
--- a/.github/data/project-dictionary.txt
+++ b/.github/data/project-dictionary.txt
@@ -105,11 +105,3 @@ there'd
 truthy
 varargs
 vsnip
-Unix
-MinGW
-CC's
-usr
-gcc
-exe
-MSYS
-SHELLFLAGS

--- a/Makefile
+++ b/Makefile
@@ -11,99 +11,81 @@ NVIM_0.9_PATH=${NVIM_PATH}/${NVIM_0.9_PATH_REL}
 
 # directory as target.
 ${NVIM_PATH}:
-	# fetch current master and 0.7.0 (the minimum version we support) and 0.9.0
-	# (the minimum version for treesitter-postfix to work).
+# fetch current master and 0.7.0 (the minimum version we support) and 0.9.0
+# (the minimum version for treesitter-postfix to work).
 	git clone --bare --depth 1 https://github.com/neovim/neovim ${NVIM_PATH}
 	git -C ${NVIM_PATH} fetch --depth 1 origin tag v0.7.0
 	git -C ${NVIM_PATH} fetch --depth 1 origin tag v0.9.0
-	# create one worktree for master, and one for 0.7.
-	# The rationale behind this is that switching from 0.7 to master (and
-	# vice-versa) requires a `make distclean`, and full clean build, which takes
-	# a lot of time.
-	# The most straightforward solution seems to be too keep two worktrees, one
-	# for master, one for 0.7, and one for 0.9 which are used for the
-	# respective builds/tests.
+# create one worktree for master, and one for 0.7.
+# The rationale behind this is that switching from 0.7 to master (and
+# vice-versa) requires a `make distclean`, and full clean build, which takes
+# a lot of time.
+# The most straightforward solution seems to be too keep two worktrees, one
+# for master, one for 0.7, and one for 0.9 which are used for the
+# respective builds/tests.
 	git -C ${NVIM_PATH} worktree add ${NVIM_MASTER_PATH_REL} master
 	git -C ${NVIM_PATH} worktree add ${NVIM_0.7_PATH_REL} v0.7.0
 	git -C ${NVIM_PATH} worktree add ${NVIM_0.9_PATH_REL} v0.9.0
 
 # |: don't update `nvim` if `${NVIM_PATH}` is changed.
 nvim: | ${NVIM_PATH}
-	# only update master
+# only update master
 	git -C ${NVIM_MASTER_PATH} fetch origin master --depth 1
 	git -C ${NVIM_MASTER_PATH} checkout FETCH_HEAD
 
 LUASNIP_DETECTED_OS?=$(shell uname;)
-ifeq ($(LUASNIP_DETECTED_OS),Darwin)
-	# flags for dynamic linking on macos, from luarocks
-	# (https://github.com/luarocks/luarocks/blob/9a3c5a879849f4f411a96cf1bdc0c4c7e26ade42/src/luarocks/core/cfg.lua#LL468C37-L468C80)
-	# remove -bundle, should be equivalent to the -shared hardcoded by jsregexp.
-	LUA_LDLIBS=-undefined dynamic_lookup -all_load
+
+ifneq (,$(findstring Darwin, $(LUASNIP_DETECTED_OS)))
+# flags for dynamic linking on macos, from luarocks
+# (https://github.com/luarocks/luarocks/blob/9a3c5a879849f4f411a96cf1bdc0c4c7e26ade42/src/luarocks/core/cfg.lua#LL468C37-L468C80)
+# remove -bundle, should be equivalent to the -shared hardcoded by jsregexp.
+LUA_LDLIBS=-undefined dynamic_lookup -all_load
+else ifneq (,$(or $(findstring MINGW,$(LUASNIP_DETECTED_OS)), $(findstring MSYS,$(LUASNIP_DETECTED_OS)), $(findstring CYGWIN,$(LUASNIP_DETECTED_OS))))
+# If neovim is installed by scoop, only scoop/shims is exposed. We need to find original nvim/bin that contains lua51.dll
+# If neovim is installed by winget or other methods, nvim/bin is already included in PATH.
+
+# `scoop prefix neovim` outputs either
+# 	1. C:\Users\MyUsername\scoop\apps\neovim\current
+# 	2. Could not find app path for 'neovim'.
+# On Git Bash, scoop returns 0 and writes error to stdout in case 2. This is tracked by
+# @link: https://github.com/ScoopInstaller/Scoop/issues/6228
+# The following code will also work if future scoop returns 1 for unknown `package`
+#
+# On Git Bash, `which nvim` returns a Unix style path: `/c/Program Files/Git/bin/nvim`
+# Always convert to `C:/Program Files/Git/bin/nvim` for powershell and pwsh users
+NEOVIM_BIN_PATH:=$(or \
+	$(shell (scoop prefix neovim | grep -q '^[A-Z]:[/\\\\]') 2>/dev/null && \
+	echo "$$(scoop prefix neovim)/bin" | sed 's/\\\\/\\//g';), \
+	$(shell which nvim >/dev/null && dirname "$$(which nvim)" | sed 's/^\\/\\(.\\)\\//\\U\\1:\\//';) \
+)
+# Always double quote the absolute path as it may contain spaces
+LUA_LDLIBS?=$(if $(strip $(NEOVIM_BIN_PATH)),-L"$(NEOVIM_BIN_PATH)" -llua51,)
 endif
 
-# Windows may have $OS env been set natively
-OS_ENV?=$(OS)
-ifeq ($(OS_ENV),Windows_NT)
-	LUASNIP_DETECTED_OS:=Windows
-endif
-# Example output on Windows: MINGW64_NT-10.0-19045 DESKTOP-ABCDE 3.4.10-1234567.x86_64 2024-02-14 20:17 UTC x86_64 Msys
-UNAME_ALL:=$(shell uname -a;)
-ifneq (,$(findstring MINGW,$(UNAME_ALL)))
-	LUASNIP_DETECTED_OS:=Windows
-endif
-ifneq (,$(findstring Msys,$(UNAME_ALL)))
-	LUASNIP_DETECTED_OS:=Windows
-endif
-
-ifeq ($(LUASNIP_DETECTED_OS),Windows)
-	# If neovim is installed by scoop, only scoop/shims is exposed. We need to find original nvim/bin that contains lua51.dll
-	# If neovim is installed by winget or other methods, nvim/bin is already included in PATH.
-
-	# `scoop prefix neovim` outputs either
-	# 	1. C:\Users\MyUsername\scoop\apps\neovim\current
-	# 	2. Could not find app path for 'neovim'.
-	# On Git Bash, scoop returns 0 and writes error to stdout in case 2. This is tracked by
-	# @link: https://github.com/ScoopInstaller/Scoop/issues/6228
-	# The following code will also work if future scoop returns 1 for unknown `package`
-	#
-	# On Git Bash, `which nvim` returns a Unix style path: `/c/Program Files/Git/bin/nvim`
-	# Always convert to `C:/Program Files/Git/bin/nvim` for powershell and pwsh users
-	NEOVIM_BIN_PATH?=$(shell \
-		if (scoop prefix neovim | grep '^[A-Z]:[/\\\\]') >/dev/null 2>&1; then \
-			echo "$$(scoop prefix neovim)/bin" | sed 's/\\\\/\\//g'; \
-		elif which nvim >/dev/null 2>&1; then \
-			dirname "$$(which nvim)" | sed 's/^\\/\\(.\\)\\//\\U\\1:\\//'; \
-		fi)
-
-	# Always double quote the absolute path as it may contain spaces
-	LUA_LDLIBS?=$(if $(strip $(NEOVIM_BIN_PATH)),-L"$(NEOVIM_BIN_PATH)" -llua51,)
-endif
-
-CC_ENV:=$(shell (which $(CC) || which gcc || which clang || (which zig >/dev/null && echo "$$(which zig) cc")) 2>/dev/null;)
-ifeq (,$(CC_ENV))
+CC:=$(shell (which $(CC) || which gcc || which clang || (which zig >/dev/null && echo "$$(which zig) cc")) 2>/dev/null;)
+ifeq (,$(CC))
 $(error No compiler is provided in this environment. Please install a C compiler (gcc, clang, or zig).)
 endif
-
 PROJECT_ROOT:=$(CURDIR)
 JSREGEXP_PATH=$(PROJECT_ROOT)/deps/jsregexp
 JSREGEXP005_PATH=$(PROJECT_ROOT)/deps/jsregexp005
 jsregexp:
 	git submodule init
 	git submodule update
-	"$(MAKE)" "CC=$(CC_ENV)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" 'LDLIBS=$(LUA_LDLIBS)' -C "$(JSREGEXP_PATH)"
-	"$(MAKE)" "CC=$(CC_ENV)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" 'LDLIBS=$(LUA_LDLIBS)' -C "$(JSREGEXP005_PATH)"
+	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" 'LDLIBS=$(LUA_LDLIBS)' -C "$(JSREGEXP_PATH)"
+	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" 'LDLIBS=$(LUA_LDLIBS)' -C "$(JSREGEXP005_PATH)"
 
 install_jsregexp: jsregexp
-	# remove old binary.
+# remove old binary.
 	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.so"
-	# there is some additional trickery to make this work with jsregexp-0.0.6 in
-	# util/jsregexp.lua.
+# there is some additional trickery to make this work with jsregexp-0.0.6 in
+# util/jsregexp.lua.
 	cp "$(JSREGEXP_PATH)/jsregexp.lua" "$(PROJECT_ROOT)/lua/luasnip-jsregexp.lua"
-	# just move out of jsregexp-directory, so it is not accidentially deleted.
+# just move out of jsregexp-directory, so it is not accidentially deleted.
 	cp "$(JSREGEXP_PATH)/jsregexp.so" "$(PROJECT_ROOT)/deps/luasnip-jsregexp.so"
 
 uninstall_jsregexp:
-	# also remove binaries of older version.
+# also remove binaries of older version.
 	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.so"
 	rm -f "$(PROJECT_ROOT)/deps/luasnip-jsregexp.so"
 	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.lua"
@@ -114,10 +96,10 @@ TEST_MASTER?=true
 PREVENT_LUA_PATH_LEAK?=true
 # Expects to be run from repo-location (eg. via `make -C path/to/luasnip`).
 test: nvim install_jsregexp
-	# unset PATH and CPATH to prevent system-env leaking into the neovim-build,
-	# add our helper-functions to lpath.
-	# exit as soon as an error occurs.
-	# For some Reason, on 0.9.0, `make functionaltest` has to be preceded by a regular make for doc to build.
+# unset PATH and CPATH to prevent system-env leaking into the neovim-build,
+# add our helper-functions to lpath.
+# exit as soon as an error occurs.
+# For some Reason, on 0.9.0, `make functionaltest` has to be preceded by a regular make for doc to build.
 	if ${PREVENT_LUA_PATH_LEAK}; then unset LUA_PATH LUA_CPATH; fi; \
 	export LUASNIP_SOURCE=$(PROJECT_ROOT); \
 	export JSREGEXP_ABS_PATH=$(JSREGEXP_PATH); \

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ ifeq ($(LUASNIP_DETECTED_OS),Windows)
 	# On Git Bash, `which nvim` returns a Unix style path: `/c/Program Files/Git/bin/nvim`
 	# Always convert to `C:/Program Files/Git/bin/nvim` for powershell and pwsh users
 	NEOVIM_BIN_PATH?=$(shell \
-		if (scoop prefix neovim | grep '^[A-Z]:[/\\]') >/dev/null 2>&1; then \
+		if (scoop prefix neovim | grep '^[A-Z]:[/\\\\]') >/dev/null 2>&1; then \
 			echo "$$(scoop prefix neovim)/bin" | sed 's/\\\\/\\//g'; \
 		elif which nvim >/dev/null 2>&1; then \
 			dirname "$$(which nvim)" | sed 's/^\\/\\(.\\)\\//\\U\\1:\\//'; \

--- a/Makefile
+++ b/Makefile
@@ -84,14 +84,15 @@ ifeq ($(LUASNIP_DETECTED_OS),Windows)
 	LUA_LDLIBS?=$(if $(strip $(NEOVIM_BIN_PATH)),-L$(NEOVIM_BIN_PATH) -llua51,)
 endif
 
+CC_ENV:=$(or $(shell which $(CC) 2>/dev/null), $(shell which gcc 2>/dev/null), $(shell which clang 2>/dev/null))
 PROJECT_ROOT:=$(shell pwd 2>/dev/null)
 JSREGEXP_PATH=$(PROJECT_ROOT)/deps/jsregexp
 JSREGEXP005_PATH=$(PROJECT_ROOT)/deps/jsregexp005
 jsregexp:
 	git submodule init
 	git submodule update
-	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" LDLIBS='$(LUA_LDLIBS)' -C "$(JSREGEXP_PATH)"
-	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" LDLIBS='$(LUA_LDLIBS)' -C "$(JSREGEXP005_PATH)"
+	"$(MAKE)" "CC=$(CC_ENV)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" LDLIBS='$(LUA_LDLIBS)' -C "$(JSREGEXP_PATH)"
+	"$(MAKE)" "CC=$(CC_ENV)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" LDLIBS='$(LUA_LDLIBS)' -C "$(JSREGEXP005_PATH)"
 
 install_jsregexp: jsregexp
 	# remove old binary.

--- a/README.md
+++ b/README.md
@@ -61,17 +61,11 @@ Neovim >= 0.7 (extmarks)
   Consider watching the repository's releases so you're notified when a new version becomes available.
 
 > [!NOTE]
-> On Windows, you need to use a shell that can run Unix commands (MinGW,MSYS2,etc).
-> Luckily, Git offers a `sh.exe`, so you don't need to install a heavy MSYS2 environment.
-> Other than Git, you also need a C compiler and `make` to install `jsregexp`.
-> You may also need to change the build command: `make install_jsregexp CC=gcc.exe SHELL=C:/path/to/sh.exe .SHELLFLAGS=-c`:
-
-```text
-SHELL=C:/path/to/Git/usr/bin/sh.exe # if Git/MinGW/MSYS2 `sh.exe` is not in PATH
-.SHELLFLAGS=-c # if Git/MinGW/MSYS2 `sh.exe` is not in PATH
-CC=gcc.exe # if CC's default value cc is not set (when `which cc` fails to find the compiler command)
-NEOVIM_BIN_PATH=C:/path/to/Neovim/bin # if the Makefile fails to automatically detect the Neovim/bin path
-```
+> On Windows, you need a C compiler and `make` to install `jsregexp`. If your
+> compiler choice is not `gcc`, `clang`, or `zig`, you need to explicitly
+> specify the `CC` variable in the build command: `make install_jsregexp
+> CC=your_compiler_program`. Also, make sure `%GIT%/bin` directory is added in
+> the `$PATH` so that `make` can use `%GIT%/bin/sh.exe`.
 
 ## Keymaps
 In Vim script, with `<Tab>` for jumping forward/expanding a snippet, `<Shift-Tab>` for

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ loaders and their benefits. The following list serves only as a short overview.
     ```lua
     -- load snippets from path/of/your/nvim/config/my-cool-snippets
     require("luasnip.loaders.from_vscode").lazy_load({ paths = { "./my-cool-snippets" } })
-
-    (Note: It's mandatory to have a 'package.json' file in the snippet directory. For examples, see documentation.)
     ```
+        > NOTE:
+        > It's mandatory to have a `package.json` file in the snippet directory. For examples, see [friendly-snippets](https://github.com/rafamadriz/friendly-snippets/blob/main/package.json).
 	For more info on the VS Code loader, check the [examples](https://github.com/L3MON4D3/LuaSnip/blob/b5a72f1fbde545be101fcd10b70bcd51ea4367de/Examples/snippets.lua#L501) or [documentation](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#loaders).
 
 - **SnipMate-like**: Very similar to VS Code packages; install a plugin that provides snippets and call the `load`-function:
@@ -133,7 +133,7 @@ loaders and their benefits. The following list serves only as a short overview.
     The SnipMate format is very simple, so adding **custom snippets** only requires a few steps:
     - add a directory beside your `init.vim` (or any other place that is in your `runtimepath`) named `snippets`.
     - inside that directory, create files named `<filetype>.snippets` and add snippets for the given filetype in it (for inspiration, check [honza/vim-snippets](https://github.com/honza/vim-snippets/tree/master/snippets)).  
-        ``` snipmate
+        ```snipmate
         # comment
         snippet <trigger> <description>
         <snippet-body>

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2025 January 04
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 02
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/tests/integration/choice_spec.lua
+++ b/tests/integration/choice_spec.lua
@@ -294,13 +294,15 @@ describe("ChoiceNode", function()
 			)
 		]])
 
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			^. -->                                             |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
 		})
 		exec_lua("ls.change_choice(1)")
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			^by bullet pointsby-bullet-points                  |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],

--- a/tests/integration/multisnippet_spec.lua
+++ b/tests/integration/multisnippet_spec.lua
@@ -35,8 +35,7 @@ describe("multisnippets", function()
 		exec_lua([[
 			add_ms({"a", "b", "c", "d"}, {t"a or b or c or d"})
 		]])
-		local function test()
-		end
+		local function test() end
 
 		feed("ia<Plug>luasnip-expand-or-jump")
 		screen:expect({
@@ -46,11 +45,11 @@ describe("multisnippets", function()
 			{2:-- INSERT --}                                      |]],
 		})
 		feed("<Esc>ccb<Plug>luasnip-expand-or-jump")
-		screen:expect({unchanged=true})
+		screen:expect({ unchanged = true })
 		feed("<Esc>ccc<Plug>luasnip-expand-or-jump")
-		screen:expect({unchanged=true})
+		screen:expect({ unchanged = true })
 		feed("<Esc>ccd<Plug>luasnip-expand-or-jump")
-		screen:expect({unchanged=true})
+		screen:expect({ unchanged = true })
 		-- can expand multiple at once.
 		feed(
 			"<Esc>cca<Plug>luasnip-expand-or-jump<Space>b<Plug>luasnip-expand-or-jump"
@@ -86,11 +85,11 @@ describe("multisnippets", function()
 		})
 
 		feed("<Esc>ccb<Plug>luasnip-expand-or-jump")
-		screen:expect({unchanged=true})
+		screen:expect({ unchanged = true })
 		feed("<Esc>ccc<Plug>luasnip-expand-or-jump")
-		screen:expect({unchanged=true})
+		screen:expect({ unchanged = true })
 		feed("<Esc>ccd<Plug>luasnip-expand-or-jump")
-		screen:expect({unchanged=true})
+		screen:expect({ unchanged = true })
 	end)
 
 	it("respects `common` context", function()
@@ -98,8 +97,7 @@ describe("multisnippets", function()
 			ls.setup({enable_autosnippets = true})
 			add_ms({common={trig="a",snippetType="autosnippet"}, "b", "c", {snippetType="snippet"}}, {t"a or b or c or d"})
 		]])
-		local function test()
-		end
+		local function test() end
 		feed("ia<Plug>luasnip-expand-or-jump")
 		screen:expect({
 			grid = [[
@@ -108,9 +106,9 @@ describe("multisnippets", function()
 			{2:-- INSERT --}                                      |]],
 		})
 		feed("<Esc>ccb")
-		screen:expect({unchanged=true})
+		screen:expect({ unchanged = true })
 		feed("<Esc>ccc")
-		screen:expect({unchanged=true})
+		screen:expect({ unchanged = true })
 	end)
 
 	it("respects `opts`", function()

--- a/tests/integration/selection_spec.lua
+++ b/tests/integration/selection_spec.lua
@@ -148,7 +148,8 @@ describe("selection", function()
 				}) )
 		]])
 		-- ^ denotes cursor, has to be behind "f".
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			asdf^                                              |
 			{3:second line}                                       |
 			{2:-- SELECT --}                                      |]],

--- a/tests/integration/snippet_basics_spec.lua
+++ b/tests/integration/snippet_basics_spec.lua
@@ -111,7 +111,8 @@ describe("snippets_basic", function()
 		exec_lua([[
 			ls.jump(1)
 		]])
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			texttext again^and again                           |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
@@ -119,7 +120,8 @@ describe("snippets_basic", function()
 		exec_lua([[
 			ls.jump(-1)
 		]])
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			text^text againand again                           |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
@@ -128,7 +130,8 @@ describe("snippets_basic", function()
 			ls.jump(1)
 			ls.jump(1)
 		]])
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			texttext againand again^                           |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
@@ -149,19 +152,22 @@ describe("snippets_basic", function()
 			{2:-- INSERT --}                                      |]],
 		})
 		feed("<Plug>luasnip-jump-next")
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			texttext again^and again                           |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
 		})
 		feed("<Plug>luasnip-jump-prev")
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			text^text againand again                           |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
 		})
 		feed("<Plug>luasnip-jump-next<Plug>luasnip-jump-next")
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			texttext againand again^                           |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
@@ -930,7 +936,8 @@ describe("snippets_basic", function()
 					end, {3}), i(3, "text??")
 				}))
 			]])
-			screen:expect({ grid = [[
+			screen:expect({
+				grid = [[
 				^text??                                            |
 				{0:~                                                 }|
 				{2:-- INSERT --}                                      |]],
@@ -938,13 +945,15 @@ describe("snippets_basic", function()
 
 			exec_lua("ls.jump(1) ls.jump(1) ls.jump(1)")
 			feed("refresh dNode ")
-			screen:expect({ grid = [[
+			screen:expect({
+				grid = [[
 				refresh dNode ^                                    |
 				{0:~                                                 }|
 				{2:-- INSERT --}                                      |]],
 			})
 			exec_lua("ls.jump(1)")
-			screen:expect({ grid = [[
+			screen:expect({
+				grid = [[
 				^refresh dNode                                     |
 				{0:~                                                 }|
 				{2:-- INSERT --}                                      |]],
@@ -1323,7 +1332,7 @@ describe("snippets_basic", function()
 			})
 			-- verify we do not exit when reaching to a child root
 			exec_lua("ls.jump(1) ls.jump(-1)")
-			screen:expect({unchanged = true})
+			screen:expect({ unchanged = true })
 
 			-- be sure that reaching root $0 exits.
 			exec_lua("ls.jump(1) ls.jump(1) ls.jump(-1)")
@@ -1364,7 +1373,7 @@ describe("snippets_basic", function()
 		})
 		-- do not exit when reaching to a child root
 		exec_lua("ls.jump(1) ls.jump(-1)")
-		screen:expect({unchanged = true})
+		screen:expect({ unchanged = true })
 		-- root $0 does not exit.
 		exec_lua("ls.jump(1) ls.jump(1) ls.jump(-1)")
 		screen:expect({
@@ -1567,14 +1576,16 @@ describe("snippets_basic", function()
 		]=])
 		exec("set ft=lua")
 		feed([[ilocal function a()  end<Esc>hhhi]])
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			local function a() ^ end                           |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
 		})
 		feed([[asdf]])
 		exec_lua("ls.expand()")
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			local function a() print("qwer")^ end              |
 			{0:~                                                 }|
 			{2:-- INSERT --}                                      |]],
@@ -1608,7 +1619,8 @@ describe("snippets_basic", function()
 				s({trig="qwer", snippetType="autosnippet"}, { t"asdf" }) })
 		]])
 		feed("qaiqwer<Esc>qo<Esc>@a")
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			qwer                                              |
 			qwe^r                                              |
 			                                                  |]],

--- a/tests/integration/source_spec.lua
+++ b/tests/integration/source_spec.lua
@@ -86,7 +86,8 @@ describe("loaders:", function()
 		)
 		-- remove error-message for easier version-compatibility (it was changed
 		-- somewhere between 0.9 and master at the time of writing).
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			^{                                                 |
 			        "snip1": {                                |
 			                "prefix": "all1",                 |
@@ -161,7 +162,8 @@ describe("loaders:", function()
 		exec_lua(
 			[[require("luasnip.extras.snip_location").jump_to_active_snippet()]]
 		)
-		screen:expect({grid = [[
+		screen:expect({
+			grid = [[
 			{                                                 |
 			{3:       ^ "snip1": {}                                |
 			{3:                "prefix": "all1",}                 |


### PR DESCRIPTION
`CC` on Windows is usually not set to the correct compiler. #1252 needs manually defined `CC` to work (i.e., `make install_jsregexp CC=compiler`). Many users complained about this extra work (#1220 #1278 ).

This PR enables compilers detection in the following order:
- manually defined `CC`
- `gcc`
- `clang`
- `zig`