### PR TITLE
fix(Makefile): use correct git shell path and add semicolons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ NVIM_0.9_PATH=${NVIM_PATH}/${NVIM_0.9_PATH_REL}
 ${NVIM_PATH}:
 # fetch current master and 0.7.0 (the minimum version we support) and 0.9.0
 # (the minimum version for treesitter-postfix to work).
-	git clone --bare --depth 1 https://github.com/neovim/neovim ${NVIM_PATH}
-	git -C ${NVIM_PATH} fetch --depth 1 origin tag v0.7.0
-	git -C ${NVIM_PATH} fetch --depth 1 origin tag v0.9.0
+	git clone --bare --depth 1 https://github.com/neovim/neovim ${NVIM_PATH}; \
+	git -C ${NVIM_PATH} fetch --depth 1 origin tag v0.7.0; \
+	git -C ${NVIM_PATH} fetch --depth 1 origin tag v0.9.0;
 # create one worktree for master, and one for 0.7.
 # The rationale behind this is that switching from 0.7 to master (and
 # vice-versa) requires a `make distclean`, and full clean build, which takes
@@ -23,18 +23,18 @@ ${NVIM_PATH}:
 # The most straightforward solution seems to be too keep two worktrees, one
 # for master, one for 0.7, and one for 0.9 which are used for the
 # respective builds/tests.
-	git -C ${NVIM_PATH} worktree add ${NVIM_MASTER_PATH_REL} master
-	git -C ${NVIM_PATH} worktree add ${NVIM_0.7_PATH_REL} v0.7.0
-	git -C ${NVIM_PATH} worktree add ${NVIM_0.9_PATH_REL} v0.9.0
+	git -C ${NVIM_PATH} worktree add ${NVIM_MASTER_PATH_REL} master; \
+	git -C ${NVIM_PATH} worktree add ${NVIM_0.7_PATH_REL} v0.7.0; \
+	git -C ${NVIM_PATH} worktree add ${NVIM_0.9_PATH_REL} v0.9.0;
 
 # |: don't update `nvim` if `${NVIM_PATH}` is changed.
 nvim: | ${NVIM_PATH}
 # only update master
-	git -C ${NVIM_MASTER_PATH} fetch origin master --depth 1
-	git -C ${NVIM_MASTER_PATH} checkout FETCH_HEAD
+	git -C ${NVIM_MASTER_PATH} fetch origin master --depth 1; \
+	git -C ${NVIM_MASTER_PATH} checkout FETCH_HEAD;
 
 # Windows: when Git is installed but %GIT%/bin is not in PATH
-WIN_GIT_SHELL:=C:/Program Files/Git/bin/sh.exe
+WIN_GIT_SHELL:=C:/Program\ Files/Git/bin/sh.exe
 WINDOWS_NT:=Windows_NT
 
 # Windows system variable
@@ -47,7 +47,7 @@ ifeq (sh.exe,$(SHELL))
 ifeq (,$(wildcard $(WIN_GIT_SHELL)))
 $(error SHELL is not set. You can specify SHELL=path_to_git/bin/sh.exe, or append path_to_git/bin to $$PATH)
 else
-SHELL:=$(WIN_GIT_SHELL)
+SHELL:=$(wildcard $(WIN_GIT_SHELL))
 endif
 endif
 endif
@@ -89,25 +89,25 @@ PROJECT_ROOT:=$(CURDIR)
 JSREGEXP_PATH=$(PROJECT_ROOT)/deps/jsregexp
 JSREGEXP005_PATH=$(PROJECT_ROOT)/deps/jsregexp005
 jsregexp:
-	git submodule init
-	git submodule update
-	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" 'LDLIBS=$(LUA_LDLIBS)' -C "$(JSREGEXP_PATH)"
-	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" 'LDLIBS=$(LUA_LDLIBS)' -C "$(JSREGEXP005_PATH)"
+	git submodule init; \
+	git submodule update; \
+	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" 'LDLIBS=$(LUA_LDLIBS)' -C "$(JSREGEXP_PATH)"; \
+	"$(MAKE)" "CC=$(CC)" "INCLUDE_DIR=-I$(PROJECT_ROOT)/deps/lua51_include/" 'LDLIBS=$(LUA_LDLIBS)' -C "$(JSREGEXP005_PATH)";
 
 install_jsregexp: jsregexp
 # remove old binary.
-	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.so"
+	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.so";
 # there is some additional trickery to make this work with jsregexp-0.0.6 in
 # util/jsregexp.lua.
-	cp "$(JSREGEXP_PATH)/jsregexp.lua" "$(PROJECT_ROOT)/lua/luasnip-jsregexp.lua"
+	cp "$(JSREGEXP_PATH)/jsregexp.lua" "$(PROJECT_ROOT)/lua/luasnip-jsregexp.lua";
 # just move out of jsregexp-directory, so it is not accidentally deleted.
-	cp "$(JSREGEXP_PATH)/jsregexp.so" "$(PROJECT_ROOT)/deps/luasnip-jsregexp.so"
+	cp "$(JSREGEXP_PATH)/jsregexp.so" "$(PROJECT_ROOT)/deps/luasnip-jsregexp.so";
 
 uninstall_jsregexp:
 # also remove binaries of older version.
-	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.so"
-	rm -f "$(PROJECT_ROOT)/deps/luasnip-jsregexp.so"
-	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.lua"
+	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.so"; \
+	rm -f "$(PROJECT_ROOT)/deps/luasnip-jsregexp.so"; \
+	rm -f "$(PROJECT_ROOT)/lua/luasnip-jsregexp.lua";
 
 TEST_07?=true
 TEST_09?=true
@@ -138,5 +138,5 @@ test_nix: nvim install_jsregexp
 
 spellcheck:
 	# grabbed from word-warden.
-	aspell --home-dir . --mode markdown --lang en --personal ./.github/data/project-dictionary.txt check DOC.md
-	aspell --home-dir . --mode markdown --lang en --personal ./.github/data/project-dictionary.txt check README.md
+	aspell --home-dir . --mode markdown --lang en --personal ./.github/data/project-dictionary.txt check DOC.md; \
+	aspell --home-dir . --mode markdown --lang en --personal ./.github/data/project-dictionary.txt check README.md;


### PR DESCRIPTION
### Problem:

PR #1343 did not use the correct git shell path as the space is not escaped.

### Solution:

1. Adding a backslash to escape the space does not fix the issue as `SHELL` still expands to `sh.exe` even after assignment. Instead of directly copying `$(WIN_GIT_SHELL)`, use `$(wildcard $(WIN_GIT_SHELL))` returned from the Makefile function to overwrite `SHELL`.

2. Similar to PR #1282 on `$(shell %COMMAND%)`, semicolons are added after each command to make sure `make` can call `CreateProcess` correctly:

- Without semicolon: calls `CreateProcess(NULL,%COMMAND%,...)`
- With semicolon: calls `CreateProcess(NULL,$(SHELL) $(.SHELLFLAGS) "%COMMAND%;",...)`