### PR TITLE
fix: use non-deprecated overload of `vim.str_utfindex`

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*             For NVIM v0.8.0             Last change: 2025 May 21
+*luasnip.txt*             For NVIM v0.8.0            Last change: 2025 June 03
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/util/mark.lua
+++ b/lua/luasnip/util/mark.lua
@@ -1,4 +1,5 @@
 local session = require("luasnip.session")
+local util = require("luasnip.util.util")
 
 local Mark = {}
 
@@ -32,9 +33,7 @@ end
 local function bytecol_to_utfcol(pos)
 	local line = vim.api.nvim_buf_get_lines(0, pos[1], pos[1] + 1, false)
 	-- line[1]: get_lines returns table.
-	-- use utf16-index.
-	local utf16_indx, _ = vim.str_utfindex(line[1] or "", pos[2])
-	return { pos[1], utf16_indx }
+	return { pos[1], util.str_utf32index(line[1] or "", pos[2]) }
 end
 
 function Mark:pos_begin_end()

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -120,10 +120,13 @@ local function move_to_mark(id)
 	set_cursor_0ind(new_cur_pos)
 end
 
-local function bytecol_to_utfcol(pos)
-	local line = vim.api.nvim_buf_get_lines(0, pos[1], pos[1] + 1, false)
-	-- line[1]: get_lines returns table.
-	return { pos[1], vim.str_utfindex(line[1] or "", pos[2]) }
+local function str_utf32index(s, index)
+	if vim.fn.has("nvim-0.11") == 1 then
+		return vim.str_utfindex(s, "utf-32", index)
+	else
+		local utf32_index, _ = vim.str_utfindex(s, index)
+		return utf32_index
+	end
 end
 
 local function multiline_equal(t1, t2)
@@ -432,7 +435,6 @@ return {
 	get_snippet_filetypes = get_snippet_filetypes,
 	json_decode = vim.json.decode,
 	json_encode = vim.json.encode,
-	bytecol_to_utfcol = bytecol_to_utfcol,
 	pos_sub = pos_sub,
 	pos_add = pos_add,
 	deduplicate = deduplicate,
@@ -448,4 +450,5 @@ return {
 	ternary = ternary,
 	pos_cmp = pos_cmp,
 	validate = validate,
+	str_utf32index = str_utf32index,
 }


### PR DESCRIPTION
The current use of `vim.str_utfindex` was deprecated in https://github.com/neovim/neovim/pull/30915. Now the encoding parameter is required and return value is an integer (instead of the table from the deprecated version corresponding to the `utf-32` and `utf-16` encodings).