### PR TITLE
feat: implement `wordTrig` behavior as a condition

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1590,6 +1590,10 @@ a snippet's `condition` or `show_condition`. These are grouped accordingly into
 **`expand`**:
 
 - `line_begin`: only expand if the cursor is at the beginning of the line.
+- `trigger_not_preceded_by(pattern)`: only expand if the character before the
+  trigger does not match `pattern`. This is a generalisation of `wordTrig`,
+  which can be implemented as `trigger_not_preceded_by("[%w_]")`, and is
+  available as `word_trig_condition`.
 
 **`show`**:
 

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1518,6 +1518,10 @@ into `luasnip.extras.conditions.expand` and `luasnip.extras.conditions.show`:
 **expand**:
 
 - `line_begin`: only expand if the cursor is at the beginning of the line.
+- `trigger_not_preceded_by(pattern)`: only expand if the character before the
+    trigger does not match `pattern`. This is a generalisation of `wordTrig`,
+    which can be implemented as `trigger_not_preceded_by("[%w_]")`, and is
+    available as `word_trig_condition`.
 
 **show**:
 

--- a/lua/luasnip/extras/conditions/expand.lua
+++ b/lua/luasnip/extras/conditions/expand.lua
@@ -40,8 +40,9 @@ M.line_begin = cond_obj.make_condition(line_begin)
 ---
 --- I think the character wordTrig=true uses should be customized
 --- A condtion seems like the best way to do it
---- @param string pattern should be a character class eg `[%w]`
-local function make_trigger_does_not_follow_char(pattern)
+---
+--- @param pattern string should be a character class eg `[%w]`
+function M.trigger_not_preceded_by(pattern)
 	local condition = function(line_to_cursor, matched_trigger)
 		local line_to_trigger_len = #line_to_cursor - #matched_trigger
 		if line_to_trigger_len == 0 then
@@ -53,9 +54,6 @@ local function make_trigger_does_not_follow_char(pattern)
 	end
 	return cond_obj.make_condition(condition)
 end
-
-M.line_begin = cond_obj.make_condition(line_begin)
-M.make_trigger_does_not_proceed = make_trigger_does_not_follow_char
-M.word_trig_condition = M.make_trigger_does_not_proceed("[%w_]")
+M.word_trig_condition = M.trigger_not_preceded_by("[%w_]")
 
 return M

--- a/lua/luasnip/extras/conditions/expand.lua
+++ b/lua/luasnip/extras/conditions/expand.lua
@@ -11,4 +11,51 @@ local function line_begin(line_to_cursor, matched_trigger)
 end
 M.line_begin = cond_obj.make_condition(line_begin)
 
+--- The wordTrig flag will only expand the snippet if
+--- the proceeding character is NOT %w or `_`.
+--- This is quite useful. The only issue is that the characters
+--- on which we negate on hard coded. See here for the actual implementation
+--- https://github.com/L3MON4D3/LuaSnip/blob/c9b9a22904c97d0eb69ccb9bab76037838326817/lua/luasnip/nodes/snippet.lua#L827
+---
+--- As a result, authors willl turn their plain triggers into regexTrig=true
+--- triggers and proceed their regex with a negated capture group.
+--- The issue is that the capture group on which the pattern matched, although
+--- its negated, still expands with the rest of the trigger.
+--- So people have worked around that by doing inserting the capture group
+--- back into the snippet
+--- https://ejmastnak.com/tutorials/vim-latex/luasnip/#after-a
+---
+--- This is an issue because it can break LuaSnips understanding
+--- of parent and child snippets, resulting in broken jump_next() etc.
+--- For instance, consider
+--- ```text
+--- $mbb$
+---    ^
+--- Cursor is here
+--- ```
+--- Some latex snippet authors will have their snippet definition
+--- for mbb look like s(trig="([^%w])mbb", t("\mathbb{}")
+--- The problem is that this consume the leading `$~ character, and even if
+--- the snippet re-inserts the `$` back, the parent snippet $$ will be broken.
+---
+--- I think the character wordTrig=true uses should be customized
+--- A condtion seems like the best way to do it
+--- @param string pattern should be a character class eg `[%w]`
+local function make_trigger_does_not_follow_char(pattern)
+	local condition = function(line_to_cursor, matched_trigger)
+		local line_to_trigger_len = #line_to_cursor - #matched_trigger
+		if line_to_trigger_len == 0 then
+			return true
+		end
+		return not string
+			.sub(line_to_cursor, line_to_trigger_len, line_to_trigger_len)
+			:match(pattern)
+	end
+	return cond_obj.make_condition(condition)
+end
+
+M.line_begin = cond_obj.make_condition(line_begin)
+M.make_trigger_does_not_proceed = make_trigger_does_not_follow_char
+M.word_trig_condition = M.make_trigger_does_not_proceed("[%w_]")
+
 return M


### PR DESCRIPTION
>[!NOTE]
> Maybe this pr should just be a code example in documentation or
> even a post on a luansip community forum. I apologize if so. I do not mean to spam.

## Upshot
I think the repo should guide users how to custom the characters used in `wordTrig=true` (from the default of `[%w_]`) . A condition function seems like the best way to do it. This PR attempts to show one such way.

The wordTrig flag will only expand the snippet if
the proceeding character is NOT %w or `_`.
This is quite useful. The only issue is that the characters on which we negate on hard coded. See here for the actual implementation [snippet.lua#L827](https://github.com/L3MON4D3/LuaSnip/blob/c9b9a22904c97d0eb69ccb9bab76037838326817/lua/luasnip/nodes/snippet.lua#L827)

As a result, authors will turn their plain triggers into `regexTrig=true` triggers and precede their regex with a negated capture group. The capture group on which the pattern is matched, although negated, still expands with the rest of the trigger. So people have worked around that by inserting the capture group back into the snippet via function node. 

- A very helpful and influential article for those using neovim + LaTeX proposes this injection technique: <https://ejmastnak.com/tutorials/vim-latex/luasnip/#after-a>
- Here is one such example of this technique <https://github.com/ejmastnak/dotfiles/blob/29d4e52ab0fef8fc7ff1a3e2f8b78b8dc297ff2f/config/nvim/LuaSnip/tex/math.lua#L384>

## Why the workaround is an issue

This is an issue because it can break LuaSnip's understanding of parent and child snippets, resulting in broken jump_next() etc. For instance, consider
```text
$mbb$
   ^
Cursor is here
```
Some latex snippet authors will have their snippet definition for mbb look like s(trig="([^%w])mbb", t("\mathbb{}") The problem is that this consume the leading `$`  character, and even if the snippet re-inserts the `$` back, the parent snippet `$$` will be broken.

