### PR TITLE
fix: replaced deprecated vim.diagnostic.disable()

### DIFF
--- a/doc/luasnip.txt
+++ b/doc/luasnip.txt
@@ -1,4 +1,4 @@
-*luasnip.txt*           For NeoVim 0.9-0.11           Last change: 2026 May 19
+*luasnip.txt*           For NeoVim 0.9-0.11          Last change: 2026 June 21
 
 ==============================================================================
 Table of Contents                                  *luasnip-table-of-contents*

--- a/lua/luasnip/extras/snippet_list.lua
+++ b/lua/luasnip/extras/snippet_list.lua
@@ -62,7 +62,7 @@ local function display_split(opts)
 		make_scratch_buf(buf)
 
 		-- disable diagnostics
-		vim.diagnostic.disable(buf)
+		vim.diagnostic.enable(false, { bufnr = buf })
 
 		-- set any extra win and buf opts
 		set_win_opts(win, opts.win_opts)


### PR DESCRIPTION
# Replace Deprecated vim.diagnostic.disable()

vim.diagnostic.disable() was deprecated in Neovim 0.10
<https://neovim.io/doc/user/deprecated/#vim.diagnostic.disable()>

This causes an error when using the "Snippet List" feature: require("luasnip.extras.snippet_list").open().

Replacing vim.diagnostic.disable() with vim.diagnostic.enable(false) resolves the problem.