### PR TITLE
from_lua loader: Don't ignore errors, warn when loading fails

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 03
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 04
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -160,14 +160,18 @@ local function _luasnip_load_file(file)
 		get_loaded_file_debuginfo,
 		nil
 	)
-	local run_ok, file_snippets, file_autosnippets = pcall(func)
+	local run_ok, file_snippets_or_err, file_autosnippets = pcall(func)
 	-- immediately nil it.
 	_G.__luasnip_get_loaded_file_frame_debuginfo = nil
 
 	if not run_ok then
-		log.error("Failed to execute\n: %s", file, file_snippets)
-		error("Failed to execute " .. file .. "\n: " .. file_snippets)
+		local err = file_snippets_or_err
+		log.error("Failed to execute snippet file %s\n: %s", file, err)
+		loader_util.msg_user_snippet_load_failed("from_lua loader", file, err)
+		error(("Failed to execute snippet file %s\n: %s"):format(file, err))
 	end
+
+	local file_snippets = file_snippets_or_err
 
 	-- make sure these aren't nil.
 	file_snippets = file_snippets or {}

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -286,6 +286,19 @@ local function scopestring_to_filetypes(str)
 	return vim.split(str_trimmed, "%s*[.,]%s*")
 end
 
+--- Notify the user that loading a snippet file failed
+---@param what string
+---@param where string
+---@param error string
+local function msg_user_snippet_load_failed(what, where, error)
+	local message = "LuaSnip: " .. what .. " failed to load snippets from " .. where
+	local see_more = "-> Use `:lua require'luasnip'.log.open()` for more details"
+	vim.notify(
+		("%s\n: %s\n\n%s"):format(message, error, see_more),
+		vim.log.levels.WARN
+	)
+end
+
 return {
 	filetypelist_to_set = filetypelist_to_set,
 	split_lines = split_lines,
@@ -302,4 +315,5 @@ return {
 	add_file_snippets = add_file_snippets,
 	normalize_opts = normalize_opts,
 	scopestring_to_filetypes = scopestring_to_filetypes,
+	msg_user_snippet_load_failed = msg_user_snippet_load_failed,
 }

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -291,8 +291,12 @@ end
 ---@param where string
 ---@param error string
 local function msg_user_snippet_load_failed(what, where, error)
-	local message = "LuaSnip: " .. what .. " failed to load snippets from " .. where
-	local see_more = "-> Use `:lua require'luasnip'.log.open()` for more details"
+	local message = "LuaSnip: "
+		.. what
+		.. " failed to load snippets from "
+		.. where
+	local see_more =
+		"-> Use `:lua require'luasnip'.log.open()` for more details"
 	vim.notify(
 		("%s\n: %s\n\n%s"):format(message, error, see_more),
 		vim.log.levels.WARN


### PR DESCRIPTION
I recently had a _hard time_ understanding why my snippets were broken..
It turns out that I triggered one of my `assert(something)` in my snippet files, and **the error was completely silent**: zero warning/error displayed to me with the error message that would have helped me understand my mistake.

This is a pretty bad UX/DX when editing snippets 😬

As a user I would expect to get a warning/error logged in the message area when neovim starts or when I open a buffer that has a matching snippet file, either telling me what the error is, or at least that there was an error and a hint to use `:lua require"luasnip".log.open()` to see the plugin logs.

---

### Steps to reproduce the issue

```lua
vim.env.LAZY_STDPATH = "/tmp/nvim-mini-repro"
load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()

require("lazy.minit").repro({
  spec = {
    {
      "L3MON4D3/LuaSnip",
      version = "v2.*",
      config = function()
        vim.keymap.set("i", [[<tab>]], function() require"luasnip".expand() end)

        require"luasnip.loaders.from_lua".load {
          paths = {
            vim.fs.joinpath(vim.fn.getcwd(), "snips"),
          },
        }
      end,
    }
  },
})
```
And in the `./snips/all.lua` file:
```lua
assert(true == false, "The laws of physics have shattered…")
```

Then start `nvim -u minimal-repro.lua`, observe that there are zero errors, and nothing in `:messages`.
But opening `:lua require"luasnip".log.open()` shows we have an error:
```
ERROR | lua-loader: Failed to execute
      | : /home/bew/projects/dotfiles/repro-luasnip/snips/all.lua
ERROR | lua-loader: Could not create collection at /home/bew/projects/dotfiles/repro-luasnip/snips: .../data/nvim/lazy/LuaSnip/lua/luasnip/loaders/from_lua.lua:246: Could not create watcher: .../data/nvim/lazy/LuaSnip/lua/luasnip/loaders/from_lua.lua:169: Failed to execute /home/bew/projects/dotfiles/repro-luasnip/snips/all.lua
      | : /home/bew/projects/dotfiles/repro-luasnip/snips/all.lua:1: The laws of physics have shattered…
```

NOTE: The first log is actually even missing the error, it only shows the file

### With this PR

The repro (using this PR) now shows this in `:messages`:
![image](https://github.com/user-attachments/assets/cb456940-271a-45e0-9312-c606edab8001)
And the plugin logs contain:
```
ERROR | 13:13:22 | lua-loader: Failed to execute snippet file /home/bew/projects/dotfiles/repro-luasnip/snips/all.lua
      | : /home/bew/projects/dotfiles/repro-luasnip/snips/all.lua:1: The laws of physics have shattered…
ERROR | 13:13:22 | lua-loader: Could not create collection at /home/bew/projects/dotfiles/repro-luasnip/snips: ...d-plugins/start/LuaSnip/lua/luasnip/loaders/from_lua.lua:248: Could not create watcher: ...d-plugins/start/LuaSnip/lua/luasnip/loaders/from_lua.lua:169: Failed to execute snippet file /home/bew/projects/dotfiles/repro-luasnip/snips/all.lua
      | : /home/bew/projects/dotfiles/repro-luasnip/snips/all.lua:1: The laws of physics have shattered…
```