### PR TITLE
WIP: Add MANY type annotations 🚀

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -785,7 +785,7 @@ the latter is special-cased to have a jump-point at the beginning of its text.
     end
     ```
     Consider passing this override into `snip_env`.
-  * `node_callbacks?: { [("change_choice"|"enter"...)]: fun(...) -> ... }?`
+  * `node_callbacks?: { [LuaSnip.EventType]: fun(...) -> ... }?`
   * `node_ext_opts?: LuaSnip.NodeExtOpts?` Pass these opts through to the underlying extmarks
     representing the node. Notably, this enables highlighting the nodes, and allows the highlight to
     be different based on the state of the node/snippet. See [ext_opts](#ext_opts)

--- a/DOC.md
+++ b/DOC.md
@@ -752,21 +752,21 @@ ChoiceNodes allow choosing between multiple nodes.
 
 <!-- panvimdoc-ignore-end -->
 
-`c(pos, choices, opts?): LuaSnip.ChoiceNode`: Create a new choiceNode from a list of choices. The
-first item in this list is the initial choice, and it can be changed while any node of a choice is
-active. So, if all choices should be reachable, every choice has to have a place for the cursor to
-stop at.
+`c(pos?, choices, node_opts?): LuaSnip.ChoiceNode`: Create a new choiceNode from a list of choices.
+The first item in this list is the initial choice, and it can be changed while any node of a choice
+is active. So, if all choices should be reachable, every choice has to have a place for the cursor
+to stop at.
 
 If the choice is a snippetNode like `sn(nil, {...nodes...})` the given `nodes` have to contain an
 `insertNode` (e.g. `i(1)`). Using an `insertNode` or `textNode` directly as a choice is also fine,
 the latter is special-cased to have a jump-point at the beginning of its text.
 
-* `pos: integer` Jump-index of the node. (See [Basics-Jump-Index](#jump-index))
+* `pos?: integer?` Jump-index of the node. (See [Basics-Jump-Index](#jump-index))
 * `choices: (LuaSnip.Node|LuaSnip.Node[])[]` A list of nodes that can be switched between
   interactively. If a list of nodes is passed as a choice, it will be turned into a snippetNode.
   Jumpable nodes that generally need a jump-index don't need one when used as a choice since they
   inherit the choiceNode's jump-index anyway.
-* `opts?: LuaSnip.Opts.ChoiceNode?` Additional optional arguments.  
+* `node_opts?: LuaSnip.Opts.ChoiceNode?` Additional optional arguments.  
   Valid keys are:
 
   * `restore_cursor?: boolean?` If set, the currently active node is looked up in the switched-to

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 10
+*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 18
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -807,7 +807,7 @@ have a jump-point at the beginning of its text.
         end
     <
     Consider passing this override into `snip_env`.
-  - `node_callbacks?: { [("change_choice"|"enter"...)]: fun(...) -> ... }?`
+  - `node_callbacks?: { [LuaSnip.EventType]: fun(...) -> ... }?`
   - `node_ext_opts?: LuaSnip.NodeExtOpts?` Pass these opts through to the
     underlying extmarks representing the node. Notably, this enables highlighting
     the nodes, and allows the highlight to be different based on the state of the

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 08
+*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 10
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 04
+*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 08
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 18
+*luasnip.txt*         For NeoVim 0.7-0.11         Last change: 2026 January 10
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 03
+*luasnip.txt*         For NeoVim 0.7-0.11        Last change: 2025 November 04
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*
@@ -772,23 +772,24 @@ ChoiceNodes allow choosing between multiple nodes.
      }))
 <
 
-`c(pos, choices, opts?): LuaSnip.ChoiceNode`: Create a new choiceNode from a
-list of choices. The first item in this list is the initial choice, and it can
-be changed while any node of a choice is active. So, if all choices should be
-reachable, every choice has to have a place for the cursor to stop at.
+`c(pos?, choices, node_opts?): LuaSnip.ChoiceNode`: Create a new choiceNode
+from a list of choices. The first item in this list is the initial choice, and
+it can be changed while any node of a choice is active. So, if all choices
+should be reachable, every choice has to have a place for the cursor to stop
+at.
 
 If the choice is a snippetNode like `sn(nil, {...nodes...})` the given `nodes`
 have to contain an `insertNode` (e.g. `i(1)`). Using an `insertNode` or
 `textNode` directly as a choice is also fine, the latter is special-cased to
 have a jump-point at the beginning of its text.
 
-- `pos: integer` Jump-index of the node. (See |luasnip-basics-jump-index|)
+- `pos?: integer?` Jump-index of the node. (See |luasnip-basics-jump-index|)
 - `choices: (LuaSnip.Node|LuaSnip.Node[])[]` A list of nodes that can be switched
   between interactively. If a list of nodes is passed as a choice, it will be
   turned into a snippetNode. Jumpable nodes that generally need a jump-index
   don’t need one when used as a choice since they inherit the choiceNode’s
   jump-index anyway.
-- `opts?: LuaSnip.Opts.ChoiceNode?` Additional optional arguments.
+- `node_opts?: LuaSnip.Opts.ChoiceNode?` Additional optional arguments.
   Valid keys are:
   - `restore_cursor?: boolean?` If set, the currently active node is looked up in
     the switched-to choice, and the cursor restored to preserve the current

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*          For NeoVim 0.7-0.11          Last change: 2026 April 05
+*luasnip.txt*          For NeoVim 0.7-0.11          Last change: 2026 April 07
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NeoVim 0.9-0.11           Last change: 2026 May 19
+*luasnip.txt*           For NeoVim 0.9-0.11          Last change: 2026 June 07
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/_types.lua
+++ b/lua/luasnip/_types.lua
@@ -17,5 +17,5 @@
 ---@field from LuaSnip.BytecolBufferPosition Starting position, included.
 ---@field to LuaSnip.BytecolBufferPosition Ending position, excluded.
 
----@alias LuaSnip.NormalizedNodeRef LuaSnip.KeyIndexer|LuaSnip.AbsoluteIndexer
----@alias LuaSnip.NodeRef LuaSnip.KeyIndexer|LuaSnip.AbsoluteIndexer|number
+---@alias LuaSnip.NormalizedNodeRef LuaSnip.KeyIndexer|LuaSnip.AbsoluteIndexer|LuaSnip.OptionalNodeRef
+---@alias LuaSnip.NodeRef LuaSnip.KeyIndexer|LuaSnip.AbsoluteIndexer|LuaSnip.OptionalNodeRef|number

--- a/lua/luasnip/_types.lua
+++ b/lua/luasnip/_types.lua
@@ -16,3 +16,6 @@
 ---@class LuaSnip.BufferRegion
 ---@field from LuaSnip.BytecolBufferPosition Starting position, included.
 ---@field to LuaSnip.BytecolBufferPosition Ending position, excluded.
+
+---@alias LuaSnip.NormalizedNodeRef LuaSnip.KeyIndexer|LuaSnip.AbsoluteIndexer
+---@alias LuaSnip.NodeRef LuaSnip.KeyIndexer|LuaSnip.AbsoluteIndexer|number

--- a/lua/luasnip/extras/conditions/expand.lua
+++ b/lua/luasnip/extras/conditions/expand.lua
@@ -50,7 +50,8 @@ function M.trigger_not_preceded_by(pattern)
 		if line_to_trigger_len == 0 then
 			return true
 		end
-		local char_before_trigger = line_to_cursor:sub(line_to_trigger_len, line_to_trigger_len)
+		local char_before_trigger =
+			line_to_cursor:sub(line_to_trigger_len, line_to_trigger_len)
 		return not char_before_trigger:match(pattern)
 	end
 	return cond_obj.make_condition(condition)

--- a/lua/luasnip/extras/conditions/expand.lua
+++ b/lua/luasnip/extras/conditions/expand.lua
@@ -9,6 +9,7 @@ local function line_begin(line_to_cursor, matched_trigger)
 	-- +1 because `string.sub("abcd", 1, -2)` -> abc
 	return line_to_cursor:sub(1, -(#matched_trigger + 1)):match("^%s*$")
 end
+--- A condition obj that is true when the trigger is at start of line (maybe after indent).
 M.line_begin = cond_obj.make_condition(line_begin)
 
 --- The wordTrig flag will only expand the snippet if
@@ -41,16 +42,16 @@ M.line_begin = cond_obj.make_condition(line_begin)
 --- I think the character wordTrig=true uses should be customized
 --- A condtion seems like the best way to do it
 ---
---- @param pattern string should be a character class eg `[%w]`
+---@param pattern string should be a character class eg `[%w]`
+---@return LuaSnip.SnipContext.ConditionObj
 function M.trigger_not_preceded_by(pattern)
 	local condition = function(line_to_cursor, matched_trigger)
 		local line_to_trigger_len = #line_to_cursor - #matched_trigger
 		if line_to_trigger_len == 0 then
 			return true
 		end
-		return not string
-			.sub(line_to_cursor, line_to_trigger_len, line_to_trigger_len)
-			:match(pattern)
+		local char_before_trigger = line_to_cursor:sub(line_to_trigger_len, line_to_trigger_len)
+		return not char_before_trigger:match(pattern)
 	end
 	return cond_obj.make_condition(condition)
 end

--- a/lua/luasnip/extras/conditions/init.lua
+++ b/lua/luasnip/extras/conditions/init.lua
@@ -29,7 +29,7 @@
 --- ```
 ---
 ---@class LuaSnip.SnipContext.ConditionObj
----@field func LuaSnip.SnipContext.ConditionFn
+---@field func LuaSnip.SnipContext.ConditionFn|LuaSnip.SnipContext.ShowConditionFn
 ---
 ---@overload fun(line_to_cursor: string, matched_trigger: string, captures: string[]): boolean
 ---  (note: same signature as `func` field)

--- a/lua/luasnip/extras/conditions/init.lua
+++ b/lua/luasnip/extras/conditions/init.lua
@@ -1,55 +1,99 @@
-local M = {}
-
------------------------
--- CONDITION OBJECTS --
------------------------
-local condition_mt = {
-	-- logic operators
-	-- not '-'
-	__unm = function(o1)
-		return M.make_condition(function(...)
-			return not o1(...)
-		end)
-	end,
-	-- or '+'
-	__add = function(o1, o2)
-		return M.make_condition(function(...)
-			return o1(...) or o2(...)
-		end)
-	end,
-	__sub = function(o1, o2)
-		return M.make_condition(function(...)
-			return o1(...) and not o2(...)
-		end)
-	end,
-	-- and '*'
-	__mul = function(o1, o2)
-		return M.make_condition(function(...)
-			return o1(...) and o2(...)
-		end)
-	end,
-	-- xor '^'
-	__pow = function(o1, o2)
-		return M.make_condition(function(...)
-			return o1(...) ~= o2(...)
-		end)
-	end,
-	-- xnor '%'
-	-- might be counter intuitive, but as we can't use '==' (must return bool)
-	-- it's best to use something weird (doesn't have to be used)
-	__mod = function(o1, o2)
-		return function(...)
-			return o1(...) == o2(...)
-		end
-	end,
+--- A composable condition object, can be used for `condition` in a snippet
+--- context.
+---
+---@class LuaSnip.SnipContext.ConditionObj
+---@field func LuaSnip.SnipContext.ConditionFn
+---
+---@overload fun(line_to_cursor: string, matched_trigger: string, captures: string[]): boolean
+---  (note: same signature as `func` field)
+---
+---@operator unm: LuaSnip.SnipContext.ConditionObj
+---@operator add(LuaSnip.SnipContext.Condition): LuaSnip.SnipContext.ConditionObj
+---@operator sub(LuaSnip.SnipContext.Condition): LuaSnip.SnipContext.ConditionObj
+---@operator mul(LuaSnip.SnipContext.Condition): LuaSnip.SnipContext.ConditionObj
+---@operator pow(LuaSnip.SnipContext.Condition): LuaSnip.SnipContext.ConditionObj
+---@operator mod(LuaSnip.SnipContext.Condition): LuaSnip.SnipContext.ConditionObj
+local ConditionObj = {}
+local ConditionObj_mt = {
+	__index = ConditionObj,
 	-- use table like a function by overloading __call
-	__call = function(tab, line_to_cursor, matched_trigger, captures)
-		return tab.func(line_to_cursor, matched_trigger, captures)
+	__call = function(self, line_to_cursor, matched_trigger, captures)
+		return self.func(line_to_cursor, matched_trigger, captures)
 	end,
 }
 
-function M.make_condition(func)
-	return setmetatable({ func = func }, condition_mt)
+--- Wrap the given `condition` function in a composable condition object.
+---@param func LuaSnip.SnipContext.Condition
+---@return LuaSnip.SnipContext.ConditionObj
+function ConditionObj.make_condition(func)
+	return setmetatable({ func = func }, ConditionObj_mt)
 end
 
-return M
+--- Returns a condition object equivalent to `not self(...)`
+---@return LuaSnip.SnipContext.ConditionObj
+function ConditionObj:inverted()
+	return ConditionObj.make_condition(function(...)
+		return not self(...)
+	end)
+end
+-- (e.g. `-cond`)
+ConditionObj_mt.__unm = ConditionObj.inverted
+
+--- Returns a condition object equivalent to `self(...) or other(...)`
+---@param other LuaSnip.SnipContext.Condition
+---@return LuaSnip.SnipContext.ConditionObj
+function ConditionObj:or_(other)
+	return ConditionObj.make_condition(function(...)
+		return self(...) or other(...)
+	end)
+end
+-- (e.g. `cond1 + cond2`)
+ConditionObj_mt.__add = ConditionObj.or_
+
+--- Returns a condition object equivalent to `self(...) and not other(...)`
+---@param other LuaSnip.SnipContext.Condition
+---@return LuaSnip.SnipContext.ConditionObj
+function ConditionObj:and_not(other)
+	return ConditionObj.make_condition(function(...)
+		return self(...) and not other(...)
+	end)
+end
+-- (e.g. `cond1 - cond2`)
+ConditionObj_mt.__sub = ConditionObj.and_not
+
+--- Returns a condition object equivalent to `self(...) and other(...)`
+---@param other LuaSnip.SnipContext.Condition
+---@return LuaSnip.SnipContext.ConditionObj
+function ConditionObj:and_(other)
+	return ConditionObj.make_condition(function(...)
+		return self(...) and other(...)
+	end)
+end
+-- (e.g. `cond1 * cond2`)
+ConditionObj_mt.__mul = ConditionObj.and_
+
+--- Returns a condition object equivalent to `self(...) ~= other(...)`
+---@param other LuaSnip.SnipContext.Condition
+---@return LuaSnip.SnipContext.ConditionObj
+function ConditionObj:not_same_as(other)
+	return ConditionObj.make_condition(function(...)
+		return self(...) ~= other(...)
+	end)
+end
+-- (e.g. `cond1 ^ cond2`)
+ConditionObj_mt.__pow = ConditionObj.not_same_as
+
+--- Returns a condition object equivalent to `self(...) == other(...)`
+---@param other LuaSnip.SnipContext.Condition
+---@return LuaSnip.SnipContext.ConditionObj
+function ConditionObj:same_as(other)
+	return ConditionObj.make_condition(function(...)
+		return self(...) == other(...)
+	end)
+end
+-- (e.g. `cond1 % cond2`)
+-- This operator might be counter intuitive, but '==' can't be used as it must
+-- return a boolean. It's best to use something weird (doesn't have to be used)
+ConditionObj_mt.__mod = ConditionObj.same_as
+
+return ConditionObj

--- a/lua/luasnip/extras/conditions/init.lua
+++ b/lua/luasnip/extras/conditions/init.lua
@@ -1,5 +1,33 @@
---- A composable condition object, can be used for `condition` in a snippet
---- context.
+
+--- A composable condition object. It can be used for `condition` in a snippet
+--- context but can also be logically combined with other condition
+--- function/object to build complex conditions.
+---
+--- This makes logical combinations of conditions very readable.
+---
+--- Compare
+--- ```lua
+--- local conds = require"luasnip.extras.conditions.expand"
+--- ...
+--- -- using combinator functions:
+--- condition = conds.line_end:or_(conds.line_begin)
+--- -- using operators:
+--- condition = conds.line_end + conds.line_begin
+--- ```
+---
+--- with the more verbose
+---
+--- ```lua
+--- local conds = require"luasnip.extras.conditions.expand"
+--- ...
+--- condition = function(...) return conds.line_end(...) or conds.line_begin(...) end
+--- ```
+---
+--- The conditions provided in `show` and `expand` are already condition objects.
+--- To create new ones, use:
+--- ```lua
+--- require("luasnip.extras.conditions").make_condition(condition_fn)
+--- ```
 ---
 ---@class LuaSnip.SnipContext.ConditionObj
 ---@field func LuaSnip.SnipContext.ConditionFn
@@ -22,8 +50,8 @@ local ConditionObj_mt = {
 	end,
 }
 
---- Wrap the given `condition` function in a composable condition object.
----@param func LuaSnip.SnipContext.Condition
+--- Wrap the given `condition` function into a composable condition object.
+---@param func LuaSnip.SnipContext.ConditionFn
 ---@return LuaSnip.SnipContext.ConditionObj
 function ConditionObj.make_condition(func)
 	return setmetatable({ func = func }, ConditionObj_mt)
@@ -36,7 +64,7 @@ function ConditionObj:inverted()
 		return not self(...)
 	end)
 end
