### PR TITLE
Add editorconfig to have uniform settings for every contributors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,4 +3,4 @@ root = true
 [*.lua]
 insert_final_newline = true
 indent_style = tab
-max_line_length = 70
+max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.lua]
+insert_final_newline = true
+indent_style = tab
+max_line_length = 70

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 03
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 04
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*


### PR DESCRIPTION
TSIA

Reference: https://editorconfig.org
The file is automatically read by Neovim since a few versions already ✨

This is useful as I personally use 2 spaces for Lua indents, but this project uses tabs exclusively and I had to run `:set shiftwidth=2 noexpandtab` to avoid making a completely different formatting as the rest of the project.
Now I only have to open a Lua file, and Neovim is automatically configured to use tabs