### PR TITLE
fix: account for deprecated format of vim.validate

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 04
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 05
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/extras/postfix.lua
+++ b/lua/luasnip/extras/postfix.lua
@@ -48,12 +48,11 @@ end
 local function postfix(context, nodes, opts)
 	opts = opts or {}
 	local user_callback = vim.tbl_get(opts, "callbacks", -1, events.pre_expand)
-	vim.validate({
-		context = { context, { "string", "table" } },
-		nodes = { nodes, "table" },
-		opts = { opts, "table" },
-		user_callback = { user_callback, { "nil", "function" } },
-	})
+
+	util.validate("context", context, { "string", "table" })
+	util.validate("nodes", nodes, "table")
+	util.validate("opts", opts, "table")
+	util.validate("user_callback", user_callback, { "function" }, true)
 
 	context = node_util.wrap_context(context)
 	context.wordTrig = false

--- a/lua/luasnip/extras/treesitter_postfix.lua
+++ b/lua/luasnip/extras/treesitter_postfix.lua
@@ -280,11 +280,9 @@ end
 
 local function treesitter_postfix(context, nodes, opts)
 	opts = opts or {}
-	vim.validate({
-		context = { context, { "string", "table" } },
-		nodes = { nodes, "table" },
-		opts = { opts, "table" },
-	})
+	util.validate("context", context, { "string", "table" })
+	util.validate("nodes", nodes, { "table" })
+	util.validate("opts", opts, { "table" })
 
 	context = node_util.wrap_context(context)
 	context.wordTrig = false

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -730,13 +730,9 @@ local function get_id_snippet(id)
 end
 
 local function add_snippets(ft, snippets, opts)
-	-- don't use yet, not available in some neovim-versions.
-	--
-	-- vim.validate({
-	-- 	filetype = { ft, { "string", "nil" } },
-	-- 	snippets = { snippets, "table" },
-	-- 	opts = { opts, { "table", "nil" } },
-	-- })
+	util.validate("filetype", ft, {"string", "nil"})
+	util.validate("snippets", snippets, {"table"})
+	util.validate("opts", opts, {"table", "nil"})
 
 	opts = opts or {}
 	opts.refresh_notify = opts.refresh_notify or true

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -730,9 +730,9 @@ local function get_id_snippet(id)
 end
 
 local function add_snippets(ft, snippets, opts)
-	util.validate("filetype", ft, {"string", "nil"})
-	util.validate("snippets", snippets, {"table"})
-	util.validate("opts", opts, {"table", "nil"})
+	util.validate("filetype", ft, { "string", "nil" })
+	util.validate("snippets", snippets, { "table" })
+	util.validate("opts", opts, { "table", "nil" })
 
 	opts = opts or {}
 	opts.refresh_notify = opts.refresh_notify or true

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -5,7 +5,8 @@ local snippet_collection = require("luasnip.session.snippet_collection")
 local log = require("luasnip.util.log").new("loaders")
 
 local function filetypelist_to_set(list)
-	vim.validate({ list = { list, "table", true } })
+	util.validate("list", list, {"table"}, true)
+
 	if not list then
 		return list
 	end

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -5,7 +5,7 @@ local snippet_collection = require("luasnip.session.snippet_collection")
 local log = require("luasnip.util.log").new("loaders")
 
 local function filetypelist_to_set(list)
-	util.validate("list", list, {"table"}, true)
+	util.validate("list", list, { "table" }, true)
 
 	if not list then
 		return list

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -273,7 +273,7 @@ local function validate(name, value, validator, optional)
 	if vimversion.ge(0, 11, 0) then
 		return vim.validate(name, value, validator, optional)
 	else
-		return vim.validate({name = {value, validator, optional}})
+		return vim.validate({ name = { value, validator, optional } })
 	end
 end
 

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -1,4 +1,5 @@
 local session = require("luasnip.session")
+local vimversion = require("luasnip.util.vimversion")
 
 local function get_cursor_0ind()
 	local c = vim.api.nvim_win_get_cursor(0)
@@ -268,8 +269,16 @@ local function redirect_filetypes(fts)
 	return snippet_fts
 end
 
+local function validate(name, value, validator, optional)
+	if vimversion.ge(0, 11, 0) then
+		return vim.validate(name, value, validator, optional)
+	else
+		return vim.validate({name = {value, validator, optional}})
+	end
+end
+
 local function deduplicate(list)
-	vim.validate({ list = { list, "table" } })
+	validate("list", list, "table")
 	local ret = {}
 	local contains = {}
 	for _, v in ipairs(list) do
@@ -438,4 +447,5 @@ return {
 	indx_of = indx_of,
 	ternary = ternary,
 	pos_cmp = pos_cmp,
+	validate = validate,
 }


### PR DESCRIPTION
Supersedes #1314, and stays backward-compatible via a version-check.