--- (e.g. `-cond`)
+--- (e.g. `-cond`, implemented as `cond:inverted()`)
 ConditionObj_mt.__unm = ConditionObj.inverted
 
 --- Returns a condition object equivalent to `self(...) or other(...)`
@@ -47,10 +75,17 @@ function ConditionObj:or_(other)
 		return self(...) or other(...)
 	end)
 end
--- (e.g. `cond1 + cond2`)
+--- (e.g. `cond1 + cond2`, implemented as `cond1:or_(cond2)`)
 ConditionObj_mt.__add = ConditionObj.or_
 
 --- Returns a condition object equivalent to `self(...) and not other(...)`
+---
+--- This is similar to set differences: `A \ B = {a in A | a not in B}`.
+--- This makes `-(a + b) = -a - b` an identity representing de Morgan's law:
+--- `not (a or b) = not a and not b`.
+--- However, since boolean algebra lacks an additive inverse, `a + (-b) = a - b`
+--- does not hold. Thus, this is NOT the same as `c1 + (-c2)`.
+---
 ---@param other LuaSnip.SnipContext.Condition
 ---@return LuaSnip.SnipContext.ConditionObj
 function ConditionObj:and_not(other)
@@ -58,7 +93,7 @@ function ConditionObj:and_not(other)
 		return self(...) and not other(...)
 	end)
 end
--- (e.g. `cond1 - cond2`)
+--- (e.g. `cond1 - cond2`, implemented as `cond1:and_not(cond2)`)
 ConditionObj_mt.__sub = ConditionObj.and_not
 
 --- Returns a condition object equivalent to `self(...) and other(...)`
@@ -69,10 +104,10 @@ function ConditionObj:and_(other)
 		return self(...) and other(...)
 	end)
 end
--- (e.g. `cond1 * cond2`)
+--- (e.g. `cond1 * cond2`, implemented as `cond1:and_(cond2)`)
 ConditionObj_mt.__mul = ConditionObj.and_
 
---- Returns a condition object equivalent to `self(...) ~= other(...)`
+--- Returns a condition object equivalent to `self(...) ~= other(...)` (xor)
 ---@param other LuaSnip.SnipContext.Condition
 ---@return LuaSnip.SnipContext.ConditionObj
 function ConditionObj:not_same_as(other)
@@ -80,10 +115,10 @@ function ConditionObj:not_same_as(other)
 		return self(...) ~= other(...)
 	end)
 end
--- (e.g. `cond1 ^ cond2`)
+--- (e.g. `cond1 ^ cond2`, implemented as `cond1:not_same_as(cond2)`)
 ConditionObj_mt.__pow = ConditionObj.not_same_as
 
---- Returns a condition object equivalent to `self(...) == other(...)`
+--- Returns a condition object equivalent to `self(...) == other(...)` (xnor)
 ---@param other LuaSnip.SnipContext.Condition
 ---@return LuaSnip.SnipContext.ConditionObj
 function ConditionObj:same_as(other)
@@ -91,9 +126,13 @@ function ConditionObj:same_as(other)
 		return self(...) == other(...)
 	end)
 end
