### PR TITLE
fix: use vim.validate(name, value, validator, optional_or_msg)

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NVIM v0.8.0           Last change: 2025 January 04
+*luasnip.txt*            For NVIM v0.8.0            Last change: 2025 April 01
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -269,7 +269,7 @@ local function redirect_filetypes(fts)
 end
 
 local function deduplicate(list)
-	vim.validate('list', list, "table")
+	vim.validate("list", list, "table")
 	local ret = {}
 	local contains = {}
 	for _, v in ipairs(list) do

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -269,7 +269,7 @@ local function redirect_filetypes(fts)
 end
 
 local function deduplicate(list)
-	vim.validate({ list = { list, "table" } })
+	vim.validate('list', list, "table")
 	local ret = {}
 	local contains = {}
 	for _, v in ipairs(list) do


### PR DESCRIPTION
Fix checkhealth report(nvim v0.12.0):

```
- ⚠️ WARNING vim.validate is deprecated. Feature will be removed in Nvim 1.0
  - ADVICE:
    - use vim.validate(name, value, validator, optional_or_msg) instead.
```