### PR TITLE
doc,loaders: add section on fixing diagnostics from lua-language-server.

### DIFF
--- a/.github/data/project-dictionary.txt
+++ b/.github/data/project-dictionary.txt
@@ -1,10 +1,11 @@
-personal_ws-1.1 en 109 utf-8
+personal_ws-1.1 en 113 utf-8
 AbsoluteIndexer
 Autosnippets
 Cfigure
 Cimg
 DeVries
 ECMAscript
+Env
 GIFs
 IDEs
 IndentSnippetNode
@@ -62,6 +63,7 @@ extmark
 extmarks
 filetype
 filetypes
+fmt
 fn
 functionNode
 functionNodes
@@ -75,7 +77,9 @@ jsregexp
 jumpable
 jumplist
 keymaps
+lsp
 luasnip
+mistyped
 molleweide
 multiline
 namespace
@@ -108,5 +112,3 @@ there'd
 truthy
 varargs
 vsnip
-fmt
-lsp

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 12
+*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 16
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -65,6 +65,7 @@ Table of Contents                                  *luasnip-table-of-contents*
 31. Troubleshooting                                  |luasnip-troubleshooting|
   - Adding Snippets                  |luasnip-troubleshooting-adding-snippets|
 32. API                                                          |luasnip-api|
+33. Links                                                      |luasnip-links|
 >
                 __                       ____
                /\ \                     /\  _`\           __
@@ -2847,6 +2848,55 @@ Load via
 <
 
 
+SNIP-ENV DIAGNOSTICS ~
+
+One side-effect of the injected globals is that language servers, for example
+`lua-language-server`, do not know about them, which means that snippet-files
+may have many diagnostics about missing symbols.
+
+There are a few ways to fix this * Add all variables in `snip_env` to
+`Lua.diagnostic.globals`: `lua -- wherever your lua-language-server lsp
+settings are defined: settings = { Lua = { ... diagnostics = { globals = {
+"vim", "s", "c", "t", ... } } } }` This will disable the warnings, but will do
+so in all files these lsp-settings are used with. Similarly, adding
+`---@diagnostic disable: undefined-global` to the snippet-files is also
+possible, but this affects not only the variables in `snip_env`, but all
+variables, like local variable names that may be mistyped. * A more complete,
+and only slightly more complicated solution is using `lua-language-server`’s
+definition files <https://luals.github.io/wiki/definition-files/>. Add a file
+with the line `---@meta`, followed by the variables defined by the `snip_env`
+to any directory listed in the `workspace.library`-settings for
+`lua-langue-server` (one likely directory is `vim.fn.stdpath("config")/lua`,
+check `:checkhealth lsp` in a lua file to be sure). ```lua —@meta
+
+s = require("luasnip.nodes.snippet").S sn = require("luasnip.nodes.snippet").SN
+isn = require("luasnip.nodes.snippet").ISN t =
+require("luasnip.nodes.textNode").T i = require("luasnip.nodes.insertNode").I f
+= require("luasnip.nodes.functionNode").F c =
+require("luasnip.nodes.choiceNode").C d =
+require("luasnip.nodes.dynamicNode").D r =
+require("luasnip.nodes.restoreNode").R events = require("luasnip.util.events")
+k = require("luasnip.nodes.key_indexer").new_key ai =
+require("luasnip.nodes.absolute_indexer") extras = require("luasnip.extras") l
+= require("luasnip.extras").lambda rep = require("luasnip.extras").rep p =
+require("luasnip.extras").partial m = require("luasnip.extras").match n =
+require("luasnip.extras").nonempty dl =
+require("luasnip.extras").dynamic_lambda fmt =
+require("luasnip.extras.fmt").fmt fmta = require("luasnip.extras.fmt").fmta
+conds = require("luasnip.extras.expand_conditions") postfix =
+require("luasnip.extras.postfix").postfix types = require("luasnip.util.types")
+parse = require("luasnip.util.parser").parse_snippet ms =
+require("luasnip.nodes.multiSnippet").new_multisnippet ```
+
+While that allows the `snip_env`-variables to resolve correctly in
+snippet-files, it also resolves them in other lua files. This can be fixed by
+putting the file in a directory that is _not_ in `workspace.library` (create,
+for example, `vim.fn.stdpath("state")/luasnip-snip_env/`), and then adding its
+path to `workspace.library` only for snippet files, for example by putting a
+`.luarc.json` with the following content into all snippet-directories: `json {
+"workspace.library": ["<state-stdpath>/luasnip-snip_env"] }`
+
+
 RELOADING WHEN EDITING REQUIRE’D FILES ~
 
 While the `lua-snippet-files` will be reloaded on edit, this does not
@@ -3495,12 +3545,6 @@ These are the settings you can provide to `luasnip.setup()`:
         If this is `"extend"`, the variables defined in `snip_env` will complement (and
         override) the defaults. If this is not desired, `"set"` will not include the
         defaults, but only the variables set here.
-    One side-effect of this is that analysis-tools (most likely
-    `lua-language-server`) for Lua will generate diagnostics for the usage of
-    undefined symbols. If you mind the (probably) large number of generated
-    warnings, consider adding the undefined globals to the globals recognized by
-    `lua-language-server` or add `---@diagnostic disable: undefined-global`
-    somewhere in the affected files.
 - `loaders_store_source`, boolean, whether loaders should store the source of the
     loaded snippets. Enabling this means that the definition of any snippet can be
     jumped to via |luasnip-extras-snippet-location|, but also entails slightly
@@ -3769,6 +3813,11 @@ GENERAL ~
 Not covered in this section are the various node-constructors exposed by the
 module, their usage is shown either previously in this file or in
 `Examples/snippets.lua` (in the repository).
+
+==============================================================================
+33. Links                                                      *luasnip-links*
+
+1. *@meta*: 
 
 Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
 

--- a/lua/luasnip/default_config.lua
+++ b/lua/luasnip/default_config.lua
@@ -17,6 +17,8 @@ local function modify_nodes(snip)
 	snip.nodes[1] = iNode.I(1)
 end
 
+-- when adding/removing entries here, be sure to keep the table in DOC.md up to
+-- date. (in the loaders @meta snip-env-section).
 local lazy_snip_env = {
 	s = function()
 		return require("luasnip.nodes.snippet").S


### PR DESCRIPTION
I've found a rather nice way of getting `lua-language-server` to shup up about missing globals (and even provide correct `go to definition`) in snippet-files for the lua-loader: One can define the `snip_env` like any other framework using a definition file, add it to a directory in `runtimepath`, and add the correct `---@module <path>` in the snippet-files, which results in correct definitions :)

While it would be nice to just put the default `snip_env` into `lua/luasnip/`, but there are issues: If one also puts a personal `snip_env` definition file in eg. `~/.config/nvim/lua/`, if some variable-names appear in both files (eg. `fmt`), `gd` will list both the `fmt` in our provided file, as well as the one in the personal file. So far, I couldn't find a way to exclude the provided file if it is not explicitly requested via `---@module`.

I'm opening this as a PR because I'd like to see if anyone has an idea on how to do this a bit more comfortably, and maybe have it working by just adding the `---@module`-line to snippet files, without thepotential drawbacks for users with custom `snip_env`.