### PR TITLE
util: Move copy3 in utils with types, to avoid code duplication

### DIFF
--- a/lua/luasnip/extras/fmt.lua
+++ b/lua/luasnip/extras/fmt.lua
@@ -1,28 +1,8 @@
 local text_node = require("luasnip.nodes.textNode").T
-local wrap_nodes = require("luasnip.util.util").wrap_nodes
+local util = require("luasnip.util.util")
 local extend_decorator = require("luasnip.util.extend_decorator")
 local Str = require("luasnip.util.str")
 local rp = require("luasnip.extras").rep
-
--- https://gist.github.com/tylerneylon/81333721109155b2d244
-local function copy3(obj, seen)
-	-- Handle non-tables and previously-seen tables.
-	if type(obj) ~= "table" then
-		return obj
-	end
-	if seen and seen[obj] then
-		return seen[obj]
-	end
-
-	-- New table; mark it as seen an copy recursively.
-	local s = seen or {}
-	local res = {}
-	s[obj] = res
-	for k, v in next, obj do
-		res[copy3(k, s)] = copy3(v, s)
-	end
-	return setmetatable(res, getmetatable(obj))
-end
 
 -- Interpolate elements from `args` into format string with placeholders.
 --
@@ -102,7 +82,7 @@ local function interpolate(fmt, args, opts)
 		if used_keys[key] then
 			local jump_index = args[key]:get_jump_index() -- For nodes that don't have a jump index, copy it instead
 			if not opts.repeat_duplicates or jump_index == nil then
-				table.insert(elements, copy3(args[key]))
+				table.insert(elements, util.copy3(args[key]))
 			else
 				table.insert(elements, rp(jump_index))
 			end
@@ -198,7 +178,7 @@ local function format_nodes(str, nodes, opts)
 	opts = vim.tbl_extend("force", defaults, opts or {})
 
 	-- allow to pass a single node
-	nodes = wrap_nodes(nodes)
+	nodes = util.wrap_nodes(nodes)
 
 	-- optimization: avoid splitting multiple times
 	local lines = nil

--- a/lua/luasnip/nodes/snippet.lua
+++ b/lua/luasnip/nodes/snippet.lua
@@ -859,28 +859,8 @@ function Snippet:matches(line_to_cursor, opts)
 	return expand_params
 end
 
--- https://gist.github.com/tylerneylon/81333721109155b2d244
-local function copy3(obj, seen)
-	-- Handle non-tables and previously-seen tables.
-	if type(obj) ~= "table" then
-		return obj
-	end
-	if seen and seen[obj] then
-		return seen[obj]
-	end
-
-	-- New table; mark it as seen an copy recursively.
-	local s = seen or {}
-	local res = {}
-	s[obj] = res
-	for k, v in next, obj do
-		res[copy3(k, s)] = copy3(v, s)
-	end
-	return setmetatable(res, getmetatable(obj))
-end
-
 function Snippet:copy()
-	return copy3(self)
+	return util.copy3(self)
 end
 
 function Snippet:del_marks()

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -444,6 +444,32 @@ local function shallow_copy(t)
 	return t
 end
 
+--- Deepcopy given table, with support for recursive tables & metatable.
+--- Taken from: https://gist.github.com/tylerneylon/81333721109155b2d244
+---
+---@generic T: table
+---@param obj T
+---@param seen? table
+---@return T
+local function copy3(obj, seen)
+	-- Handle non-tables and previously-seen tables.
+	if type(obj) ~= "table" then
+		return obj
+	end
+	if seen and seen[obj] then
+		return seen[obj]
+	end
+
+	-- New table; mark it as seen an copy recursively.
+	local s = seen or {}
+	local res = {}
+	s[obj] = res
+	for k, v in next, obj do
+		res[copy3(k, s)] = copy3(v, s)
+	end
+	return setmetatable(res, getmetatable(obj))
+end
+
 return {
 	get_cursor_0ind = get_cursor_0ind,
 	set_cursor_0ind = set_cursor_0ind,
@@ -489,4 +515,5 @@ return {
 	pos_offset = pos_offset,
 	pos_from_offset = pos_from_offset,
 	shallow_copy = shallow_copy,
+	copy3 = copy3,
 }

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -246,7 +246,7 @@ local function to_line_table(table_or_string)
 	-- split entries at \n.
 	local line_table = {}
 	for _, str in ipairs(tbl) do
-		local split = vim.split(str, "\n", {plain=true})
+		local split = vim.split(str, "\n", { plain = true })
 		for i = 1, #split do
 			line_table[#line_table + 1] = split[i]
 		end

--- a/lua/luasnip/util/util.lua
+++ b/lua/luasnip/util/util.lua
@@ -68,7 +68,7 @@ end
 --- by.
 ---@param parent_indent_displaycolumns number, displaycolumn this text is
 --- already at.
----@return string[], `text` (only for simple nesting).
+---@return string[] _ `text` (only for simple nesting).
 local function expand_tabs(text, tabwidth, parent_indent_displaycolumns)
 	for i, line in ipairs(text) do
 		local new_line = ""
@@ -246,7 +246,7 @@ local function to_line_table(table_or_string)
 	-- split entries at \n.
 	local line_table = {}
 	for _, str in ipairs(tbl) do
-		local split = vim.split(str, "\n", true)
+		local split = vim.split(str, "\n", {plain=true})
 		for i = 1, #split do
 			line_table[#line_table + 1] = split[i]
 		end


### PR DESCRIPTION
Extracted from #1396 