--- (e.g. `cond1 % cond2`)
--- This operator might be counter intuitive, but '==' can't be used as it must
--- return a boolean. It's best to use something weird (doesn't have to be used)
+--- (e.g. `cond1 % cond2`, implemented as `cond1:same_as(cond2)`)
+---
+--- Using `%` might be counter intuitive, considering the `==`-operator exists,
+--- unfortunately, it's not possible to use this for our purposes (some info
+--- [here](https://github.com/L3MON4D3/LuaSnip/pull/612#issuecomment-1264487743)).
+--- We decided instead to make use of a more obscure symbol (which will
+--- hopefully avoid false assumptions about its meaning).
 ConditionObj_mt.__mod = ConditionObj.same_as
 
 return ConditionObj

--- a/lua/luasnip/extras/conditions/init.lua
+++ b/lua/luasnip/extras/conditions/init.lua
@@ -1,4 +1,3 @@
-
 --- A composable condition object. It can be used for `condition` in a snippet
 --- context but can also be logically combined with other condition
 --- function/object to build complex conditions.

--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -23,7 +23,7 @@ local rp = require("luasnip.extras").rep
 ---   counting from the new value (e.g. `{} {3} {}` is `{1} {3} {4}`)
 ---
 ---@param fmt string String with placeholders
----@param args table Table with list-like and/or map-like keys
+---@param args {[integer|string]: LuaSnip.Node} Table with list-like and/or map-like keys
 ---@param opts? LuaSnip.Opts.Extra.FmtInterpolate
 ---@return (string|LuaSnip.Node)[] _ A list of strings & elements of `args`
 ---  inserted into placeholders.

--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -1,53 +1,39 @@
 local text_node = require("luasnip.nodes.textNode").T
-local wrap_nodes = require("luasnip.util.util").wrap_nodes
+local util = require("luasnip.util.util")
 local extend_decorator = require("luasnip.util.extend_decorator")
 local Str = require("luasnip.util.str")
 local rp = require("luasnip.extras").rep
 
--- https://gist.github.com/tylerneylon/81333721109155b2d244
-local function copy3(obj, seen)
-	-- Handle non-tables and previously-seen tables.
-	if type(obj) ~= "table" then
-		return obj
-	end
-	if seen and seen[obj] then
-		return seen[obj]
-	end
+---@class LuaSnip.Opts.Extra.FmtInterpolate
+---@field delimiters? string String of 2 distinct characters (left, right).
+---  Defaults to "{}".
+---@field strict? boolean Whether to allow error out on unused `args`.
+---  Defaults to true.
+---@field repeat_duplicates? boolean Repeat nodes which have the same jump_index
+---  instead of copying them. Default to false.
 
-	-- New table; mark it as seen an copy recursively.
-	local s = seen or {}
-	local res = {}
-	s[obj] = res
-	for k, v in next, obj do
-		res[copy3(k, s)] = copy3(v, s)
-	end
-	return setmetatable(res, getmetatable(obj))
-end
-
--- Interpolate elements from `args` into format string with placeholders.
---
--- The placeholder syntax for selecting from `args` is similar to fmtlib and
--- Python's .format(), with some notable differences:
--- * no format options (like `{:.2f}`)
--- * 1-based indexing
--- * numbered/auto-numbered placeholders can be mixed; numbered ones set the
---   current index to new value, so following auto-numbered placeholders start
---   counting from the new value (e.g. `{} {3} {}` is `{1} {3} {4}`)
---
--- Arguments:
---   fmt: string with placeholders
---   args: table with list-like and/or map-like keys
---   opts:
---     delimiters: string, 2 distinct characters (left, right), default "{}"
---     strict: boolean, set to false to allow for unused `args`, default true
---     repeat_duplicates: boolean, repeat nodes which have jump_index instead of copying them, default false
--- Returns: a list of strings and elements of `args` inserted into placeholders
+--- Interpolate elements from `args` into format string with placeholders.
+---
+--- The placeholder syntax for selecting from `args` is similar to fmtlib and
+--- Python's .format(), with some notable differences:
+--- * no format options (like `{:.2f}`)
+--- * 1-based indexing
+--- * numbered/auto-numbered placeholders can be mixed; numbered ones set the
+---   current index to new value, so following auto-numbered placeholders start
+---   counting from the new value (e.g. `{} {3} {}` is `{1} {3} {4}`)
+---
+---@param fmt string String with placeholders
+---@param args table Table with list-like and/or map-like keys
+---@param opts? LuaSnip.Opts.Extra.FmtInterpolate
+---@return (string|LuaSnip.Node)[] _ A list of strings & elements of `args`
+---  inserted into placeholders.
 local function interpolate(fmt, args, opts)
 	local defaults = {
 		delimiters = "{}",
 		strict = true,
 		repeat_duplicates = false,
 	}
+	---@type LuaSnip.Opts.Extra.FmtInterpolate
 	opts = vim.tbl_extend("force", defaults, opts or {})
 
 	-- sanitize delimiters
@@ -102,7 +88,7 @@ local function interpolate(fmt, args, opts)
 		if used_keys[key] then
 			local jump_index = args[key]:get_jump_index() -- For nodes that don't have a jump index, copy it instead
 			if not opts.repeat_duplicates or jump_index == nil then
-				table.insert(elements, copy3(args[key]))
+				table.insert(elements, util.copy3(args[key]))
 			else
 				table.insert(elements, rp(jump_index))
 			end
@@ -175,30 +161,34 @@ local function interpolate(fmt, args, opts)
 	return elements
 end
 
--- Use a format string with placeholders to interpolate nodes.
---
--- See `interpolate` documentation for details on the format.
---
--- Arguments:
---   str: format string
---   nodes: snippet node or list of nodes
---   opts: optional table
---     trim_empty: boolean, remove whitespace-only first/last lines, default true
---     dedent: boolean, remove all common indent in `str`, default true
---     indent_string: string, convert `indent_string` at beginning of each line to unit indent ('\t')
---                            after applying `dedent`, default empty string (disabled)
---     ... the rest is passed to `interpolate`
--- Returns: list of snippet nodes
+---@class LuaSnip.Opts.Extra.Fmt: LuaSnip.Opts.Extra.FmtInterpolate
+---@field trim_empty? boolean Whether to remove whitespace-only first/last lines
+---  Defaults to true.
+---@field dedent? boolean Whether to remove all common indent in `str`.
+---  Defaults to true.
+---@field indent_string? string When set, will convert `indent_string` at
+---  beginning of each line to unit indent ('\t') after applying `dedent`.
+---  Defaults to empty string (disabled).
+
+--- Use a format string with placeholders to interpolate nodes.
+---
+--- See `interpolate` documentation for details on the format.
+---
+---@param str string The format string
+---@param nodes LuaSnip.Node|LuaSnip.Node[]
+---@param opts? LuaSnip.Opts.Extra.Fmt
+---@return LuaSnip.Node[]
 local function format_nodes(str, nodes, opts)
 	local defaults = {
 		trim_empty = true,
 		dedent = true,
 		indent_string = "",
 	}
+	---@type LuaSnip.Opts.Extra.Fmt
 	opts = vim.tbl_extend("force", defaults, opts or {})
 
 	-- allow to pass a single node
-	nodes = wrap_nodes(nodes)
+	nodes = util.wrap_nodes(nodes)
 
 	-- optimization: avoid splitting multiple times
 	local lines = nil

--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -194,8 +194,12 @@ local function format_nodes(str, nodes, opts)
 	-- optimization: avoid splitting multiple times
 	local lines = nil
 
-	lines = vim.split(str, "\n", true)
-	Str.process_multiline(lines, opts)
+	lines = vim.split(str, "\n", { plain = true })
+	Str.process_multiline(lines, {
+		trim_empty = opts.trim_empty,
+		dedent = opts.dedent,
+		indent_string = opts.indent_string,
+	})
 	str = table.concat(lines, "\n")
 
 	-- pop format_nodes's opts
@@ -207,7 +211,7 @@ local function format_nodes(str, nodes, opts)
 	return vim.tbl_map(function(part)
 		-- wrap strings in text nodes
 		if type(part) == "string" then
-			return text_node(vim.split(part, "\n", true))
+			return text_node(vim.split(part, "\n", { plain = true }))
 		else
 			return part
 		end
@@ -219,7 +223,7 @@ extend_decorator.register(format_nodes, { arg_indx = 3 })
 return {
 	interpolate = interpolate,
 	format_nodes = format_nodes,
-	-- alias
+	-- aliases
 	fmt = format_nodes,
 	fmta = extend_decorator.apply(format_nodes, { delimiters = "<>" }),
 }

--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -23,7 +23,8 @@ local rp = require("luasnip.extras").rep
 ---   counting from the new value (e.g. `{} {3} {}` is `{1} {3} {4}`)
 ---
 ---@param fmt string String with placeholders
----@param args {[integer|string]: LuaSnip.Node} Table with list-like and/or map-like keys
+---@param args LuaSnip.Node[]|{[string]: LuaSnip.Node} Table with list-like
+---  and/or map-like keys
 ---@param opts? LuaSnip.Opts.Extra.FmtInterpolate
 ---@return (string|LuaSnip.Node)[] _ A list of strings & elements of `args`
 ---  inserted into placeholders.
@@ -175,7 +176,7 @@ end
 --- See `interpolate` documentation for details on the format.
 ---
 ---@param str string The format string
----@param nodes LuaSnip.Node|LuaSnip.Node[]
+---@param nodes LuaSnip.Node|LuaSnip.Node[]|{[string]: LuaSnip.Node}
 ---@param opts? LuaSnip.Opts.Extra.Fmt
 ---@return LuaSnip.Node[]
 local function format_nodes(str, nodes, opts)

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -122,7 +122,7 @@ return {
 	--- s("extras4", { i(1), t { "", "" }, extras.rep(1) })
 	--- ```
 	---
-	---@param node_ref LuaSnip.NodeRef a single [Node Reference](#node-reference).
+	---@param node_ref LuaSnip.NodeRef a single [Node Reference](../../../DOC.md#node-reference).
 	---@return LuaSnip.FunctionNode
 	rep = function(node_ref)
 		return F(function(args)

--- a/lua/luasnip/extras/init.lua
+++ b/lua/luasnip/extras/init.lua
@@ -116,11 +116,18 @@ end
 return {
 	lambda = lambda,
 	match = match,
-	-- repeat a node.
-	rep = function(node_indx)
+	--- Repeat a node, by inserting the text of the passed node.
+	---
+	--- ```lua
+	--- s("extras4", { i(1), t { "", "" }, extras.rep(1) })
+	--- ```
+	---
+	---@param node_ref LuaSnip.NodeRef a single [Node Reference](#node-reference).
+	---@return LuaSnip.FunctionNode
+	rep = function(node_ref)
 		return F(function(args)
 			return args[1]
-		end, node_indx)
+		end, node_ref)
 	end,
 	-- Insert the output of a function.
 	partial = function(func, ...)

--- a/lua/luasnip/init.lua
+++ b/lua/luasnip/init.lua
@@ -61,6 +61,10 @@ local function api_leave()
 	session.luasnip_changedtick = nil
 end
 
+---@generic T: any?
+---@param fn (fun(...))|(fun(...): T)
+---@param ... any
+---@return T
 local function api_do(fn, ...)
 	api_enter()
 
@@ -523,6 +527,7 @@ end
 ---@field jump_into_func? (fun(snip: LuaSnip.Snippet): LuaSnip.Node)
 ---  Callback responsible for jumping into the snippet. The returned node is
 ---  set as the new active node, i.e. it is the origin of the next jump.
+---
 ---  The default is basically this:
 ---  ```lua
 ---  function(snip)
@@ -531,15 +536,14 @@ end
 ---      return snip:jump_into(1)
 ---  end
 ---  ```
----  while this can be used to insert the snippet and immediately move the cursor
----  at the `i(0)`:
+---  while this can be used to insert the snippet and immediately move the
+---  cursor at the `i(0)`:
 ---  ```lua
 ---  function(snip)
 ---      return snip.insert_nodes[0]
 ---  end
 ---  ```
 
---This can also use `jump_into_func`.
 ---@class LuaSnip.Opts.SnipExpand: LuaSnip.Opts.Expand
 ---
 ---@field clear_region? LuaSnip.BufferRegion A region of text to clear after
@@ -590,8 +594,12 @@ end
 ---  }
 ---  ```
 
+---@param snippet LuaSnip.Snippet
+---@param opts? LuaSnip.Opts.SnipExpand
+---@return LuaSnip.ExpandedSnippet
 local function _snip_expand(snippet, opts)
 	local snip = snippet:copy()
+	---@cast snip LuaSnip.ExpandedSnippet
 
 	opts = opts or {}
 	opts.expand_params = opts.expand_params or {}
@@ -681,9 +689,8 @@ function API.snip_expand(snippet, opts)
 end
 
 ---Find a snippet matching the current cursor-position.
----@param opts table: may contain:
---- - `jump_into_func`: passed through to `snip_expand`.
----@return boolean: whether a snippet was expanded.
+---@param opts? LuaSnip.Opts.Expand
+---@return boolean _ Whether a snippet was expanded.
 local function _expand(opts)
 	local expand_params
 	local snip
@@ -740,6 +747,7 @@ function API.expand_auto()
 		local snip, expand_params =
 			match_snippet(util.get_current_line_to_cursor(), "autosnippets")
 		if snip then
+			---@cast expand_params -nil
 			local cursor = util.get_cursor_0ind()
 			local clear_region = expand_params.clear_region
 				or {

--- a/lua/luasnip/loaders/from_lua.lua
+++ b/lua/luasnip/loaders/from_lua.lua
@@ -102,6 +102,7 @@ local function _luasnip_load_file(file)
 		log.error("Failed to load %s\n: %s", file, error_msg)
 		error(string.format("Failed to load %s\n: %s", file, error_msg))
 	end
+	---@cast func -nil
 
 	-- the loaded file may add snippets to these tables, they'll be
 	-- combined with the snippets returned regularly.

--- a/lua/luasnip/loaders/util.lua
+++ b/lua/luasnip/loaders/util.lua
@@ -87,7 +87,7 @@ end
 
 ---Get paths of .snippets files
 ---@param root string @snippet directory path
----@return table @keys are file types, values are paths
+---@return table _ @keys are file types, values are paths
 local function get_ft_paths(root, extension)
 	local ft_path = {}
 	local files, dirs = Path.scandir(root)
@@ -155,7 +155,7 @@ end
 --- directory named `rtp_dirname` in the runtimepath.
 ---@param extension string: extension of valid snippet-files for the given
 --- collection (eg `.lua` or `.snippets`)
----@return table: a list of tables, each of the inner tables contains two
+---@return table _ a list of tables, each of the inner tables contains two
 --- entries:
 --- - collection_paths: ft->files for the entire collection and
 --- - load_paths: ft->files for only the files that should be loaded.

--- a/lua/luasnip/nodes/absolute_indexer.lua
+++ b/lua/luasnip/nodes/absolute_indexer.lua
@@ -1,5 +1,9 @@
 -- absolute_indexer[0][1][2][3] -> { absolute_insert_position = {0,1,2,3} }
 
+---@class LuaSnip.AbsoluteIndexer: {[integer]: LuaSnip.AbsoluteIndexer}
+---@field absolute_insert_position integer[]
+
+---@return LuaSnip.AbsoluteIndexer
 local function new()
 	return setmetatable({
 		absolute_insert_position = {},

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -122,7 +122,12 @@ function ChoiceNode:subsnip_init()
 	for _, choice in ipairs(self.choices) do
 		choice.parent = self.parent
 		-- only insertNode needs this. (?)
-		if vim.list_contains({types.textNode, types.insertNode, types.functionNode}, choice.type) then
+		if
+			vim.list_contains(
+				{ types.textNode, types.insertNode, types.functionNode },
+				choice.type
+			)
+		then
 			choice.pos = self.pos
 		end
 	end

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -123,7 +123,7 @@ function ChoiceNode:subsnip_init()
 		choice.parent = self.parent
 		-- only insertNode needs this. (?)
 		if
-			util.list_contains(
+			vim.tbl_contains(
 				{ types.textNode, types.insertNode, types.functionNode },
 				choice.type
 			)

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -61,7 +61,7 @@ end
 ---  ```
 ---  Consider passing this override into `snip_env`.
 ---
----@field node_callbacks? {["change_choice"|"enter"|"leave"]: fun(node:LuaSnip.Node)}
+---@field node_callbacks? {[LuaSnip.EventType]: fun(node:LuaSnip.Node)}
 ---  Specify functions to call after changing the choice, or entering or leaving
 ---  the node. The callback receives the `node` the callback was called on.
 

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -123,7 +123,7 @@ function ChoiceNode:subsnip_init()
 		choice.parent = self.parent
 		-- only insertNode needs this. (?)
 		if
-			vim.list_contains(
+			util.list_contains(
 				{ types.textNode, types.insertNode, types.functionNode },
 				choice.type
 			)

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -458,6 +458,7 @@ function ChoiceNode:extmarks_valid()
 	return node_util.generic_extmarks_valid(self, self.active_choice)
 end
 
+---@param opts LuaSnip.Opts.NodeSubtreeDo
 function ChoiceNode:subtree_do(opts)
 	opts.pre(self)
 	self.active_choice:subtree_do(opts)

--- a/lua/luasnip/nodes/choiceNode.lua
+++ b/lua/luasnip/nodes/choiceNode.lua
@@ -11,9 +11,17 @@ local feedkeys = require("luasnip.util.feedkeys")
 local log = require("luasnip.util.log").new("choice")
 
 ---@class LuaSnip.ChoiceNode.ItemNode: LuaSnip.Node
+---@field choice ...
+---@field parent? LuaSnip.ChoiceNode
+---@field next_choice? LuaSnip.ChoiceNode.ItemNode
+---@field prev_choice LuaSnip.ChoiceNode.ItemNode
 
 ---@class LuaSnip.ChoiceNode: LuaSnip.Node
 ---@field choices LuaSnip.ChoiceNode.ItemNode[]
+---@field parent? LuaSnip.ChoiceNode
+---@field active_choice LuaSnip.ChoiceNode.ItemNode The active choice item node
+---@field restore_cursor boolean Whether the cursor should be restored when
+---  changing the current choice.
 local ChoiceNode = Node:new()
 
 function ChoiceNode:init_nodes()
@@ -111,8 +119,8 @@ extend_decorator.register(ChoiceNode.C, { arg_indx = 3 })
 function ChoiceNode:subsnip_init()
 	for _, choice in ipairs(self.choices) do
 		choice.parent = self.parent
-		-- only insertNode needs this.
-		if choice.type == 2 or choice.type == 1 or choice.type == 3 then
+		-- only insertNode needs this. (?)
+		if vim.list_contains({types.textNode, types.insertNode, types.functionNode}, choice.type) then
 			choice.pos = self.pos
 		end
 	end

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -607,6 +607,7 @@ function DynamicNode:extmarks_valid()
 	return true
 end
 
+---@param opts LuaSnip.Opts.NodeSubtreeDo
 function DynamicNode:subtree_do(opts)
 	opts.pre(self)
 	if opts.static then

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -15,7 +15,7 @@ local session = require("luasnip.session")
 ---@field old_state? any
 ---@field dynamicNode? LuaSnip.DynamicNode
 
----@alias LuaSnip.DynamicNode.Fn fun(args: (string[])[], parent: LuaSnip.Snippet | LuaSnip.SnippetNode, old_state?: table, ...: table): LuaSnip.SnippetNode
+---@alias LuaSnip.DynamicNode.Fn fun(args: (string[])[], parent: LuaSnip.Snippet | LuaSnip.SnippetNode, old_state?: table, ...: any): LuaSnip.SnippetNode
 
 ---@class LuaSnip.DynamicNode: LuaSnip.Node
 ---@field fn LuaSnip.DynamicNode.Fn
@@ -217,6 +217,8 @@ function DynamicNode:jump_into_snippet(no_move)
 	return self:jump_into(1, no_move, false)
 end
 
+-- FIXME(@bew): This should be on a `ExpandedDynamicNode` class?
+-- To have access to `next`/`prev` (that would go on a `ExpandedNode` 🤔)
 function DynamicNode:update()
 	local args = self:get_args()
 	local str_args = node_util.str_args(args)

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -263,8 +263,12 @@ function DynamicNode:update()
 
 	-- build new snippet before exiting, markers may be needed for
 	-- construncting.
-	tmp =
-		self.fn(effective_args or {}, self.parent, old_state, unpack(self.user_args))
+	tmp = self.fn(
+		effective_args or {},
+		self.parent,
+		old_state,
+		unpack(self.user_args)
+	)
 	---@cast tmp LuaSnip.SnippetNodeForDynNode
 
 	if self.snip then

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -1,4 +1,3 @@
-local DynamicNode = require("luasnip.nodes.node").Node:new()
 local util = require("luasnip.util.util")
 local node_util = require("luasnip.nodes.util")
 local Node = require("luasnip.nodes.node").Node
@@ -12,20 +11,90 @@ local log = require("luasnip.util.log").new("dynamicNode")
 local describe = require("luasnip.util.log").describe
 local session = require("luasnip.session")
 
-local function D(pos, fn, args, opts)
-	opts = opts or {}
+---@class LuaSnip.SnippetNodeForDynNode: LuaSnip.SnippetNode
+---@field old_state? any
+---@field dynamicNode? LuaSnip.DynamicNode
 
-	return DynamicNode:new({
+---@alias LuaSnip.DynamicNode.Fn fun(args: (string[])[], parent: LuaSnip.Snippet | LuaSnip.SnippetNode, old_state?: table, ...: table): LuaSnip.SnippetNode
+
+---@class LuaSnip.DynamicNode: LuaSnip.Node
+---@field fn LuaSnip.DynamicNode.Fn
+---@field user_args any[] Additional args that will be passed to `fn`
+---@field args LuaSnip.NodeRef[]
+---@field snip? LuaSnip.SnippetNodeForDynNode
+---@field static_snip? LuaSnip.SnippetNodeForDynNode
+---@field last_static_args? (string[])[]
+---@field snippetstring_args boolean
+local DynamicNode = Node:new()
+
+---@class LuaSnip.Opts.DynamicNode: LuaSnip.Opts.FunctionNode
+---@field snippetstring_args? boolean (FIXME: not documented?)
+
+--- Very similar to functionNode, but returns a snippetNode instead of just text,
+--- which makes them very powerful as parts of the snippet can be changed based on
+--- user input.
+---
+---@param pos integer? Just like all jumpable nodes, its' position in the
+---  jump-list ([Basics-Jump-Index](#jump-index)).
+---
+---@param fn LuaSnip.DynamicNode.Fn
+---  This function is called when the argnodes' text changes.
+---  It should generate and return (wrapped inside a `snippetNode`) nodes, which
+---  will be inserted at the dynamicNode's place.
+---
+---  note: `args`, `parent` and `user_args` are also explained in
+---  [FunctionNode](#functionnode)
+---
+---  - `argnode_text`: The text currently contained in the argnodes
+---    (e.g. `{{line1}, {line1, line2}}`).
+---
+---  - `parent`: The immediate parent of the `functionNode`. It is included here
+---    as it allows easy access to some information that could be useful in
+---    functionNodes (see [Snippets-Data](#data) for some examples).
+---
+---    Many snippets access the surrounding snippet just as `parent`, but if the
+---    `functionNode` is nested within a `snippetNode`, the immediate parent is
+---    a `snippetNode`, not the surrounding snippet (only the surrounding
+---    snippet contains data like `env` or `captures`).
+---
+---  - `old_state`: a user-defined table.
+---    This table may contain anything; its intended usage is to preserve
+---    information from the previously generated `snippetNode`.
+---    If the `dynamicNode` depends on other nodes, it may be
+---    reconstructed, which means all user input (text inserted in
+---    `insertNodes`, changed choices) to the previous `dynamicNode` is lost.
+---
+---    The `old_state` table must be stored in `snippetNode` returned by
+---    the function (`snippetNode.old_state`).
+---    The second example below illustrates the usage of `old_state`.
+---
+---  - `user_args`: The `user_args` passed in `opts`.
+---    Note that there may be multiple `user_args`.
+---    (e.g. `user_args1, ..., user_argsn`)
+---
+---@param argsnode_refs? LuaSnip.NodeRef[]|LuaSnip.NodeRef
+---  [Node References](#node-reference) to the nodes the dynamicNode depends on.
+---  Changing any of these will trigger a re-evaluation of `fn`, and the result will be inserted at the `dynamicNode`'s place.
+---  (`dynamicNode` behaves exactly the same as `functionNode` in this regard)
+---
+---@param node_opts? LuaSnip.Opts.DynamicNode
+---@return LuaSnip.DynamicNode
+local function D(pos, fn, argsnode_refs, node_opts)
+	node_opts = node_opts or {}
+
+	local node = DynamicNode:new({
 		pos = pos,
 		fn = fn,
-		args = node_util.wrap_args(args),
+		args = node_util.wrap_args(argsnode_refs or {}),
 		type = types.dynamicNode,
 		mark = nil,
-		user_args = opts.user_args or {},
-		snippetstring_args = opts.snippetstring_args or false,
+		user_args = node_opts.user_args or {},
+		snippetstring_args = node_opts.snippetstring_args or false,
 		dependents = {},
 		active = false,
-	}, opts)
+	}, node_opts)
+	---@cast node LuaSnip.DynamicNode
+	return node
 end
 extend_decorator.register(D, { arg_indx = 4 })
 
@@ -195,7 +264,8 @@ function DynamicNode:update()
 	-- build new snippet before exiting, markers may be needed for
 	-- construncting.
 	tmp =
-		self.fn(effective_args, self.parent, old_state, unpack(self.user_args))
+		self.fn(effective_args or {}, self.parent, old_state, unpack(self.user_args))
+	---@cast tmp LuaSnip.SnippetNodeForDynNode
 
 	if self.snip then
 		self.snip:exit()
@@ -332,6 +402,8 @@ function DynamicNode:update_static()
 		-- set empty snippet on failure
 		tmp = SnippetNode(nil, {})
 	end
+	---@cast tmp LuaSnip.SnippetNodeForDynNode
+
 	self.last_static_args = str_args
 
 	-- act as if snip is directly inside parent.
@@ -419,6 +491,7 @@ function DynamicNode:update_restore()
 		and vim.deep_equal(str_args, self.last_args)
 	then
 		local tmp = self.snip
+		---@cast tmp -nil
 
 		-- position might (will probably!!) still have changed, so update it
 		-- here too (as opposed to only in update).
@@ -498,7 +571,7 @@ end
 DynamicNode.make_args_absolute = FunctionNode.make_args_absolute
 DynamicNode.set_dependents = FunctionNode.set_dependents
 
-function DynamicNode:resolve_position(position, static)
+function DynamicNode:resolve_position(_position, static)
 	-- position must be 0, there are no other options.
 	if static then
 		return self.static_snip

--- a/lua/luasnip/nodes/dynamicNode.lua
+++ b/lua/luasnip/nodes/dynamicNode.lua
@@ -28,7 +28,8 @@ local session = require("luasnip.session")
 local DynamicNode = Node:new()
 
 ---@class LuaSnip.Opts.DynamicNode: LuaSnip.Opts.FunctionNode
----@field snippetstring_args? boolean (FIXME: not documented?)
+---@field snippetstring_args? boolean Preserve expanded inner snippets as
+---  snippet strings. Helps keep jump-points in self-dependent dynamic nodes.
 
 --- Very similar to functionNode, but returns a snippetNode instead of just text,
 --- which makes them very powerful as parts of the snippet can be changed based on

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -47,7 +47,7 @@ local FunctionNode = Node:new()
 --- local function fn(
 ---   args,     -- text from i(2) in this example i.e. { { "456" } }
 ---   parent,   -- parent snippet or parent node
----   user_args -- user_args from opts.user_args 
+---   user_args -- user_args from opts.user_args
 --- )
 ---    return '[' .. args[1][1] .. user_args .. ']'
 --- end

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -206,7 +206,8 @@ function FunctionNode:indent(_) end
 function FunctionNode:expand_tabs(_) end
 
 function FunctionNode:make_args_absolute(position_so_far)
-	self.args_absolute = node_util.make_args_absolute(self.args, position_so_far)
+	self.args_absolute =
+		node_util.make_args_absolute(self.args, position_so_far)
 end
 
 function FunctionNode:set_dependents()

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -9,7 +9,6 @@ local opt_args = require("luasnip.nodes.optional_arg")
 local snippet_string = require("luasnip.nodes.util.snippet_string")
 
 ---@alias LuaSnip.FunctionNode.Fn fun(args: (string[])[], parent: LuaSnip.Snippet | LuaSnip.SnippetNode, ...: table): string|string[]
--- FIXME: how to document each param of the callback function?
 
 ---@class LuaSnip.FunctionNode: LuaSnip.Node
 ---@field fn LuaSnip.FunctionNode.Fn
@@ -94,9 +93,6 @@ local FunctionNode = Node:new()
 ---
 ---@param node_opts? LuaSnip.Opts.FunctionNode
 ---@return LuaSnip.FunctionNode
---
--- FIXME(@bew): The super flexible NodeRef param & the fact that the NodeRef
--- type is an alias, makes luals make a huge function signature here 👀
 local function F(fn, argsnode_refs, node_opts)
 	node_opts = node_opts or {}
 

--- a/lua/luasnip/nodes/functionNode.lua
+++ b/lua/luasnip/nodes/functionNode.lua
@@ -206,8 +206,7 @@ function FunctionNode:indent(_) end
 function FunctionNode:expand_tabs(_) end
 
 function FunctionNode:make_args_absolute(position_so_far)
-	self.args_absolute = {}
-	node_util.make_args_absolute(self.args, position_so_far, self.args_absolute)
+	self.args_absolute = node_util.make_args_absolute(self.args, position_so_far)
 end
 
 function FunctionNode:set_dependents()

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -33,8 +33,56 @@ local ExitNode = InsertNode:new()
 --- })
 --- ```
 ---
---- FIXME(@bew): how to put the whole InsertNode documentation here, how to deal
---- with the gifs here?
+--- <demo-gif:InsertNode>
+---
+--- The Insert Nodes are visited in order `1,2,3,..,n,0`.
+--- (The jump-index 0 also _has_ to belong to an `insertNode`!)
+--- So the order of InsertNode-jumps is as follows:
+---
+--- 1. After expansion, the cursor is at InsertNode 1,
+--- 2. after jumping forward once at InsertNode 2,
+--- 3. and after jumping forward again at InsertNode 0.
+---
+--- If no 0-th InsertNode is found in a snippet, one is automatically inserted
+--- after all other nodes.
+---
+--- The jump-order doesn't have to follow the "textual" order of the nodes:
+--- ```lua
+--- s("trigger", {
+--- 	t({"After jumping forward once, cursor is here ->"}), i(2),
+--- 	t({"", "After expanding, the cursor is here ->"}), i(1),
+--- 	t({"", "After jumping once more, the snippet is exited there ->"}), i(0),
+--- })
+--- ```
+--- The above snippet will behave as follows:
+---
+--- 1. After expansion, we will be at InsertNode 1.
+--- 2. After jumping forward, we will be at InsertNode 2.
+--- 3. After jumping forward again, we will be at InsertNode 0.
+---
+--- An **important** (because here Luasnip differs from other snippet engines) detail
+--- is that the jump-indices restart at 1 in nested snippets:
+--- ```lua
+--- s("trigger", {
+--- 	i(1, "First jump"),
+--- 	t(" :: "),
+--- 	sn(2, {
+--- 		i(1, "Second jump"),
+--- 		t" : ",
+--- 		i(2, "Third jump")
+--- 	})
+--- })
+--- ```
+---
+--- <demo-gif:InsertNode2>
+---
+--- as opposed to e.g. the TextMate syntax, where tabstops are snippet-global:
+--- ```snippet
+--- ${1:First jump} :: ${2: ${3:Third jump} : ${4:Fourth jump}}
+--- ```
+--- (this is not exactly the same snippet of course, but as close as possible)
+--- (the restart-rule only applies when defining snippets in Lua, the above
+--- TextMate-snippet will expand correctly when parsed).
 ---
 ---@param pos integer? Jump-index of the node.
 ---@param static_text? string|LuaSnip.SnippetString
@@ -44,7 +92,7 @@ local function I(pos, static_text, node_opts)
 	if not snippet_string.isinstance(static_text) then
 		static_text = snippet_string.new(util.to_string_table(static_text))
 	end
-	---@cast snippet_string LuaSnip.SnippetString
+	---@cast static_text LuaSnip.SnippetString
 
 	local node
 	if pos == 0 then

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -417,15 +417,7 @@ function InsertNode:get_snippetstring()
 			snippetstring:append_text(
 				str_util.multiline_substr(text, current, snip_from_base_rel)
 			)
-			snippetstring:append_snip(
-				snip,
-				-- FIXME(@bew): This param does not exist on append_snip? 👀
-				str_util.multiline_substr(
-					text,
-					snip_from_base_rel,
-					snip_to_base_rel
-				)
-			)
+			snippetstring:append_snip(snip)
 			current = snip_to_base_rel
 		end
 	end

--- a/lua/luasnip/nodes/insertNode.lua
+++ b/lua/luasnip/nodes/insertNode.lua
@@ -577,6 +577,7 @@ function InsertNode:update_restore()
 	end
 end
 
+---@param opts LuaSnip.Opts.NodeSubtreeDo
 function InsertNode:subtree_do(opts)
 	opts.pre(self)
 	if opts.do_child_snippets then

--- a/lua/luasnip/nodes/key_indexer.lua
+++ b/lua/luasnip/nodes/key_indexer.lua
@@ -1,10 +1,18 @@
 local M = {}
 
+---@class LuaSnip.KeyIndexer
+---@field key string
+
 local key_mt = {}
+
+--- Create a key indexer
+---@param key string
+---@return LuaSnip.KeyIndexer
 function M.new_key(key)
 	return setmetatable({ key = key }, key_mt)
 end
 
+---@return boolean
 function M.is_key(t)
 	return getmetatable(t) == key_mt
 end

--- a/lua/luasnip/nodes/multiSnippet.lua
+++ b/lua/luasnip/nodes/multiSnippet.lua
@@ -3,6 +3,8 @@ local node_util = require("luasnip.nodes.util")
 local extend_decorator = require("luasnip.util.extend_decorator")
 
 ---@class LuaSnip.VirtualSnippet: LuaSnip.NormalizedSnippetContext
+---@field id? integer Internal ID of this snippet (used for source mapping)
+---  (note: this is part of LuaSnip.Addable, which is present on LuaSnip.MultiSnippet)
 ---@field snippet LuaSnip.BareInternalSnippet
 local VirtualSnippet = {}
 local VirtualSnippet_mt = { __index = VirtualSnippet }
@@ -12,8 +14,8 @@ function VirtualSnippet:get_docstring()
 end
 function VirtualSnippet:copy()
 	local copy = self.snippet:copy()
-	-- FIXME(@bew): why does the VirtualSnippet have an ID ?
-	--   It's never added to a collection is it?
+	---@diagnostic disable-next-line: cast-type-mismatch
+	---@cast copy LuaSnip.VirtualSnippet
 	copy.id = self.id
 
 	return copy

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -29,8 +29,9 @@ local describe = require("luasnip.util.log").describe
 ---  snippet node.
 ---@field indx integer Index of the node in the snippet or snippet node.
 ---
+---(FIXME(@L3MON4D3): Document these)
 ---@field visible boolean
----@field static_text string[] (FIXME(@bew): What is this for?)
+---@field static_text string[]
 ---@field static_visible boolean
 ---@field visited boolean
 ---@field old_text ... (?)

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -31,7 +31,7 @@ local describe = require("luasnip.util.log").describe
 ---
 ---(FIXME(@L3MON4D3): Document these)
 ---@field visible boolean
----@field static_text string[]
+---@field static_text string[] (FIXME(@bew): can also be a `SnippetString`?)
 ---@field static_visible boolean
 ---@field visited boolean
 ---@field old_text ... (?)
@@ -697,6 +697,13 @@ function Node:update_dependents_static(which)
 	end
 end
 
+---@class LuaSnip.Opts.NodeSubtreeDo
+---@field pre fun(node: LuaSnip.Node)
+---@field post fun(node: LuaSnip.Node)
+---@field static? boolean
+---@field do_child_snippets? boolean
+
+---@param opts LuaSnip.Opts.NodeSubtreeDo
 function Node:subtree_do(opts)
 	opts.pre(self)
 	opts.post(self)

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -27,12 +27,10 @@ local describe = require("luasnip.util.log").describe
 ---@field prev LuaSnip.Node Link to the previous node in jump-order.
 ---@field parent LuaSnip.Snippet|LuaSnip.SnippetNode The parent snippet or
 ---  snippet node.
----@field indx ... (FIXME(@bew): what is this? is it an indexer?)
----  It looks like it's something used like an integer,
----  but other times `:resolve` is called on it 🤔
+---@field indx integer Index of the node in the snippet or snippet node.
 ---
 ---@field visible boolean
----@field static_text string[] (FIXME(@bew): Where is this initialized?)
+---@field static_text string[] (FIXME(@bew): What is this for?)
 ---@field static_visible boolean
 ---@field visited boolean
 ---@field old_text ... (?)

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -167,6 +167,7 @@ function Node:jumpable(dir)
 	end
 end
 
+---@return string[]?
 function Node:get_text()
 	if not self.visible then
 		return nil
@@ -192,11 +193,13 @@ function Node:get_text()
 	return ok and text or { "" }
 end
 
+---@return LuaSnip.SnippetString
 function Node:get_snippetstring()
 	-- if this is not overridden, get_text returns a multiline string.
 	return snippet_string.new(self:get_text())
 end
 
+---@return LuaSnip.SnippetString
 function Node:get_static_snippetstring()
 	-- if this is not overridden, get_static_text() is a multiline string.
 	return snippet_string.new(self:get_static_text())
@@ -252,6 +255,11 @@ function Node:init_insert_positions(position_so_far)
 	self.absolute_insert_position = vim.deepcopy(position_so_far)
 end
 
+--- Run event handlers for the given event type.
+--- - runs node callback if defined
+--- - runs parent callback for the node if defined
+--- - fires `User LuaSnip<Event>` autocmd
+---
 ---@param event LuaSnip.EventType
 function Node:event(event)
 	local node_callback = self.node_callbacks[event]
@@ -277,7 +285,7 @@ function Node:event(event)
 	})
 end
 
----@return (string[])?
+---@return string[]?
 local function get_args(node, get_text_func_name, static)
 	local argnodes_text = {}
 	for key, arg in ipairs(node.args_absolute) do
@@ -342,9 +350,11 @@ local function get_args(node, get_text_func_name, static)
 	return argnodes_text
 end
 
+---@return string[]?
 function Node:get_args()
 	return get_args(self, "argnode_text", false)
 end
+---@return string[]?
 function Node:get_static_args()
 	return get_args(self, "get_static_snippetstring", true)
 end
@@ -431,7 +441,8 @@ function Node:resolve_node_ext_opts(base_prio, parent_ext_opts)
 	)
 end
 
-function Node:is_interactive()
+---@param info any (note: this is used in ast_parser)
+function Node:is_interactive(info)
 	-- safe default.
 	return true
 end
@@ -701,6 +712,7 @@ end
 -- those that don't.
 function Node:subtree_leave_entered() end
 
+---@return LuaSnip.SnippetString
 function Node:argnode_text()
 	return self:get_snippetstring()
 end

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -14,7 +14,7 @@ local describe = require("luasnip.util.log").describe
 ---@field key? any Key to identify the node with.
 ---@field node_ext_opts LuaSnip.NodeExtOpts
 ---@field merge_node_ext_opts boolean
----@field node_callbacks {["enter"|"leave"]: fun(node:LuaSnip.Node)}
+---@field node_callbacks {[LuaSnip.EventType]: fun(node:LuaSnip.Node)}
 
 ---@class LuaSnip.Node: LuaSnip.NormalizedNodeOpts
 ---@field pos? integer Jump-index of the node
@@ -254,9 +254,6 @@ end
 
 ---@param event LuaSnip.EventType
 function Node:event(event)
-	-- FIXME(@bew): wrong type for node_callbacks ?
-	-- We index witha EventType(integer), but the field definition uses string
-	-- keys "enter"/"leave" 🤔
 	local node_callback = self.node_callbacks[event]
 	if node_callback then
 		node_callback(self)
@@ -264,11 +261,9 @@ function Node:event(event)
 
 	-- try to get the callback from the parent.
 	if self.pos then
-		-- node needs position to get callback (nodes may not have position if
-		-- defined in a choiceNode, ie. c(1, {
-		--	i(nil, {"works!"})
-		-- }))
-		-- works just fine.
+		-- The node needs position to get callback
+		-- (nodes may not have position if defined in a choiceNode)
+		-- ie. `c(1, { i(nil, {"works!"}) }))` works just fine.
 		local parent_callback = self.parent.callbacks[self.pos][event]
 		if parent_callback then
 			parent_callback(self)

--- a/lua/luasnip/nodes/node.lua
+++ b/lua/luasnip/nodes/node.lua
@@ -62,7 +62,7 @@ local Node = {}
 ---  to return a keyed node from a dynamicNode, because even if it will be
 ---  generated multiple times, the same key not occur twice at the same time.
 ---
----@field node_callbacks? {["enter"|"leave"]: fun(node:LuaSnip.Node)}
+---@field node_callbacks? {[LuaSnip.EventType]: fun(node:LuaSnip.Node)}
 ---  Specify functions to call after changing the choice, or entering or leaving
 ---  the node. The callback receives the `node` the callback was called on.
 

--- a/lua/luasnip/nodes/optional_arg.lua
+++ b/lua/luasnip/nodes/optional_arg.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+-- FIXME: This is not documented!
+
 local opt_mt = {}
 function M.new_opt(ref)
 	return setmetatable({ ref = ref }, opt_mt)

--- a/lua/luasnip/nodes/optional_arg.lua
+++ b/lua/luasnip/nodes/optional_arg.lua
@@ -1,12 +1,18 @@
 local M = {}
 
--- FIXME: This is not documented!
+---@class LuaSnip.OptionalNodeRef
+---@field ref LuaSnip.NodeRef
 
 local opt_mt = {}
+
+--- Create an optional node ref
+---@param ref LuaSnip.NodeRef
+---@return LuaSnip.OptionalNodeRef
 function M.new_opt(ref)
 	return setmetatable({ ref = ref }, opt_mt)
 end
 
+---@return boolean
 function M.is_opt(t)
 	return getmetatable(t) == opt_mt
 end

--- a/lua/luasnip/nodes/restoreNode.lua
+++ b/lua/luasnip/nodes/restoreNode.lua
@@ -288,6 +288,7 @@ function RestoreNode:extmarks_valid()
 	return node_util.generic_extmarks_valid(self, self.snip)
 end
 
+---@param opts LuaSnip.Opts.NodeSubtreeDo
 function RestoreNode:subtree_do(opts)
 	opts.pre(self)
 	if self.snip then

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -337,7 +337,7 @@ local function init_snippet_context(context, opts)
 		)
 		engine = trig_engines[engine_name]
 		if not engine then
-		  error("Unknown trigEngine '".. engine_name.."'")
+			error("Unknown trigEngine '" .. engine_name .. "'")
 		end
 	end
 	---@cast engine -nil (We know it's valid here)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -60,6 +60,7 @@ local callbacks_mt = {
 -- declare SN here, is needed in metatable.
 local SN
 
+-- TODO(@bew): rename to LuaSnip.CommonSnippetData (?)
 ---@class LuaSnip.BareInternalSnippet: LuaSnip.Node
 ---  To be used as a base for all snippet-like nodes (Snippet, SnippetProxy, ..)
 ---
@@ -84,8 +85,11 @@ local Snippet = node_mod.Node:new()
 
 ---Anything that can be passed to ls.add_snippets().
 ---@class LuaSnip.Addable
----@field id? integer Internal ID of this snippet (used for source mapping)
 ---@field retrieve_all (fun(self: LuaSnip.Addable): LuaSnip.Snippet[])
+---
+---(FIXME(@bew): these fields are only for RegisteredSnippet? (not nil!))
+---@field id? integer Internal ID of this snippet (used for source mapping)
+---@field effective_priority? integer Effective priority of the added snippet
 
 ---Represents an expanded snippet.
 ---@class LuaSnip.ExpandedSnippet: LuaSnip.Snippet
@@ -153,7 +157,7 @@ local function P(indx)
 end
 
 -- TODO(@bew): Categorize each Snippet method, between:
--- - InitializedSnippet (created, not yet added)
+-- - DefinedSnippet (created, not yet added)
 -- - RegisteredSnippet (added in collection)
 -- - ExpandedSnippet
 -- - ..(?)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -103,6 +103,9 @@ local Snippet = node_mod.Node:new()
 ---  `trigEngine` for getting the full match.
 ---@field captures string[] The capture-groups when the snippet was triggered
 ---  with a non-"plain" `trigEngine`.
+---
+---@field prev LuaSnip.Node
+---@field next LuaSnip.Node
 
 ---@class LuaSnip.NormalizedSnippetContext
 ---@field trigger string The trigger of the snippet

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -261,7 +261,7 @@ local function init_snippet_context(context, opts)
 
 	local given_trigger = context.trig
 	if not given_trigger then
-	  error("Snippet trigger is not set!")
+		error("Snippet trigger is not set!")
 	end
 	-- note: at this point `given_trigger` is guaranteed to be a string
 
@@ -654,7 +654,6 @@ extend_decorator.register(
 	{ arg_indx = 1, extend = node_util.snippet_extend_context },
 	{ arg_indx = 3 }
 )
-
 
 ---@class LuaSnip.SnippetNode: LuaSnip.BareInternalSnippet, LuaSnip.NormalizedSnippetNodeOpts
 ---@field is_default boolean

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -639,7 +639,8 @@ end
 local function S(context, nodes, opts)
 	opts = opts or {}
 
-	local snip_with_ctx = init_snippet_context(node_util.wrap_context(context), opts)
+	local snip_with_ctx =
+		init_snippet_context(node_util.wrap_context(context), opts)
 	local snip_with_opts = init_snippet_opts(opts)
 
 	local base_snip = vim.tbl_extend("error", snip_with_ctx, snip_with_opts)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -1886,6 +1886,7 @@ function Snippet:extmarks_valid()
 	return true
 end
 
+---@param opts LuaSnip.Opts.NodeSubtreeDo
 function Snippet:subtree_do(opts)
 	opts.pre(self)
 	for _, child in ipairs(self.nodes) do

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -21,6 +21,9 @@ local true_func = function()
 	return true
 end
 
+---@param condition LuaSnip.SnipContext.Condition
+---@param user_resolve LuaSnip.ResolveExpandParamsFn
+---@return LuaSnip.ResolveExpandParamsFn
 local generate_resolve_expand_params_func = function(condition, user_resolve)
 	return function(self, line_to_cursor, match, captures)
 		if condition then
@@ -29,6 +32,7 @@ local generate_resolve_expand_params_func = function(condition, user_resolve)
 			end
 		end
 
+		---@type LuaSnip.ExpandParams
 		local default_expand_params = {
 			trigger = match,
 			captures = captures,
@@ -66,20 +70,62 @@ local stored_mt = {
 	end,
 }
 
----@class LuaSnip.Snippet: LuaSnip.Addable, LuaSnip.ExpandedSnippet
+---@class LuaSnip.BareInternalSnippet: LuaSnip.Node
+---  To be used as a base for all snippet-like nodes (Snippet, SnippetProxy, ..)
+---
+---@field _source? {file: string, line: integer}
 ---@field nodes LuaSnip.Node[]
+---@field env table<string, any> Variables used in the LSP-protocol (e.g. `TM_CURRENT_LINE` or `TM_FILENAME`).
+---@field trigger string The string that triggered this snipper. Only
+---  interesting when the snippet was triggered with a non-"plain" `trigEngine`
+---  for getting the full match.
+---@field captures string[] The capture-groups when the snippet was triggered
+---  with a non-"plain" `trigEngine`.
+---@field snippet LuaSnip.Snippet
+---@field dependents_dict table (FIXME: type!)
+---@field child_snippets table[] (FIXME: type!)
 local Snippet = node_mod.Node:new()
+
+---@class LuaSnip._SnippetData: LuaSnip.BareInternalSnippet, LuaSnip.NormalizedSnippetContext, LuaSnip.NormalizedSnippetOpts
+---@class LuaSnip.Snippet: LuaSnip._SnippetData, LuaSnip.Addable, LuaSnip.ExpandedSnippet
 
 -- very approximate classes, for now.
 ---@alias LuaSnip.SnippetID integer
 
 ---Anything that can be passed to ls.add_snippets().
 ---@class LuaSnip.Addable
+---@field id? integer Internal ID of this snippet (used for source mapping)
+---@field retrieve_all (fun(self: LuaSnip.Addable): LuaSnip.Snippet[])
 
 ---Represents an expanded snippet.
 ---@class LuaSnip.ExpandedSnippet: LuaSnip.Node
 
----@class LuaSnip.SnippetNode: LuaSnip.Node
+---@class LuaSnip.NormalizedSnippetContext
+---@field trigger string The trigger of the snippet
+---@field name string
+---@field description string[]
+---@field dscr string[] Same as `description`, kept to avoid breaking downstream
+---  usages.
+---@field docstring? string[]
+---@field priority? integer
+---@field snippetType? "snippets"|"autosnippets"
+---@field filetype? string
+---@field wordTrig boolean
+---@field hidden boolean
+---@field regTrig boolean
+---@field docTrig? string
+---@field trig_matcher LuaSnip.SnipContext.TrigMatcher
+---@field resolveExpandParams LuaSnip.ResolveExpandParamsFn
+---@field show_condition fun(line_to_cursor: string): boolean
+---@field invalidated boolean
+
+---@class LuaSnip.NormalizedSnippetNodeOpts
+---@field callbacks {[integer]: {[LuaSnip.EventType]: fun(node: LuaSnip.Node, event_args?: table)}}
+---@field child_ext_opts LuaSnip.ChildExtOpts
+---@field merge_child_ext_opts boolean
+
+---@class LuaSnip.NormalizedSnippetOpts: LuaSnip.NormalizedSnippetNodeOpts
+---@field stored {[string]: LuaSnip.SnippetNode}
 
 local Parent_indexer = {}
 
@@ -106,6 +152,8 @@ end
 function Snippet:init_nodes()
 	local insert_nodes = {}
 	for i, node in ipairs(self.nodes) do
+		---(allowed: A BareInternalSnippet will later be a full snippet)
+		---@diagnostic disable-next-line: assign-type-mismatch
 		node.parent = self
 		node.indx = i
 		if
@@ -140,6 +188,8 @@ function Snippet:init_nodes()
 	self.insert_nodes = insert_nodes
 end
 
+---@param nodes LuaSnip.Node|LuaSnip.Node[]
+---@return LuaSnip.SnippetNode
 local function wrap_nodes_in_snippetNode(nodes)
 	if getmetatable(nodes) then
 		-- is a node, not a table.
@@ -151,7 +201,7 @@ local function wrap_nodes_in_snippetNode(nodes)
 			return SN(nil, { nodes })
 		else
 			-- is a snippetNode, wrapping it twice is unnecessary.
-			return nodes
+			return nodes ---@type LuaSnip.SnippetNode
 		end
 	else
 		-- is a table of nodes.
@@ -159,8 +209,11 @@ local function wrap_nodes_in_snippetNode(nodes)
 	end
 end
 
+---@param opts LuaSnip.Opts.SnippetNode
+---@return LuaSnip.NormalizedSnippetNodeOpts
 local function init_snippetNode_opts(opts)
-	local in_node = {}
+	---@type LuaSnip.NormalizedSnippetNodeOpts
+	local in_node = {} ---@diagnostic disable-line: missing-fields
 
 	in_node.child_ext_opts =
 		ext_util.child_complete(vim.deepcopy(opts.child_ext_opts or {}))
@@ -178,34 +231,46 @@ local function init_snippetNode_opts(opts)
 	return in_node
 end
 
+---@param opts LuaSnip.Opts.Snippet
+---@return LuaSnip.NormalizedSnippetOpts
 local function init_snippet_opts(opts)
-	local in_node = {}
+	---@type LuaSnip.NormalizedSnippetOpts
+	local in_node = {} ---@diagnostic disable-line: missing-fields
 
-	-- return sn(t("")) for so-far-undefined keys.
-	in_node.stored = setmetatable(opts.stored or {}, stored_mt)
+	-- The metatable will return `sn(t(""))` for so-far-undefined keys.
+	in_node.stored = setmetatable({}, stored_mt)
 
 	-- wrap non-snippetNode in snippetNode.
-	for key, nodes in pairs(in_node.stored) do
+	for key, nodes in pairs(opts.stored or {}) do
 		in_node.stored[key] = wrap_nodes_in_snippetNode(nodes)
 	end
 
 	return vim.tbl_extend("error", in_node, init_snippetNode_opts(opts))
 end
 
--- context, opts non-nil tables.
+---@param context LuaSnip.SnipContext
+---@param opts LuaSnip.Opts.Snippet
+---@return LuaSnip.NormalizedSnippetContext
 local function init_snippet_context(context, opts)
-	local effective_context = {}
+	---@type LuaSnip.NormalizedSnippetContext
+	local effective_context = {} ---@diagnostic disable-line: missing-fields
+
+	local given_trigger = context.trig
+	if not given_trigger then
+	  error("Snippet trigger is not set!")
+	end
+	-- note: at this point `given_trigger` is guaranteed to be a string
 
 	-- trig is set by user, trigger is used internally.
 	-- not worth a breaking change, we just make it compatible here.
-	effective_context.trigger = context.trig
+	effective_context.trigger = given_trigger
 
-	effective_context.name = context.name or context.trig
+	effective_context.name = context.name or given_trigger
 
 	-- context.{desc,dscr} could be nil, string or table.
 	-- (defaults to trigger)
 	effective_context.description =
-		util.to_line_table(context.desc or context.dscr or context.trig)
+		util.to_line_table(context.desc or context.dscr or given_trigger)
 	-- (keep dscr to avoid breaking downstream usages)
 	effective_context.dscr = effective_context.description
 
@@ -303,6 +368,10 @@ end
 
 -- Create snippet without initializing opts+context.
 -- this might be called from snippetProxy.
+---@param snip table
+---@param nodes LuaSnip.Node|LuaSnip.Node[]
+---@param opts? LuaSnip.Opts.Node
+---@return LuaSnip.BareInternalSnippet
 local function _S(snip, nodes, opts)
 	nodes = util.wrap_nodes(nodes)
 	-- tbl_extend creates a new table! Important with Proxy, metatable of snip
@@ -378,9 +447,13 @@ local function _S(snip, nodes, opts)
 		}),
 		opts
 	)
+	---@cast snip LuaSnip.BareInternalSnippet
 
 	-- is propagated to all subsnippets, used to quickly find the outer snippet
 	snip.snippet = snip
+	-- FIXME(@bew): typing is annoying here, because at this stage we have the
+	--   guarentee to have a BareInternalSnippet.
+	--   (and we know this function's return might never be a full snippet..)
 
 	verify_nodes(nodes)
 	snip:init_nodes()
@@ -389,6 +462,7 @@ local function _S(snip, nodes, opts)
 		-- Generate implied i(0)
 		local i0 = iNode.I(0)
 		local i0_indx = #nodes + 1
+		-- FIXME(@bew): same comment as for `snip.snippet`'s typing..
 		i0.parent = snip
 		i0.indx = i0_indx
 		snip.insert_nodes[0] = i0
@@ -398,13 +472,169 @@ local function _S(snip, nodes, opts)
 	return snip
 end
 
+---@alias LuaSnip.SnipContext.BuiltinTrigEngine
+---| '"plain"' # The default behavior, the trigger has to match the text before the
+---    cursor exactly.
+---
+---| '"pattern"' # The trigger is interpreted as a Lua pattern, and is a match
+---    if `trig .. "$"` matches the line up to the cursor.
+---    Capture-groups will be accessible as `snippet.captures`.
+---
+---| '"ecma"' # The trigger is interpreted as an ECMAscript-regex, and is a
+---    match if `trig .. "$"` matches the line up to the cursor.
+---    Capture-groups will be accessible as `snippet.captures`.
+---    This `trigEngine` requires `jsregexp` (see
+---    [LSP-snippets-transformations](#transformations)) to be installed, if it
+---    is not, this engine will behave like `"plain"`.
+---
+---| '"vim"' # The trigger is interpreted as a vim-regex, and is a match if
+---    `trig .. "$"` matches the line up to the cursor.
+---    Capture-groups will be accessible as `snippet.captures`, but there is one
+---    caveat: the matching is done using `matchlist`, so for now empty-string
+---    submatches will be interpreted as unmatched, and the corresponding
+---    `snippet.captures[i]` will be `nil` (this will most likely change, don't
+---    rely on this behavior).
+
+---@class LuaSnip.SnipContext.TrigEngineFn.Opts
+---@field max_len integer Upper bound on the length of the trigger.
+--   If set, the `line_to_cursor` will be truncated (from the cursor of
+--   course) to `max_len` characters before performing the match.
+--   This is implemented because feeding long `line_to_cursor` into e.g. the
+--   pattern-`trigEngine` will hurt performance quite a bit.
+--   (see issue Luasnip#1103)
+--   This option is implemented for all `trigEngines`.
+
+---@alias LuaSnip.SnipContext.TrigMatcher fun(line_to_cursor: string, trigger: string): [string, string[]]
+---@alias LuaSnip.SnipContext.TrigEngineFn fun(trigger: string, opts: LuaSnip.SnipContext.TrigEngineFn.Opts): LuaSnip.SnipContext.TrigMatcher
+
+---@alias LuaSnip.ResolveExpandParamsFn fun(snippet: LuaSnip.Snippet, line_to_cursor: string, matched_trigger: string, captures: string[]): LuaSnip.ExpandParams?
+
+---@class LuaSnip.ExpandParams
+---
+---@field trigger? string The fully matched trigger.
+---@field captures? string[] Updated capture-groups from parameter in snippet
+---  expansion.
+---  NOTE: Both `trigger` and `captures` can override the values returned via
+---  `trigEngine`.
+---@field clear_region? {from: [integer, integer], to: [integer, integer]}
+---  Both (0, 0)-indexed {<row>, <column>}, the region where text has to be
+---  cleared before inserting the snippet.
+---@field env_override? {[string]: string[]|string} Override or extend
+---  the snippet's environment (`snip.env`)
+
+---@alias LuaSnip.SnipContext.Condition fun(line_to_cursor: string, matched_trigger: string, captures: string[]): boolean
+---@alias LuaSnip.SnipContext.ShowCondition fun(line_to_cursor: string): boolean
+
+---@class LuaSnip.SnipContext
+---
+---@field trig? string The trigger of the snippet.
+---  If the text in front of (to the left of) the cursor when `ls.expand()` is
+---  called matches it, the snippet will be expanded.
+---  By default, "matches" means the text in front of the cursor matches the
+---  trigger exactly, this behavior can be modified through `trigEngine`.
+---
+---@field name? string Can be used to identify the snippet.
+---
+---@field desc? string|string[] Description of the snippet.
+---
+---@field dscr? string|string[] Same as `desc`.
+---
+---@field wordTrig? boolean If true, the snippet is only expanded if the word
+---  (`[%w_]+`) before the cursor matches the trigger entirely.
+---  Defaults to true.
+---
+---@field regTrig? boolean whether the trigger should be interpreted as a
+---  Lua pattern. Defaults to false.
+---  Consider setting `trigEngine` to `"pattern"` instead, it is more expressive,
+---  and in line with other settings.
+---
+---@field trigEngine? LuaSnip.SnipContext.BuiltinTrigEngine|LuaSnip.SnipContext.TrigEngineFn
+---  Determines how `trig` is interpreted, and what it means for it to "match"
+---  the text in front of the cursor.
+---  This behavior can be completely customized by passing a function, but the
+---  predefined ones should suffice in most cases.
+---
+---@field trigEngineOpts? LuaSnip.SnipContext.TrigEngineFn.Opts Options for the
+---  used `trigEngine`.
+---
+---@field docstring? string|string[] Textual representation of the snippet, specified like
+---  `desc`. Overrides docstrings loaded from `json`.
+---
+---@field docTrig? string used as `line_to_cursor` during docstring-generation.
+---  This might be relevant if the snippet relies on specific values in the
+---  capture-groups (for example, numbers, which won't work with the default
+---  `$CAPTURESN` used during docstring-generation)
+---
+---@field hidden? boolean Hint for completion-engines.
+---  If set, the snippet should not show up when querying snippets.
+---
+---@field priority? number Priority of the snippet. Defaults to 1000.
+---  Snippets with high priority will be matched to a trigger before those with
+---  a lower one.
+---  The priority for multiple snippets can also be set in `add_snippets`.
+---
+---@field snippetType? "snippet"|"autosnippet" Decides whether this snippet has
+---  to be triggered by `ls.expand()` or whether is triggered automatically.
+---  (don't forget to set `ls.config.setup({ enable_autosnippets = true })` if
+---  you want to use this feature).
+---  If unset, the snippet type will be determined by how the snippet is added.
+---
+---@field resolveExpandParams? LuaSnip.ResolveExpandParamsFn
+---  - `snippet`: The expanding snippet object
+---  - `line_to_cursor`: The line up to the cursor.
+---  - `matched_trigger`: The fully matched trigger (can be retrieved
+---    from `line_to_cursor`, but we already have that info here :D)
+---  - `captures`: Captures as returned by `trigEngine`.
+---
+---  This function will be evaluated in `Snippet:matches()` to decide whether
+---  the snippet can be expanded or not.
+---  Returns a table if the snippet can be expanded, `nil` if can not.
+---
+---  If any field in the returned table is `nil`, the default is used (`trigger` and `captures` as
+---  returned by `trigEngine`, `clear_region` such that exactly the trigger is
+---  deleted, no overridden environment-variables).
+---
+---  A good example for the usage of `resolveExpandParams` can be found in the
+---  implementation of [`postfix`](https://github.com/L3MON4D3/LuaSnip/blob/master/lua/luasnip/extras/postfix.lua).
+---
+---@field condition? LuaSnip.SnipContext.Condition
+---  - `line_to_cursor`: the line up to the cursor.
+---  - `matched_trigger`: the fully matched trigger (can be retrieved
+---    from `line_to_cursor`, but we already have that info here :D).
+---  - `captures`: if the trigger is pattern, contains the capture-groups.
+---    Again, could be computed from `line_to_cursor`, but we already did so.
+---
+---  This function can prevent manual snippet expansion via `ls.expand()`.
+---  Return `true` to allow expansion, and `false` to prevent it.
+---
+---@field show_condition? LuaSnip.SnipContext.ShowCondition
+---  This function is (should be) evaluated by completion engines, indicating
+---  whether the snippet should be included in current completion candidates.
+---  Defaults to a function returning `true`.
+---
+---  This is different from `condition` because `condition` is evaluated by
+---  LuaSnip on snippet expansion (and thus has access to the matched trigger and
+---  captures), while `show_condition` is (should be) evaluated by the
+---  completion engines when scanning for available snippet candidates.
+---
+---@field filetype? string The filetype of the snippet.
+---  This overrides the filetype the snippet is added (via `add_snippet`) as.
+
+---@class LuaSnip.Opts.Snippet: LuaSnip.Opts.SnippetNode
+---@field stored? {[string]: LuaSnip.Node}
+
+---@param context string|LuaSnip.SnipContext The snippet context.
+---  Passing a string is equivalent to passing `{ trig = <the string> }`.
+---@param nodes LuaSnip.Node|LuaSnip.Node[] The nodes that make up the snippet.
+---@param opts? LuaSnip.Opts.Snippet
+---@return LuaSnip.Snippet
 local function S(context, nodes, opts)
 	opts = opts or {}
 
 	local snip = init_snippet_context(node_util.wrap_context(context), opts)
-	snip = vim.tbl_extend("error", snip, init_snippet_opts(opts))
+	local snip = vim.tbl_extend("error", snip, init_snippet_opts(opts))
 
-	snip = _S(snip, nodes, opts)
+	local snip = _S(snip, nodes, opts)
 
 	if __luasnip_get_loaded_file_frame_debuginfo ~= nil then
 		-- this snippet is being lua-loaded, and the source should be recorded.
@@ -412,6 +642,7 @@ local function S(context, nodes, opts)
 			source.from_debuginfo(__luasnip_get_loaded_file_frame_debuginfo())
 	end
 
+	---@type LuaSnip.Snippet
 	return snip
 end
 extend_decorator.register(
@@ -420,6 +651,37 @@ extend_decorator.register(
 	{ arg_indx = 3 }
 )
 
+
+---@class LuaSnip.SnippetNode: LuaSnip.BareInternalSnippet, LuaSnip.NormalizedSnippetNodeOpts
+---@field is_default boolean
+
+---@class LuaSnip.Opts.SnippetNode: LuaSnip.Opts.Node
+---@field callbacks? {[integer]: {[LuaSnip.EventType]: fun(node: LuaSnip.Node, event_args?: table)}}
+---  Contains functions by node position, that are called upon entering/leaving
+---  a node of this snippet.
+---  To register a callback for the snippets' own events, the key `[-1]` may
+---  be used.
+---
+---  For example: to print text upon entering the _second_ node of a snippet,
+---  `callbacks` should be set as follows:
+---  ```lua
+---  {
+---    -- position of the node, not the jump-index!!
+---    -- s("trig", {t"first node", t"second node", i(1, "third node")}).
+---    [2] = {
+---      [events.enter] = function(node, _event_args) print("2!") end
+---    }
+---  }
+---  ```
+---  More info on events in [events](#events).
+---
+---@field child_ext_opts? `false`|LuaSnip.ChildExtOpts (TODO: doc!)
+---@field merge_child_ext_opts? boolean (TODO: doc!)
+
+---@param pos integer?
+---@param nodes LuaSnip.Node|LuaSnip.Node[] The nodes that make up the snippet.
+---@param opts? LuaSnip.Opts.SnippetNode
+---@return LuaSnip.SnippetNode
 function SN(pos, nodes, opts)
 	opts = opts or {}
 
@@ -436,6 +698,8 @@ function SN(pos, nodes, opts)
 		}, init_snippetNode_opts(opts)),
 		opts
 	)
+	---@cast snip LuaSnip.SnippetNode
+
 	verify_nodes(nodes)
 	snip:init_nodes()
 
@@ -443,6 +707,13 @@ function SN(pos, nodes, opts)
 end
 extend_decorator.register(SN, { arg_indx = 3 })
 
+---@param pos integer?
+---@param nodes LuaSnip.Node|LuaSnip.Node[] The nodes that make up the `snippetNode`.
+---@param indent_text string Used to indent the nodes inside this `snippetNode`.
+---  All occurrences of `"$PARENT_INDENT"` are replaced with the actual indent
+---  of the parent.
+---@param opts? LuaSnip.Opts.SnippetNode
+---@return LuaSnip.SnippetNode
 local function ISN(pos, nodes, indent_text, opts)
 	local snip = SN(pos, nodes, opts)
 
@@ -650,6 +921,12 @@ function Snippet:insert_into_jumplist(
 	table.insert(sibling_snippets, own_indx, self)
 end
 
+-- IDEA(THINKING, @bew): Most methods in Snippet should really be on a BareInternalSnippet class
+-- But this method should be on an actual Snippet class
+-- (so it can be called on a full Snippet, but not a BareInternalSnippet)
+-- This came to my mind because this function uses `self.stored` &
+-- `self.merge_child_ext_opts` that _only_ exist on full Snippet but not on
+-- BareInternalSnippet.
 function Snippet:trigger_expand(current_node, pos_id, env, indent_nodes)
 	local pos = vim.api.nvim_buf_get_extmark_by_id(0, session.ns_id, pos_id, {})
 
@@ -817,6 +1094,9 @@ end
 -- the text does usually not match, but resolveExpandParams may still give
 -- useful data (e.g. when the snippet is a treesitter_postfix, see
 -- https://github.com/L3MON4D3/LuaSnip/issues/1374)
+--
+-- IDEA(THINKING, @bew): Similar to `trigger_expand`, this uses fields from
+-- Snippet (from its context & opts) not BareInternalSnippet, should be moved.
 function Snippet:matches(line_to_cursor, opts)
 	local fallback_match = util.default_tbl_get(nil, opts, "fallback_match")
 
@@ -889,6 +1169,7 @@ function Snippet:del_marks()
 	end
 end
 
+-- FIXME: `info` is _never_ used anywhere?
 function Snippet:is_interactive(info)
 	for _, node in ipairs(self.nodes) do
 		-- return true if any node depends on another node or is an insertNode.
@@ -929,6 +1210,9 @@ end
 -- populate env,inden,captures,trigger(regex),... but don't put any text.
 -- the env may be passed in opts via opts.env, if none is passed a new one is
 -- generated.
+--
+-- IDEA(THINKING, @bew): Similar to `trigger_expand`, this uses fields from
+-- Snippet (from its context & opts) not BareInternalSnippet, should be moved.
 function Snippet:fake_expand(opts)
 	if not opts then
 		opts = {}
@@ -1099,6 +1383,8 @@ Snippet.init_insert_positions = node_util.init_child_positions_func(
 
 function Snippet:make_args_absolute()
 	for _, node in ipairs(self.nodes) do
+		-- (allowed: this arg only exists for some node types)
+		---@diagnostic disable-next-line: redundant-parameter
 		node:make_args_absolute(self.absolute_insert_position)
 	end
 end
@@ -1198,6 +1484,10 @@ function Snippet:text_only()
 	return true
 end
 
+--- Trigger event with args
+---@param event LuaSnip.EventType
+---@param event_args? table
+---@return unknown
 function Snippet:event(event, event_args)
 	-- there are 3 sources of a callback, for a snippetNode:
 	-- self.callbacks[-1], self.node_callbacks, and parent.callbacks[self.pos].
@@ -1347,6 +1637,7 @@ function Snippet:static_init()
 end
 
 -- called only for snippetNodes!
+-- => FIXME(@bew): should then be in a SnippetNode class?
 function Snippet:resolve_child_ext_opts()
 	if self.merge_child_ext_opts then
 		self.effective_child_ext_opts = ext_util.child_extend(

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -60,16 +60,6 @@ local callbacks_mt = {
 -- declare SN here, is needed in metatable.
 local SN
 
-local stored_mt = {
-	__index = function(table, key)
-		-- default-node is just empty text.
-		local val = SN(nil, { iNode.I(1) })
-		val.is_default = true
-		rawset(table, key, val)
-		return val
-	end,
-}
-
 ---@class LuaSnip.BareInternalSnippet: LuaSnip.Node
 ---  To be used as a base for all snippet-like nodes (Snippet, SnippetProxy, ..)
 ---
@@ -237,6 +227,16 @@ local function init_snippetNode_opts(opts)
 
 	return in_node
 end
+
+local stored_mt = {
+	__index = function(table, key)
+		-- default-node is just empty text.
+		local val = SN(nil, { iNode.I(1) })
+		val.is_default = true
+		rawset(table, key, val)
+		return val
+	end,
+}
 
 ---@param opts LuaSnip.Opts.Snippet
 ---@return LuaSnip.NormalizedSnippetOpts
@@ -628,7 +628,7 @@ end
 ---  This overrides the filetype the snippet is added (via `add_snippet`) as.
 
 ---@class LuaSnip.Opts.Snippet: LuaSnip.Opts.SnippetNode
----@field stored? {[string]: LuaSnip.Node}
+---@field stored? {[string]: LuaSnip.Node} Snippet-level state for restore node.
 
 ---@param context string|LuaSnip.SnipContext The snippet context.
 ---  Passing a string is equivalent to passing `{ trig = <the string> }`.

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -113,7 +113,7 @@ local Snippet = node_mod.Node:new()
 ---@field docTrig? string
 ---@field trig_matcher LuaSnip.SnipContext.TrigMatcher
 ---@field resolveExpandParams LuaSnip.ResolveExpandParamsFn
----@field show_condition LuaSnip.SnipContext.ShowCondition
+---@field show_condition LuaSnip.SnipContext.ShowConditionFn
 ---@field condition LuaSnip.SnipContext.Condition
 ---@field invalidated boolean
 
@@ -530,8 +530,9 @@ end
 ---@field env_override? {[string]: string[]|string} Override or extend
 ---  the snippet's environment (`snip.env`)
 
----@alias LuaSnip.SnipContext.Condition fun(line_to_cursor: string, matched_trigger: string, captures: string[]): boolean
----@alias LuaSnip.SnipContext.ShowCondition fun(line_to_cursor: string): boolean
+---@alias LuaSnip.SnipContext.ConditionFn fun(line_to_cursor: string, matched_trigger: string, captures: string[]): boolean
+---@alias LuaSnip.SnipContext.Condition LuaSnip.SnipContext.ConditionFn|LuaSnip.SnipContext.ConditionObj
+---@alias LuaSnip.SnipContext.ShowConditionFn fun(line_to_cursor: string): boolean
 
 ---@class LuaSnip.SnipContext
 ---
@@ -615,7 +616,7 @@ end
 ---  This function can prevent manual snippet expansion via `ls.expand()`.
 ---  Return `true` to allow expansion, and `false` to prevent it.
 ---
----@field show_condition? LuaSnip.SnipContext.ShowCondition
+---@field show_condition? LuaSnip.SnipContext.ShowConditionFn
 ---  This function is (should be) evaluated by completion engines, indicating
 ---  whether the snippet should be included in current completion candidates.
 ---  Defaults to a function returning `true`.
@@ -630,6 +631,11 @@ end
 
 ---@class LuaSnip.Opts.Snippet: LuaSnip.Opts.SnippetNode
 ---@field stored? {[string]: LuaSnip.Node} Snippet-level state for restore node.
+---
+---@field show_condition? LuaSnip.SnipContext.ShowConditionFn Same as
+---  `show_condition` in snippet context. (here for backward compat)
+---@field condition? LuaSnip.SnipContext.Condition Same as `condition` in
+---  snippet context. (here for backward compat)
 
 ---@param context string|LuaSnip.SnipContext The snippet context.
 ---  Passing a string is equivalent to passing `{ trig = <the string> }`.

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -75,6 +75,7 @@ local stored_mt = {
 ---
 ---@field _source? {file: string, line: integer}
 ---@field nodes LuaSnip.Node[]
+---@field insert_nodes LuaSnip.InsertNode[]
 ---@field snippet LuaSnip.Snippet
 ---@field dependents_dict table (FIXME(@bew): type!)
 ---@field child_snippets table[] (FIXME(@bew): type!)

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -336,7 +336,12 @@ local function init_snippet_context(context, opts)
 			util.ternary(context.regTrig ~= nil, "pattern", "plain")
 		)
 		engine = trig_engines[engine_name]
+		if not engine then
+		  error("Unknown trigEngine '".. engine_name.."'")
+		end
 	end
+	---@cast engine -nil (We know it's valid here)
+
 	-- make sure to pass through nil-trigEngineOpts, they will be recognized and
 	-- we will get a default-version of that function instead of generating a
 	-- curried (?) version of it (which would waste space I think).

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -817,6 +817,13 @@ local function find_node_dependents(node)
 	return nodes
 end
 
+-- (note: same as LuaSnip.Opts.NodeSubtreeDo, with default hooks)
+---@class LuaSnip.Opts.NodeSubtreeDoWithDefault: LuaSnip.Opts.NodeSubtreeDo
+---@field pre? fun(node: LuaSnip.Node)
+---@field post? fun(node: LuaSnip.Node)
+
+---@param node LuaSnip.Node
+---@param opts LuaSnip.Opts.NodeSubtreeDoWithDefault
 local function node_subtree_do(node, opts)
 	-- provide default-values.
 	if not opts.pre then

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -44,23 +44,25 @@ end
 
 ---@param args LuaSnip.NodeRef[]
 ---@param parent_insert_position integer[]
----@param target LuaSnip.NormalizedNodeRef[] Target for the normalized node refs
--- FIXME(@bew): Why is the `target` param updated instead of returning a new table?
-local function make_args_absolute(args, parent_insert_position, target)
+---@return LuaSnip.NormalizedNodeRef[] _ The normalized node refs
+local function make_args_absolute(args, parent_insert_position)
+	---@type LuaSnip.NormalizedNodeRef[]
+	local normalized_args = {}
 	for i, arg in ipairs(args) do
 		if type(arg) == "number" then
 			-- the arg is a number, should be interpreted relative to direct
 			-- parent.
 			local t = vim.deepcopy(parent_insert_position)
 			table.insert(t, arg)
-			target[i] = { absolute_insert_position = t }
+			normalized_args[i] = { absolute_insert_position = t }
 		else
 			-- insert node, absolute_indexer, or key itself, node's
 			-- absolute_insert_position may be nil, check for that during
 			-- usage.
-			target[i] = arg
+			normalized_args[i] = arg
 		end
 	end
+	return normalized_args
 end
 
 --- Normarlizes node references
@@ -866,7 +868,7 @@ local function collect_dependents(node, which, static)
 	return tbl_util.set_to_list(dependents_set)
 end
 
----@param args string[]?
+---@param args (string|LuaSnip.SnippetString)[]?
 ---@return string[][]?
 local function str_args(args)
 	return args

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -19,6 +19,10 @@ local function subsnip_init_children(parent, children)
 	end
 end
 
+---@param key string
+---@param node_children_key string
+---@param child_func_name string
+---@return fun(node: LuaSnip.Node, position_so_far: integer[])
 local function init_child_positions_func(
 	key,
 	node_children_key,
@@ -859,6 +863,8 @@ local function collect_dependents(node, which, static)
 	return tbl_util.set_to_list(dependents_set)
 end
 
+---@param args (string[])?
+---@return ((string[])[])?
 local function str_args(args)
 	return args
 		and vim.tbl_map(function(arg)
@@ -868,38 +874,43 @@ local function str_args(args)
 end
 
 ---@class LuaSnip.SnippetCursorRestoreData
----This class holds data about the current position of the cursor in a snippet.
+---  This class holds data about the current position of the cursor in a snippet.
+---
 ---@field key string key of the current node.
 ---@field store_id number uniquely identifies the data associated with this
----store-restore cycle.
----This is necessary because eg. the snippetStrings may contain cursor-positions
----of more than one restore data, and the correct ones can be identified via
----store_id.
+---  store-restore cycle.
+---  This is necessary because eg. the snippetStrings may contain
+---  cursor-positions of more than one restore data, and the correct ones can be
+---  identified via store_id.
+---
 ---@field node LuaSnip.Node The node the cursor will be stored relative to.
+---
 ---@field cursor_start_relative LuaSnip.BytecolBufferPosition The position of
----the cursor, or beginning of selected area, relative to the beginning of
----`node`.
+---  the cursor, or beginning of selected area, relative to the beginning of
+---  `node`.
+---
 ---@field selection_end_start_relative LuaSnip.BytecolBufferPosition The
----position of the cursor, or end of selected area, relative to the beginning of
----`node`. The column is one beyond the byte where the selection ends.
+---  position of the cursor, or end of selected area, relative to the beginning of
+---  `node`. The column is one beyond the byte where the selection ends.
+---
 ---@field mode string The first character (see `vim.fn.mode()`) of the mode at
----the time of `store`.
+---  the time of `store`.
 
 ---@alias LuaSnip.CursorRestoreData table<number, LuaSnip.SnippetCursorRestoreData>
----Represents the position of the cursor relative to all snippets the cursor was
----inside.
----Maps a `store_id` to the data needed to restore the cursor relative to the
----stored node of that snippet.
----We need the data relative to all parent-snippets of some node because the
----first 1,2,... snippets may disappear when a choice is changed.
+---  Represents the position of the cursor relative to all snippets the cursor
+---  was inside.
+---  Maps a `store_id` to the data needed to restore the cursor relative to the
+---  stored node of that snippet.
+---  We need the data relative to all parent-snippets of some node because the
+---  first 1,2,... snippets may disappear when a choice is changed.
 
----@class LuaSnip.StoreCursorNodeRelativeOpts
----@field place_cursor_mark boolean? Whether to, if possible, place a mark in
----snippetText.
+---@class LuaSnip.Opts.StoreCursorNodeRelative
+---@field place_cursor_mark? boolean Whether to, if possible, place a mark in
+---  snippetText.
 
 local store_id = 0
 ---@param node LuaSnip.Node The node to store the cursor relative to.
----@param opts LuaSnip.StoreCursorNodeRelativeOpts
+---@param opts LuaSnip.Opts.StoreCursorNodeRelative
 local function store_cursor_node_relative(node, opts)
 	local data = {}
 
@@ -945,6 +956,7 @@ local function store_cursor_node_relative(node, opts)
 			snippet_current_node.type == types.insertNode
 			and opts.place_cursor_mark
 		then
+			---@cast snippet_current_node LuaSnip.InsertNode
 			-- if the snippet_current_node is not an insertNode, the cursor
 			-- should always be exactly at the beginning if the node is entered
 			-- (which, btw, can only happen if a text or functionNode is

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -45,6 +45,7 @@ end
 ---@param args LuaSnip.NodeRef[]
 ---@param parent_insert_position integer[]
 ---@param target LuaSnip.NormalizedNodeRef[] Target for the normalized node refs
+-- FIXME(@bew): Why is the `target` param updated instead of returning a new table?
 local function make_args_absolute(args, parent_insert_position, target)
 	for i, arg in ipairs(args) do
 		if type(arg) == "number" then
@@ -188,6 +189,8 @@ local function snippet_extend_context(arg, extend)
 	return vim.tbl_extend("keep", arg or {}, extend or {})
 end
 
+---@param context LuaSnip.SnipContext|string
+---@return LuaSnip.SnipContext
 local function wrap_context(context)
 	if type(context) == "string" then
 		return { trig = context }
@@ -863,8 +866,8 @@ local function collect_dependents(node, which, static)
 	return tbl_util.set_to_list(dependents_set)
 end
 
----@param args (string[])?
----@return ((string[])[])?
+---@param args string[]?
+---@return string[][]?
 local function str_args(args)
 	return args
 		and vim.tbl_map(function(arg)

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -38,6 +38,9 @@ local function init_child_positions_func(
 	end
 end
 
+---@param args LuaSnip.NodeRef[]
+---@param parent_insert_position integer[]
+---@param target LuaSnip.NormalizedNodeRef[] Target for the normalized node refs
 local function make_args_absolute(args, parent_insert_position, target)
 	for i, arg in ipairs(args) do
 		if type(arg) == "number" then
@@ -55,6 +58,9 @@ local function make_args_absolute(args, parent_insert_position, target)
 	end
 end
 
+--- Normarlizes node references
+---@param args LuaSnip.NodeRef[]|LuaSnip.NodeRef
+---@return LuaSnip.NodeRef[]
 local function wrap_args(args)
 	-- stylua: ignore
 	if type(args) ~= "table" or
@@ -144,6 +150,8 @@ local function print_dict(dict)
 	}))
 end
 
+---@param opts LuaSnip.Opts.Node
+---@return LuaSnip.NormalizedNodeOpts
 local function init_node_opts(opts)
 	local in_node = {}
 	if not opts then

--- a/lua/luasnip/nodes/util.lua
+++ b/lua/luasnip/nodes/util.lua
@@ -140,6 +140,7 @@ local function enter_nodes_between(parent, child, no_move)
 	nodes[#nodes]:input_enter(no_move)
 end
 
+---@param node LuaSnip.Node
 local function select_node(node)
 	local node_begin, node_end = node.mark:pos_begin_end_raw()
 	feedkeys.select_range(node_begin, node_end)

--- a/lua/luasnip/nodes/util/snippet_string.lua
+++ b/lua/luasnip/nodes/util/snippet_string.lua
@@ -2,7 +2,7 @@ local str_util = require("luasnip.util.str")
 local util = require("luasnip.util.util")
 
 ---@class LuaSnip.SnippetString.Mark
----  A kind-of extmark to the text in this buffer.
+---  A kind of extmark, but for a string not a Neovim buffer.
 ---
 ---  It moves with inserted text, and has a gravity to control into which
 ---  direction it shifts. pos is 1-based and refers to one character in the
@@ -10,8 +10,6 @@ local util = require("luasnip.util.util")
 ---
 ---  If the edge is in the middle of multiple characters (for example rgrav=true,
 ---  and chars at pos and pos+1 are replaced), the mark is removed.
----
----  FIXME(@bew): How is it different than extmarks? (-> why not use them?)
 ---
 ---@field id string ID of the mark
 ---@field pos integer 1-based, refers to one character in the string
@@ -152,7 +150,7 @@ function SnippetString:put(pos)
 	end
 end
 
--- FIXME(@bew): what is the return type here?
+---@return LuaSnip.SnippetString
 function SnippetString:copy()
 	-- on 0.7 vim.deepcopy does not behave correctly on snippets => have to manually copy.
 	return setmetatable(

--- a/lua/luasnip/nodes/util/snippet_string.lua
+++ b/lua/luasnip/nodes/util/snippet_string.lua
@@ -32,13 +32,11 @@ local SnippetString_mt = {
 	-- __concat and __tostring will be set later on.
 }
 
-local M = {}
-
 ---Create new SnippetString.
 ---@param initial_str string[]?, optional initial multiline string.
 ---@param metadata? table
 ---@return LuaSnip.SnippetString
-function M.new(initial_str, metadata)
+function SnippetString.new(initial_str, metadata)
 	local o = {
 		initial_str and table.concat(initial_str, "\n"),
 		marks = {},
@@ -47,7 +45,7 @@ function M.new(initial_str, metadata)
 	return setmetatable(o, SnippetString_mt)
 end
 
-function M.isinstance(o)
+function SnippetString.isinstance(o)
 	return getmetatable(o) == SnippetString_mt
 end
 
@@ -74,7 +72,7 @@ local function gen_snipstr_map(self, map, from_offset)
 			v.snip:subtree_do({
 				pre = function(node)
 					if node.static_text then
-						if M.isinstance(node.static_text) then
+						if SnippetString.isinstance(node.static_text) then
 							local nested_str = gen_snipstr_map(
 								node.static_text,
 								map,
@@ -219,11 +217,11 @@ end
 ---@return LuaSnip.SnippetString
 local function to_snippetstring(o)
 	if type(o) == "string" then
-		return M.new({ o })
+		return SnippetString.new({ o })
 	elseif getmetatable(o) == SnippetString_mt then
 		return o
 	else
-		return M.new(o)
+		return SnippetString.new(o)
 	end
 end
 
@@ -302,7 +300,7 @@ local function nodetext_len(node, snipstr_map)
 		return 0
 	end
 
-	if M.isinstance(node.static_text) then
+	if SnippetString.isinstance(node.static_text) then
 		return #snipstr_map[node.static_text].str
 	else
 		-- +1 for each newline.
@@ -354,7 +352,7 @@ local function _replace(self, replacements, snipstr_map)
 							and node_relative_repl_from <= node_len
 						then
 							if node_relative_repl_to <= node_len then
-								if M.isinstance(node.static_text) then
+								if SnippetString.isinstance(node.static_text) then
 									-- node contains a snippetString, recurse!
 									-- since we only check string-positions via
 									-- snipstr_map, we don't even have to
@@ -462,7 +460,7 @@ local function upper(self)
 			v.snip:subtree_do({
 				pre = function(node)
 					if node.static_text then
-						if M.isinstance(node.static_text) then
+						if SnippetString.isinstance(node.static_text) then
 							node.static_text:_upper()
 						else
 							str_util.multiline_upper(node.static_text)
@@ -483,7 +481,7 @@ local function lower(self)
 			v.snip:subtree_do({
 				pre = function(node)
 					if node.static_text then
-						if M.isinstance(node.static_text) then
+						if SnippetString.isinstance(node.static_text) then
 							node.static_text:_lower()
 						else
 							str_util.multiline_lower(node.static_text)
@@ -562,7 +560,7 @@ function SnippetString:sub(from, to)
 
 	-- empty range => return empty snippetString.
 	if from > #str or to < from or to < 1 then
-		return M.new({ "" })
+		return SnippetString.new({ "" })
 	end
 
 	from = math.max(from, 1)
@@ -617,4 +615,4 @@ function SnippetString:clear_marks()
 	self.marks = {}
 end
 
-return M
+return SnippetString

--- a/lua/luasnip/nodes/util/snippet_string.lua
+++ b/lua/luasnip/nodes/util/snippet_string.lua
@@ -352,7 +352,9 @@ local function _replace(self, replacements, snipstr_map)
 							and node_relative_repl_from <= node_len
 						then
 							if node_relative_repl_to <= node_len then
-								if SnippetString.isinstance(node.static_text) then
+								if
+									SnippetString.isinstance(node.static_text)
+								then
 									-- node contains a snippetString, recurse!
 									-- since we only check string-positions via
 									-- snipstr_map, we don't even have to

--- a/lua/luasnip/session/snippet_collection/init.lua
+++ b/lua/luasnip/session/snippet_collection/init.lua
@@ -1,5 +1,5 @@
 local source = require("luasnip.session.snippet_collection.source")
-local u_table = require("luasnip.util.table")
+local table_util = require("luasnip.util.table")
 local auto_creating_tables =
 	require("luasnip.util.auto_table").warn_depth_autotable
 local session = require("luasnip.session")
@@ -328,7 +328,7 @@ local function get_all_snippet_fts()
 		ft_set[ft] = true
 	end
 
-	return u_table.set_to_list(ft_set)
+	return table_util.set_to_list(ft_set)
 end
 
 -- modules that want to call refresh_notify probably also want to notify others

--- a/lua/luasnip/session/snippet_collection/init.lua
+++ b/lua/luasnip/session/snippet_collection/init.lua
@@ -16,6 +16,12 @@ local M = {
 	invalidated_count = 0,
 }
 
+--- Stores given addables for a given `key`
+--- Allows to invalidates all snippets added for that key later on.
+---
+--- See `key` in `add_snippets`'s opts param.
+---
+---@type {[string]: LuaSnip.Addable[]}
 local by_key = {}
 
 -- stores snippets/autosnippets by priority.
@@ -211,9 +217,10 @@ function M.clean_invalidated(opts)
 	M.invalidated_count = 0
 end
 
+---@param addables_by_ft {[string]: LuaSnip.Addable[]}
 local function invalidate_addables(addables_by_ft)
-	for _, addables in pairs(addables_by_ft) do
-		for _, addable in ipairs(addables) do
+	for _, ft_addables in pairs(addables_by_ft) do
+		for _, addable in ipairs(ft_addables) do
 			for _, expandable in ipairs(addable:retrieve_all()) do
 				expandable:invalidate()
 			end
@@ -241,10 +248,10 @@ end
 local current_id = 0
 --- Add snippets to the collection of snippets.
 ---
----@param snippets {[string]: LuaSnip.Addable[]}
+---@param snippets_by_ft {[string]: LuaSnip.Addable[]}
 ---@param opts LuaSnip.Opts.SessionAddSnippets
-function M.add_snippets(snippets, opts)
-	for ft, ft_snippets in pairs(snippets) do
+function M.add_snippets(snippets_by_ft, opts)
+	for ft, ft_snippets in pairs(snippets_by_ft) do
 		for _, addable in ipairs(ft_snippets) do
 			for _, snip in ipairs(addable:retrieve_all()) do
 				local snip_prio = opts.override_priority
@@ -285,7 +292,7 @@ function M.add_snippets(snippets, opts)
 		if by_key[opts.key] then
 			invalidate_addables(by_key[opts.key])
 		end
-		by_key[opts.key] = snippets
+		by_key[opts.key] = snippets_by_ft
 	end
 end
 

--- a/lua/luasnip/session/snippet_collection/source.lua
+++ b/lua/luasnip/session/snippet_collection/source.lua
@@ -43,6 +43,8 @@ function M.set(snippet, source)
 	id_to_source[snippet.id] = source
 end
 
+---@param snippet LuaSnip.Snippet
+---@return LuaSnip.Source
 function M.get(snippet)
 	return id_to_source[snippet.id]
 end

--- a/lua/luasnip/session/snippet_collection/source.lua
+++ b/lua/luasnip/session/snippet_collection/source.lua
@@ -1,14 +1,14 @@
----@class LuaSnip._Source
+---@class LuaSnip.Source
 ---@field file string
 ---@field line? integer
 ---@field line_end? integer
 
----@type {[integer]: LuaSnip._Source}
+---@type {[integer]: LuaSnip.Source}
 local id_to_source = {}
 
 local M = {}
 
----@return LuaSnip._Source
+---@return LuaSnip.Source
 function M.from_debuginfo(debuginfo)
 	assert(debuginfo.source, "debuginfo contains source")
 	assert(
@@ -25,7 +25,7 @@ end
 
 ---@param file string
 ---@param opts? {line: integer, line_end: integer}
----@return LuaSnip._Source
+---@return LuaSnip.Source
 function M.from_location(file, opts)
 	assert(file, "source needs file")
 	opts = opts or {}
@@ -34,7 +34,7 @@ function M.from_location(file, opts)
 end
 
 ---@param snippet LuaSnip.Snippet
----@param source LuaSnip._Source
+---@param source LuaSnip.Source
 function M.set(snippet, source)
 	-- snippets only get their id after being added, make sure this is the
 	-- case.

--- a/lua/luasnip/session/snippet_collection/source.lua
+++ b/lua/luasnip/session/snippet_collection/source.lua
@@ -1,7 +1,14 @@
+---@class LuaSnip._Source
+---@field file string
+---@field line? integer
+---@field line_end? integer
+
+---@type {[integer]: LuaSnip._Source}
 local id_to_source = {}
 
 local M = {}
 
+---@return LuaSnip._Source
 function M.from_debuginfo(debuginfo)
 	assert(debuginfo.source, "debuginfo contains source")
 	assert(
@@ -16,6 +23,9 @@ function M.from_debuginfo(debuginfo)
 	}
 end
 
+---@param file string
+---@param opts? {line: integer, line_end: integer}
+---@return LuaSnip._Source
 function M.from_location(file, opts)
 	assert(file, "source needs file")
 	opts = opts or {}
@@ -23,6 +33,8 @@ function M.from_location(file, opts)
 	return { file = file, line = opts.line, line_end = opts.line_end }
 end
 
+---@param snippet LuaSnip.Snippet
+---@param source LuaSnip._Source
 function M.set(snippet, source)
 	-- snippets only get their id after being added, make sure this is the
 	-- case.

--- a/lua/luasnip/util/events.lua
+++ b/lua/luasnip/util/events.lua
@@ -9,6 +9,9 @@ local EventType = {
 }
 
 local M = setmetatable({}, { __index = EventType })
+-- NOTE: The metatable is set so that callers of this `events` module can do
+-- `events.change_choice` to get a named value from the enum, while leaving the
+-- enum definition standalone to avoid adding unnecessary enum fields.
 
 ---@param node_type LuaSnip.NodeType
 ---@param event_id LuaSnip.EventType

--- a/lua/luasnip/util/events.lua
+++ b/lua/luasnip/util/events.lua
@@ -1,18 +1,27 @@
 local node_names = require("luasnip.util.types").names_pascal_case
 
-return {
+---@enum LuaSnip.EventType
+local EventType = {
 	enter = 1,
 	leave = 2,
 	change_choice = 3,
 	pre_expand = 4,
-	to_string = function(node_type, event_id)
-		if event_id == 3 then
-			return "ChangeChoice"
-		elseif event_id == 4 then
-			return "PreExpand"
-		else
-			return node_names[node_type]
-				.. (event_id == 1 and "Enter" or "Leave")
-		end
-	end,
 }
+
+local M = setmetatable({}, { __index = EventType })
+
+---@param node_type LuaSnip.NodeType
+---@param event_id LuaSnip.EventType
+---@return string
+function M.to_string(node_type, event_id)
+	if event_id == EventType.change_choice then
+		return "ChangeChoice"
+	elseif event_id == EventType.pre_expand then
+		return "PreExpand"
+	else
+		return node_names[node_type]
+			.. (event_id == EventType.enter and "Enter" or "Leave")
+	end
+end
+
+return M

--- a/lua/luasnip/util/ext_opts.lua
+++ b/lua/luasnip/util/ext_opts.lua
@@ -35,6 +35,8 @@ local function clear_invalid(opts)
 	--stylua: ignore end
 end
 
+---@param ext_opts? LuaSnip.NodeExtOpts
+---@return LuaSnip.NodeExtOpts
 local function _complete_ext_opts(ext_opts)
 	if not ext_opts then
 		ext_opts = {}
@@ -78,18 +80,22 @@ end
 -- active inherits unset values from passive, which in turn inherits from
 -- snippet_passive.
 -- Also make sure that all keys have a table, and are not nil!
+---@param ext_opts LuaSnip.ChildExtOpts
+---@return LuaSnip.ChildExtOpts
 local function child_complete(ext_opts)
 	for _, node_type in pairs(types.node_types) do
 		ext_opts[node_type] = _complete_ext_opts(ext_opts[node_type])
 	end
-	ext_opts.base_prio = 0
+	ext_opts.base_prio = 0 ---@diagnostic disable-line: inject-field
 
 	return ext_opts
 end
 
+---@param ext_opts? LuaSnip.NodeExtOpts
+---@return LuaSnip.NodeExtOpts
 local function complete(ext_opts)
-	_complete_ext_opts(ext_opts)
-	ext_opts.base_prio = 0
+	local ext_opts = _complete_ext_opts(ext_opts)
+	ext_opts.base_prio = 0 ---@diagnostic disable-line: inject-field
 
 	return ext_opts
 end

--- a/lua/luasnip/util/extend_decorator.lua
+++ b/lua/luasnip/util/extend_decorator.lua
@@ -1,26 +1,46 @@
 local M = {}
 
--- map fn -> {arg_indx = int, extend = fn}[]
+---@alias LuaSnip.Opts.Util.ExtendDecoratorFn fun(arg: any[], extend_value: any[]): any[]
+
+---@class LuaSnip.Opts.Util.ExtendDecoratorRegister
+---@field arg_indx integer The position of the parameter to override
+---@field extend? LuaSnip.Opts.Util.ExtendDecoratorFn A function used to extend
+---  the args passed to the decorated function.
+---  Defaults to a function which extends the arg-table with the extend-table.
+---  This extend-behaviour is adaptable to accomodate `s`, where the first
+---  argument may be string or table.
+
+---@type {[fun(...): any]: LuaSnip.Opts.Util.ExtendDecoratorRegister[]}
 local function_properties = setmetatable({}, { __mode = "k" })
 
+--- The default extend function implementation.
+---
+---@param arg any[]
+---@param extend any[]
+---@return any[]
 local function default_extend(arg, extend)
 	return vim.tbl_extend("keep", arg or {}, extend or {})
 end
 
----Create a new decorated version of `fn`.
----@param fn The function to create a decorator for.
----@vararg The values to extend with. These should match the descriptions passed
----in `register`:
----```lua
----local function somefn(arg1, arg2, opts1, opts2)
----...
----end
----register(somefn, {arg_indx=4}, {arg_indx=3})
----apply(somefn,
----	{key = "opts2 is extended with this"},
----	{key = "and opts1 with this"})
----```
----@return function: The decorated function.
+--- Create a new decorated version of `fn`.
+---
+---@generic T: fun(...: any): any
+---@param fn T The function to create a decorator for.
+---@vararg any The values to extend with.
+---  These should match the descriptions passed in `register`.
+---
+---  Example:
+---  ```lua
+---  local function somefn(arg1, arg2, opts1, opts2)
+---  ...
+---  end
+---  register(somefn, {arg_indx=4}, {arg_indx=3})
+---  apply(somefn,
+---  	{key = "opts2 is extended with this"},
+---  	{key = "and opts1 with this"}
+---  )
+---  ```
+---@return T The decorated function.
 function M.apply(fn, ...)
 	local extend_properties = function_properties[fn]
 	assert(
@@ -54,20 +74,16 @@ function M.apply(fn, ...)
 	return decorated_fn
 end
 
----Prepare a function for usage with extend_decorator.
----To create a decorated function which extends `opts`-style tables passed to it, we need to know
---- 1. which parameter-position the opts are in and
---- 2. how to extend them.
----@param fn function: the function that should be registered.
----@vararg tables. Each describes how to extend one parameter to `fn`.
----The tables accept the following keys:
---- - arg_indx, number (required): the position of the parameter to override.
---- - extend, fn(arg, extend_value) -> effective_arg (optional): this function
----   is used to extend the args passed to the decorated function.
----   It defaults to a function which just extends the the arg-table with the
----   extend-table.
----   This extend-behaviour is adaptable to accomodate `s`, where the first
----   argument may be string or table.
+--- Prepare a function for usage with extend_decorator.
+---
+--- To create a decorated function which extends `opts`-style tables passed to
+--- it, we need to know:
+---   1. which parameter-position the opts are in and
+---   2. how to extend them.
+---
+---@param fn function The function that should be registered.
+---@vararg LuaSnip.Opts.Util.ExtendDecoratorRegister Each describes how to
+---  extend one parameter to `fn`.
 function M.register(fn, ...)
 	local fn_eps = { ... }
 

--- a/lua/luasnip/util/feedkeys.lua
+++ b/lua/luasnip/util/feedkeys.lua
@@ -75,7 +75,13 @@ function M.feedkeys_insert(keys)
 	end, next_id())
 end
 
--- pos: (0,0)-indexed.
+--- Returns keybind-expr actions to place the cursor at the given position,
+--- optionally on the previous char on the left or previous line.
+---
+---@param pos LuaSnip.RawPos0 Position, 0-indexed
+---@param before? boolean Place the cursor on the previous char,
+---  on the left or previous line.
+---@return string
 local function cursor_set_keys(pos, before)
 	if before then
 		if pos[2] == 0 then
@@ -115,10 +121,12 @@ local function cursor_set_keys(pos, before)
 		.. ","
 		-- -1 works for multibyte because of rounding, apparently.
 		.. pos[2]
-		.. "})"
-		.. "<cr><cmd>:silent! foldopen!<cr>"
+		.. "})<cr>"
+		.. "<cmd>:silent! foldopen!<cr>"
 end
 
+---@param b LuaSnip.RawPos0
+---@param e LuaSnip.RawPos0
 function M.select_range(b, e)
 	local id = next_id()
 	enqueued_cursor_state =

--- a/lua/luasnip/util/table.lua
+++ b/lua/luasnip/util/table.lua
@@ -1,7 +1,7 @@
 ---Convert set of values to a list of those values.
 ---@generic T
----@param tbl T|T[]|{[T]: boolean}
----@return {[T]: boolean}
+---@param tbl T[]|{[T]: boolean}
+---@return T[]
 local function set_to_list(tbl)
 	local ls = {}
 
@@ -14,7 +14,7 @@ end
 
 ---Convert value or list of values to a table of booleans for fast lookup.
 ---@generic T
----@param values T|T[]|{[T]: boolean}
+---@param values T|T[]?
 ---@return {[T]: boolean}
 local function list_to_set(values)
 	if values == nil then

--- a/lua/luasnip/util/table.lua
+++ b/lua/luasnip/util/table.lua
@@ -1,6 +1,6 @@
 ---Convert set of values to a list of those values.
 ---@generic T
----@param tbl T[]|{[T]: boolean}
+---@param tbl {[T]: boolean}
 ---@return T[]
 local function set_to_list(tbl)
 	local ls = {}

--- a/lua/luasnip/util/types.lua
+++ b/lua/luasnip/util/types.lua
@@ -1,4 +1,5 @@
-return {
+---@enum LuaSnip.NodeType
+local NodeType = {
 	textNode = 1,
 	insertNode = 2,
 	functionNode = 3,
@@ -8,27 +9,33 @@ return {
 	snippet = 7,
 	exitNode = 8,
 	restoreNode = 9,
-	node_types = { 1, 2, 3, 4, 5, 6, 7, 8, 9 },
-	names = {
-		"textNode",
-		"insertNode",
-		"functionNode",
-		"snippetNode",
-		"choiceNode",
-		"dynamicNode",
-		"snippet",
-		"exitNode",
-		"restoreNode",
-	},
-	names_pascal_case = {
-		"TextNode",
-		"InsertNode",
-		"FunctionNode",
-		"SnippetNode",
-		"ChoiceNode",
-		"DynamicNode",
-		"Snippet",
-		"ExitNode",
-		"RestoreNode",
-	},
 }
+
+local M = setmetatable({}, { __index = NodeType })
+
+local refs = {
+	{ value = NodeType.textNode, name = "textNode", pascal_name = "TextNode" },
+	{ value = NodeType.insertNode, name = "insertNode", pascal_name = "InsertNode" },
+	{ value = NodeType.functionNode, name = "functionNode", pascal_name = "FunctionNode" },
+	{ value = NodeType.snippetNode, name = "snippetNode", pascal_name = "SnippetNode" },
+	{ value = NodeType.choiceNode, name = "choiceNode", pascal_name = "ChoiceNode" },
+	{ value = NodeType.dynamicNode, name = "dynamicNode", pascal_name = "DynamicNode" },
+	{ value = NodeType.snippet, name = "snippet", pascal_name = "Snippet" },
+	{ value = NodeType.exitNode, name = "exitNode", pascal_name = "ExitNode" },
+	{ value = NodeType.restoreNode, name = "restoreNode", pascal_name = "RestoreNode" },
+}
+
+---@type LuaSnip.NodeType[]
+M.node_types = {}
+---@type string[]
+M.names = {}
+---@type string[]
+M.names_pascal_case = {}
+
+for _, ref in ipairs(refs) do
+  table.insert(M.node_types, ref.value)
+  table.insert(M.names, ref.name)
+  table.insert(M.names_pascal_case, ref.pascal_name)
+end
+
+return M

--- a/lua/luasnip/util/types.lua
+++ b/lua/luasnip/util/types.lua
@@ -12,6 +12,9 @@ local NodeType = {
 }
 
 local M = setmetatable({}, { __index = NodeType })
+-- NOTE: The metatable is set so that callers of this `types` module can do
+-- `types.insertNode` to get a named value from the enum, while leaving the
+-- enum definition standalone to avoid adding unnecessary enum fields.
 
 local refs = {
 	{ value = NodeType.textNode, name = "textNode", pascal_name = "TextNode" },

--- a/lua/luasnip/util/types.lua
+++ b/lua/luasnip/util/types.lua
@@ -15,14 +15,38 @@ local M = setmetatable({}, { __index = NodeType })
 
 local refs = {
 	{ value = NodeType.textNode, name = "textNode", pascal_name = "TextNode" },
-	{ value = NodeType.insertNode, name = "insertNode", pascal_name = "InsertNode" },
-	{ value = NodeType.functionNode, name = "functionNode", pascal_name = "FunctionNode" },
-	{ value = NodeType.snippetNode, name = "snippetNode", pascal_name = "SnippetNode" },
-	{ value = NodeType.choiceNode, name = "choiceNode", pascal_name = "ChoiceNode" },
-	{ value = NodeType.dynamicNode, name = "dynamicNode", pascal_name = "DynamicNode" },
+	{
+		value = NodeType.insertNode,
+		name = "insertNode",
+		pascal_name = "InsertNode",
+	},
+	{
+		value = NodeType.functionNode,
+		name = "functionNode",
+		pascal_name = "FunctionNode",
+	},
+	{
+		value = NodeType.snippetNode,
+		name = "snippetNode",
+		pascal_name = "SnippetNode",
+	},
+	{
+		value = NodeType.choiceNode,
+		name = "choiceNode",
+		pascal_name = "ChoiceNode",
+	},
+	{
+		value = NodeType.dynamicNode,
+		name = "dynamicNode",
+		pascal_name = "DynamicNode",
+	},
 	{ value = NodeType.snippet, name = "snippet", pascal_name = "Snippet" },
 	{ value = NodeType.exitNode, name = "exitNode", pascal_name = "ExitNode" },
-	{ value = NodeType.restoreNode, name = "restoreNode", pascal_name = "RestoreNode" },
+	{
+		value = NodeType.restoreNode,
+		name = "restoreNode",
+		pascal_name = "RestoreNode",
+	},
 }
 
 ---@type LuaSnip.NodeType[]
@@ -33,9 +57,9 @@ M.names = {}
 M.names_pascal_case = {}
 
 for _, ref in ipairs(refs) do
-  table.insert(M.node_types, ref.value)
-  table.insert(M.names, ref.name)
-  table.insert(M.names_pascal_case, ref.pascal_name)
+	table.insert(M.node_types, ref.value)
+	table.insert(M.names, ref.name)
+	table.insert(M.names_pascal_case, ref.pascal_name)
 end
 
 return M

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -484,14 +484,14 @@ end
 ---@param needle any Value to compare
 ---@return boolean _ `true` if `t` contains `needle`
 local function list_contains(t, needle)
-  vim.validate('t', t, 'table')
+	vim.validate("t", t, "table")
 
-  for _, v in ipairs(t) do
-    if v == needle then
-      return true
-    end
-  end
-  return false
+	for _, v in ipairs(t) do
+		if v == needle then
+			return true
+		end
+	end
+	return false
 end
 
 return {

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -59,15 +59,17 @@ local function indent(text, indentstring)
 end
 
 --- In-place expands tabs in `text`.
---- Difficulties:
---- we cannot simply replace tabs with a given number of spaces, the tabs align
---- text at multiples of `tabwidth`. This is also the reason we need the number
---- of columns the text is already indented by (otherwise we can only start a 0).
----@param text string[], multiline string.
----@param tabwidth number, displaycolumns one tab should shift following text
---- by.
----@param parent_indent_displaycolumns number, displaycolumn this text is
---- already at.
+---
+--- _Difficulties_:
+--- We cannot simply replace tabs with a given number of spaces, the tabs align
+--- text at multiples of `tabwidth`.
+--- This is also the reason we need the number of columns the text is already
+--- indented by (otherwise we can only start a 0).
+---
+---@param text string[] multiline string.
+---@param tabwidth number displaycolumns one tab should shift following text by.
+---@param parent_indent_displaycolumns number displaycolumn this text is
+---  already at.
 ---@return string[] _ `text` (only for simple nesting).
 local function expand_tabs(text, tabwidth, parent_indent_displaycolumns)
 	for i, line in ipairs(text) do
@@ -171,8 +173,9 @@ local function put(text, pos)
 	pos[2] = (#text > 1 and 0 or pos[2]) + #text[#text]
 end
 
---[[ Wraps the value in a table if it's not one, makes
-  the first element an empty str if the table is empty]]
+--- Wraps the value in a table if it's not one, makes
+--- the first element an empty str if the table is empty
+---@return string[]
 local function to_string_table(value)
 	if not value then
 		return { "" }
@@ -188,13 +191,17 @@ local function to_string_table(value)
 	return value
 end
 
--- Wrap node in a table if it is not one
+--- Wrap node in a table if it is not one
+---@param nodes LuaSnip.Node[]|LuaSnip.Node
+---@return LuaSnip.Node[]
 local function wrap_nodes(nodes)
 	-- safe to assume, if nodes has a metatable, it is a single node, not a
 	-- table.
 	if getmetatable(nodes) and nodes.type then
+		---@cast nodes LuaSnip.Node
 		return { nodes }
 	else
+		---@cast nodes LuaSnip.Node[]
 		return nodes
 	end
 end

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -240,6 +240,8 @@ local function buffer_comment_chars()
 	return comments
 end
 
+---@param table_or_string string|string[]
+---@return string[]
 local function to_line_table(table_or_string)
 	local tbl = to_string_table(table_or_string)
 

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -479,6 +479,21 @@ local function copy3(obj, seen)
 	return setmetatable(res, getmetatable(obj))
 end
 
+--- Checks if a list-like table (integer keys without gaps) contains `needle`.
+---@param t table Table to check (must be list-like, not validated)
+---@param needle any Value to compare
+---@return boolean _ `true` if `t` contains `needle`
+local function list_contains(t, needle)
+  vim.validate('t', t, 'table')
+
+  for _, v in ipairs(t) do
+    if v == needle then
+      return true
+    end
+  end
+  return false
+end
+
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -525,4 +540,5 @@ return {
 	pos_from_offset = pos_from_offset,
 	shallow_copy = shallow_copy,
 	copy3 = copy3,
+	list_contains = list_contains,
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -479,21 +479,6 @@ local function copy3(obj, seen)
 	return setmetatable(res, getmetatable(obj))
 end
 
---- Checks if a list-like table (integer keys without gaps) contains `needle`.
----@param t table Table to check (must be list-like, not validated)
----@param needle any Value to compare
----@return boolean _ `true` if `t` contains `needle`
-local function list_contains(t, needle)
-	vim.validate("t", t, "table")
-
-	for _, v in ipairs(t) do
-		if v == needle then
-			return true
-		end
-	end
-	return false
-end
-
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -540,5 +525,4 @@ return {
 	pos_from_offset = pos_from_offset,
 	shallow_copy = shallow_copy,
 	copy3 = copy3,
-	list_contains = list_contains,
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -68,7 +68,7 @@ end
 --- by.
 ---@param parent_indent_displaycolumns number, displaycolumn this text is
 --- already at.
----@return string[], `text` (only for simple nesting).
+---@return string[] _ `text` (only for simple nesting).
 local function expand_tabs(text, tabwidth, parent_indent_displaycolumns)
 	for i, line in ipairs(text) do
 		local new_line = ""
@@ -446,6 +446,32 @@ local function shallow_copy(t)
 	return t
 end
 
+--- Deepcopy given table, with support for recursive tables & metatable.
+--- Taken from: https://gist.github.com/tylerneylon/81333721109155b2d244
+---
+---@generic T: table
+---@param obj T
+---@param seen? table
+---@return T
+local function copy3(obj, seen)
+	-- Handle non-tables and previously-seen tables.
+	if type(obj) ~= "table" then
+		return obj
+	end
+	if seen and seen[obj] then
+		return seen[obj]
+	end
+
+	-- New table; mark it as seen an copy recursively.
+	local s = seen or {}
+	local res = {}
+	s[obj] = res
+	for k, v in next, obj do
+		res[copy3(k, s)] = copy3(v, s)
+	end
+	return setmetatable(res, getmetatable(obj))
+end
+
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -491,4 +517,5 @@ return {
 	pos_offset = pos_offset,
 	pos_from_offset = pos_from_offset,
 	shallow_copy = shallow_copy,
+	copy3 = copy3,
 }


### PR DESCRIPTION
Hola @L3MON4D3, it's been a while o/

I've recently updated my neovim to 0.11 & reworking my config a bit, and since the _big_ PR #1353 that started adding type annotations & DOC.md generation, I didn't touch my snippets at all...
The nvim upgrade was the nudge, and [I started replacing the few type annotations I had manually crafted in my config](https://github.com/bew/dotfiles/commit/78d7f38ed20b696d606a2df7e9b9d356f28f9249), replacing them with the ones from the plugin!..
...
And then I kinda went down the rabbit hole 🤪
Porting documentation, reading the codebase while adding a few types for the things I understood, and adding MOAR types....

:point_right: So here is a first draft of ~1k LoC of doc additions & a few small reworks 🚀🚀

It took a few iterations of codebase exploration to kinda understand the various relationships between the different kind of snippet, node, and what 'layer'/'stage' of the snippets definition process I was on

I'm still far from understanding everything, and I might have made some mistakes, put some fields in the wrong class or failed a few inheritance relations, but I think it's pretty good for a start!

There are still many things I saw and could work on / refactor with your permissions, but I got a
good chunk going on and I'm quite happy with it!

> [!NOTE]
> I left a few `FIXME`/`IDEA` in the PR with questions for you

> [!WARNING]
> I didn't test the DOC.md generation at all, I only focused on the Lua-side of things

### Some things I typed/documented

- Node, InsertNode, FunctionNode, DynamicNode, ChoiceNode, with (most of) their internal fields ✨
- Snippet, SnippetNode & most of the internal snippet-initialization functions (their input opts & their normalized types)

  I managed to build a sort of hierarchy of classes that when combined build the final Snippet & SnippetNode types (with extra fields if needed), I'd need careful review of this part, I tried to follow the calls and build the structures but I might be wrong here and there..

  I know there are a few fields missing but they're kind of overwelming by their number, and the
  lack of internal documentation in such a big codebase 😅

- MultiSnippet, SnippetString
- some util functions here and there
- fmt's main functions
- AbsoluteIndexer, KeyIndexer, NodeRef

### Other things

- moved `copy3` impl to util, to avoid duplication between `snippet.lua` & `fmt.lua`
- rewrote the `events.lua` & `types.lua` for nicer typing without duplication

---

👉 In the end, most core files type-checks correctly, with only a few warnings that make sense and
that would need to be addressed (some of them challenge the class hierarchy in place, and I made a
few comments on ideas to improve the situation)

As for where to go with the types design, I think the codebase would benefit from splitting the Snippet class into multiple classes to reflect the various stages of use (barebone for internal use, snippetnode, snippet, expandedsnippet, (..?)). For the actual type annotations, maybe you'd like to have a public/private interface to avoid exposing the huge internals of the nodes to the users 🤔

I was also quite surprised that you used `Node:new` both to create new node types & new node instances, would you welcome some changes around this to segregate the types/functions more by use-cases?
(this can probably come later though)

> [!NOTE]
> This PR targets the `self-dependent-dNode` branch, since this is the branch I'm on normally.
> :grey_question: I'm wondering, do you think we could merge it soon or do you still have planned work on it?
> I'm asking because otherwise I'd need to rework some parts of this PR to be able to rebase on `master` 👀

Let me know what you think, and how you'd want to tackle this!
I'm available to do a day/night pair-programming/review session if you want :upside_down_face: 