### PR TITLE
fix: avoid deprecated usage of `vim.validate`

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2025 January 04
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2025 April 01
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/extras/postfix.lua
+++ b/lua/luasnip/extras/postfix.lua
@@ -48,12 +48,14 @@ end
 local function postfix(context, nodes, opts)
 	opts = opts or {}
 	local user_callback = vim.tbl_get(opts, "callbacks", -1, events.pre_expand)
-	vim.validate({
+	for key, value in pairs({
 		context = { context, { "string", "table" } },
 		nodes = { nodes, "table" },
 		opts = { opts, "table" },
 		user_callback = { user_callback, { "nil", "function" } },
-	})
+	}) do
+		vim.validate(key, value[1], value[2])
+	end
 
 	context = node_util.wrap_context(context)
 	context.wordTrig = false

--- a/lua/luasnip/extras/treesitter_postfix.lua
+++ b/lua/luasnip/extras/treesitter_postfix.lua
@@ -274,11 +274,13 @@ end
 
 local function treesitter_postfix(context, nodes, opts)
 	opts = opts or {}
-	vim.validate({
+	for key, value in pairs({
 		context = { context, { "string", "table" } },
 		nodes = { nodes, "table" },
 		opts = { opts, "table" },
-	})
+	}) do
+		vim.validate(key, value[1], value[2])
+	end
 
 	context = node_util.wrap_context(context)
 	context.wordTrig = false

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -730,14 +730,6 @@ local function get_id_snippet(id)
 end
 
 local function add_snippets(ft, snippets, opts)
-	-- don't use yet, not available in some neovim-versions.
-	--
-	-- vim.validate({
-	-- 	filetype = { ft, { "string", "nil" } },
-	-- 	snippets = { snippets, "table" },
-	-- 	opts = { opts, { "table", "nil" } },
-	-- })
-
 	opts = opts or {}
 	opts.refresh_notify = opts.refresh_notify or true
 	-- alternatively, "autosnippets"

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -5,7 +5,7 @@ local snippet_collection = require("luasnip.session.snippet_collection")
 local log = require("luasnip.util.log").new("loaders")
 
 local function filetypelist_to_set(list)
-	vim.validate({ list = { list, "table", true } })
+	vim.validate("list", list, "table", true)
 	if not list then
 		return list
 	end

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -269,7 +269,7 @@ local function redirect_filetypes(fts)
 end
 
 local function deduplicate(list)
-	vim.validate({ list = { list, "table" } })
+	vim.validate("list", list, "table")
 	local ret = {}
 	local contains = {}
 	for _, v in ipairs(list) do


### PR DESCRIPTION
`vim.validate` in its spec form is deprecated.
This fixes it.